### PR TITLE
VOTE-845 Patch double_field module to fix display of labels for text_long fields

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "enable-patching": true,
         "patches": {
             "drupal/double_field": {
-                "Support input filters on text formats": "https://www.drupal.org/files/issues/2022-12-20/2091587-text_long-60_1.patch"
+                "Support input filters on text formats (original issue: https://www.drupal.org/node/2091587)": "patches/double_field/2091587-text_long-60_2.patch"
             }
         },
         "drupal-scaffold": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a1b7f1ecefce8053d3de2bcfe51c88bb",
+    "content-hash": "31db4ed629f96c3d57930c1f55de6bd5",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2133,7 +2133,7 @@
             "extra": {
                 "drupal": {
                     "version": "4.1.3",
-                    "datestamp": "1665573795",
+                    "datestamp": "1674225949",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,3 @@
+# Custom Drupal module patches
+- Add any custom patches to a directory matching the name of the module.
+- Add the patch to the composer.json file.

--- a/patches/double_field/2091587-text_long-60_2.patch
+++ b/patches/double_field/2091587-text_long-60_2.patch
@@ -1,0 +1,126 @@
+diff --git a/src/Plugin/Field/FieldFormatter/Base.php b/src/Plugin/Field/FieldFormatter/Base.php
+index d457e31..eee9fb8 100644
+--- a/src/Plugin/Field/FieldFormatter/Base.php
++++ b/src/Plugin/Field/FieldFormatter/Base.php
+@@ -255,6 +255,14 @@ abstract class Base extends FormatterBase {
+           $item->{$subfield} = $field_settings[$subfield][$item->{$subfield} ? 'on_label' : 'off_label'];
+         }
+
++        if ($field_settings['storage'][$subfield]['type'] == 'text_long') {
++          $item->{$subfield} = array(
++            '#type' => 'processed_text',
++            '#text' => $item->{$subfield},
++            '#format' => $item->{$subfield . '_format'},
++          );
++        }
++
+         // Empty string should already be converted into NULL.
+         // @see Drupal\double_field\Plugin\Field\FieldWidget\DoubleField::massageFormValues()
+         if ($item->{$subfield} === NULL) {
+diff --git a/src/Plugin/Field/FieldType/DoubleField.php b/src/Plugin/Field/FieldType/DoubleField.php
+index 43de602..5667c0f 100644
+--- a/src/Plugin/Field/FieldType/DoubleField.php
++++ b/src/Plugin/Field/FieldType/DoubleField.php
+@@ -376,6 +376,15 @@ class DoubleField extends FieldItemBase {
+           $columns[$subfield]['size'] = 'big';
+           break;
+
++        case 'text_long':
++          $columns[$subfield]['type'] = 'text';
++          $columns[$subfield]['size'] = 'big';
++          $columns[$subfield . '_format'] = [
++            'type' => 'varchar_ascii',
++            'length' => 255,
++          ];
++          break;
++
+         case 'integer':
+           $columns[$subfield]['type'] = 'int';
+           $columns[$subfield]['size'] = 'normal';
+@@ -431,7 +440,7 @@ class DoubleField extends FieldItemBase {
+
+       $subfield_type = $settings['storage'][$subfield]['type'];
+       // Typed data are slightly different from schema the definition.
+-      if ($subfield_type == 'text' || $subfield_type == 'telephone') {
++      if ($subfield_type == 'text' || $subfield_type == 'telephone' || $subfield_type == 'text_long') {
+         $subfield_type = 'string';
+       }
+       elseif ($subfield_type == 'numeric') {
+@@ -440,6 +449,9 @@ class DoubleField extends FieldItemBase {
+
+       $properties[$subfield] = DataDefinition::create($subfield_type)
+         ->setLabel($subfield_types[$subfield_type]);
++
++      $properties[$subfield . '_format'] = DataDefinition::create('filter_format')
++        ->setLabel(t('Text format'));
+     }
+
+     return $properties;
+@@ -579,6 +591,7 @@ class DoubleField extends FieldItemBase {
+       'boolean' => t('Boolean'),
+       'string' => t('Text'),
+       'text' => t('Text (long)'),
++      'text_long' => t('Text (formatted, long)'),
+       'integer' => t('Integer'),
+       'float' => t('Float'),
+       'numeric' => t('Decimal'),
+diff --git a/src/Plugin/Field/FieldWidget/DoubleField.php b/src/Plugin/Field/FieldWidget/DoubleField.php
+index 4c149f2..00fa370 100644
+--- a/src/Plugin/Field/FieldWidget/DoubleField.php
++++ b/src/Plugin/Field/FieldWidget/DoubleField.php
+@@ -332,6 +332,16 @@ class DoubleField extends WidgetBase {
+           if ($settings[$subfield]['placeholder']) {
+             $widget[$subfield]['#placeholder'] = $settings[$subfield]['placeholder'];
+           }
++          if (!empty($settings[$subfield]['editor'])) {
++            $value_element = $widget[$subfield];
++            $widget[$subfield] = [];
++            $widget[$subfield]['#default_value'] = $value_element['#default_value'];
++            $widget[$subfield]['value'] = $value_element;
++            $widget[$subfield]['#type'] = 'text_format';
++            $widget[$subfield]['#title'] = $value_element['#title'];
++            $widget[$subfield]['#format'] = isset($items[$delta]->{$subfield . '_format'}) ? $items[$delta]->{$subfield . '_format'} : NULL;
++            $widget[$subfield]['#base_type'] = 'textarea';
++          }
+           break;
+
+         case 'number':
+@@ -384,7 +393,17 @@ class DoubleField extends WidgetBase {
+
+     foreach ($values as $delta => $value) {
+       foreach (['first', 'second'] as $subfield) {
+-        if ($value[$subfield] === '') {
++        if (is_array($value[$subfield])) {
++          foreach ($value[$subfield] as $key => $field_value) {
++            if ($key == 'value') {
++              $values[$delta][$subfield] = $field_value;
++            }
++            else {
++              $values[$delta][$subfield . '_' . $key] = $field_value;
++            }
++          }
++        }
++        elseif ($value[$subfield] === '') {
+           $values[$delta][$subfield] = NULL;
+         }
+         elseif ($value[$subfield] instanceof DrupalDateTime) {
+@@ -446,6 +465,7 @@ class DoubleField extends WidgetBase {
+         break;
+
+       case 'text':
++      case 'text_long':
+         $subwidgets['textarea'] = $this->t('Text area');
+         break;
+
+@@ -504,6 +524,11 @@ class DoubleField extends WidgetBase {
+       if (!$settings[$subfield]['type']) {
+         $settings[$subfield]['type'] = key($widget_types);
+       }
++
++      if ($field_settings['storage'][$subfield]['type'] == 'text_long') {
++        $settings[$subfield]['type'] = 'textarea';
++        $settings[$subfield]['editor'] = TRUE;
++      }
+     }
+
+     return $settings;


### PR DESCRIPTION
## Jira ticket (required)
[https://bixal-projects.atlassian.net/browse/VOTE-845](https://bixal-projects.atlassian.net/browse/VOTE-845)

## Description (optional)
Create a new patch file for the double_field module to enable label display for text_long fields

## Deployment and testing (required if applicable)
### Post deploy steps
1. run `lando composer install`
2. run `lando drush cr` 

### Testing steps
1. Create a new accordion group block
2. Make sure the label is displaying above the wysiwyg field