### PR TITLE
VOTE-854 Apply styling to the header components

### DIFF
--- a/config/core.entity_view_display.block_content.government_banner.default.yml
+++ b/config/core.entity_view_display.block_content.government_banner.default.yml
@@ -21,7 +21,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 6
+    weight: 1
     region: content
   field_accordion_text:
     type: string

--- a/web/themes/custom/vote_gov/src/sass/_uswds-theme.scss
+++ b/web/themes/custom/vote_gov/src/sass/_uswds-theme.scss
@@ -151,7 +151,7 @@ Or a USWDS mixin...
   $theme-alert-link-color: 'base-darker',
 
   // -- Banner
-  $theme-banner-background-color: "base-darkest",
+  //$theme-banner-background-color: "base-darkest",
   $theme-banner-max-width: "widescreen",
 
   // -- Breadcrumb

--- a/web/themes/custom/vote_gov/templates/block/block--region--header.html.twig
+++ b/web/themes/custom/vote_gov/templates/block/block--region--header.html.twig
@@ -1,0 +1,44 @@
+{#
+/**
+ * @file
+ * Theme override to display a block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * @see template_preprocess_block()
+ */
+#}
+{% set classes = [
+  'block',
+  'block-' ~ configuration.provider|clean_class,
+  'block-' ~ plugin_id|clean_class,
+  'usa-header',
+] %}
+
+<div{{ attributes.addClass(classes) }}>
+  {{ title_prefix }}
+  {% if label %}
+    <h2{{ title_attributes }}>{{ label }}</h2>
+  {% endif %}
+  {{ title_suffix }}
+  {% block content %}
+    {{ content }}
+  {% endblock %}
+</div>

--- a/web/themes/custom/vote_gov/templates/block/block-content--government-banner.html.twig
+++ b/web/themes/custom/vote_gov/templates/block/block-content--government-banner.html.twig
@@ -1,0 +1,67 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display a block content.
+ *
+ * @see template_preprocess_block_content_template()
+ *
+ * @ingroup themeable
+ */
+#}
+{%
+  set classes = [
+    'block-content',
+    'block-content--type-' ~ bundle|clean_class,
+    'block-content--' ~ id,
+    'block-content--view-mode-' ~ view_mode|clean_class
+  ]
+%}
+
+<section class="usa-banner" aria-label="Official government website">
+    <div class="usa-accordion">
+      <div class="usa-banner__header usa-banner__header--expanded">
+        <div class="usa-banner__inner">
+          <div class="banner__text-container grid-row">
+            <div class="grid-col-auto">
+              <img class="usa-banner__header-flag" width="16" height="11" loading="lazy" src="{{ base_path ~ directory }}/dist/assets/img/us_flag_small.png" alt="U.S. flag">
+            </div>
+            <div class="grid-col-fill tablet:grid-col-auto">
+              <div class="usa-banner__header-text">{{ content.field_accordion_text | field_value }}</div>
+              <div class="usa-banner__header-action" aria-hidden="true">{{ content.field_accordion_link_label | field_value }}</div>
+            </div>
+            <button type="button" class="usa-accordion__button usa-banner__button" aria-expanded="false" aria-controls="gov-banner">
+              <span class="usa-banner__button-text">{{ content.field_accordion_link_label | field_value }}</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="usa-banner__content usa-accordion__content" id="gov-banner">
+      <div class="grid-row grid-gap-lg">
+        <div class="usa-banner__guidance tablet:grid-col-6">
+          <img class="usa-banner__icon usa-media-block__img" loading="lazy" width="40" height="40" src="{{ base_path ~ directory }}/dist/assets/img/icon-dot-gov.svg" role="presentation" alt="" aria-hidden="true">
+          <div class="usa-media-block__body">
+            <p>
+              <strong>{{ content.field_gov_heading | field_value }}</strong>
+              <br>
+              {{ content.field_gov_text | field_value }}
+            </p>
+          </div>
+        </div>
+        <div class="usa-banner__guidance tablet:grid-col-6">
+          <img class="usa-banner__icon usa-media-block__img" loading="lazy" width="40" height="40" src="{{ base_path ~ directory }}/dist/assets/img/icon-https.svg" role="presentation" alt="" aria-hidden="true">
+          <div class="usa-media-block__body">
+            <p>
+              <strong>{{ content.field_https_heading | field_value }}</strong>
+              <br>
+              (<span class="icon-lock"><svg xmlns="http://www.w3.org/2000/svg" width="52" height="64" viewBox="0 0 52 64" class="usa-banner__lock-image">
+                  <path fill="#000000" fill-rule="evenodd" d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z">
+                  </path>
+                </svg></span>) {{ content.field_https_text | field_value }}
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
**_Delete all details that do not apply to this PR!_**

## Jira ticket (required)
https://bixal-projects.atlassian.net/browse/VOTE-905

## Description (optional)
Apply styling to the header region div
Apply styling to the government banner component of the header
Disable the Drupal theme background color override

### Testing steps
1. 1. Check out the feature/VOTE-905-branch
2. Run lando retune
3. View the website in browser and check the following:
a. The default state of the accordion is collasped
b. The background color is #f0f0f0
c. The images and icons are visible
