### PR TITLE
VOTE-968: drush cron buildpack implementation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ node_modules
 
 # Allow cloud.gov settings file.
 !web/sites/default/settings.cloudgov.php
+
 # Ignore Cypress Reports 
 /testing/cypress/reports
 /testing/cypress/screenshots

--- a/manifest.yml
+++ b/manifest.yml
@@ -3,23 +3,19 @@ default_config: &defaults
   buildpacks:
     - php_buildpack
   disk_quota: 768M
+  env:
+    ENV: ${CIRCLE_BRANCH}
+    LD_LIBRARY_PATH: /home/vcap/app/php/lib/
+    PHP_INI_SCAN_DIR: /home/vcap/app/php/etc/:/home/vcap/app/php/etc/php.ini.d/
   timeout: 180
   services:
-    - vote-mysql-dev
-    - vote-secrets-dev
-    - vote-storage-dev
+    - vote-mysql-${CIRCLE_BRANCH}
+    - vote-secrets-${CIRCLE_BRANCH}
+    - vote-storage-${CIRCLE_BRANCH}
 
 applications:
-- name: vote-drupal-dev
+- name: vote-drupal-${CIRCLE_BRANCH}
   <<: *defaults
   memory: 512M
   instances: 1
   random-route: false
-# - name: vote-cron-dev
-#   <<: *defaults
-#   no-route: true
-#   command: ./cronish.sh
-#   health-check-type: process
-#   memory: 128M
-
-#/home/vcap/app/php/bin/php -m

--- a/private/.htaccess
+++ b/private/.htaccess
@@ -1,0 +1,20 @@
+# Deny all requests from Apache 2.4+.
+<IfModule mod_authz_core.c>
+  Require all denied
+</IfModule>
+# Deny all requests from Apache 2.0-2.2.
+<IfModule !mod_authz_core.c>
+  Deny from all
+</IfModule>
+# Turn off all options we don't need.
+Options -Indexes -ExecCGI -Includes -MultiViews
+# Set the catch-all handler to prevent scripts from being executed.
+SetHandler Drupal_Security_Do_Not_Remove_See_SA_2006_006
+<Files *>
+  # Override the handler again if we're run later in the evaluation list.
+  SetHandler Drupal_Security_Do_Not_Remove_See_SA_2013_003
+</Files>
+# If we know how to do it safely, disable the PHP engine entirely.
+<IfModule mod_php.c>
+  php_flag engine off
+</IfModule>

--- a/scripts/cronish.sh
+++ b/scripts/cronish.sh
@@ -1,8 +1,9 @@
 #!/bin/bash 
-set -euo pipefail
 
 while true
 do
+  echo "Running 'drush cron'..."
   drush --root=$HOME/web core:cron
-  sleep 15m
+  echo "'drush cron' task completed!"
+  sleep 60m
 done

--- a/web/sites/default/settings.cloudgov.php
+++ b/web/sites/default/settings.cloudgov.php
@@ -11,7 +11,7 @@ $applicaiton_fqdn_regex = "^.+\.app\.cloud\.gov$";
 
 $settings['tome_static_directory'] = dirname(DRUPAL_ROOT) . '/html';
 $settings['config_sync_directory'] = dirname(DRUPAL_ROOT) . '/config';
-$settings['file_private_path'] = "../private";
+$settings['file_private_path'] = dirname(DRUPAL_ROOT) . '/private';
 
 //$settings['config_sync_directory'] = dirname(DRUPAL_ROOT) . '/config/sync';
 


### PR DESCRIPTION
## Jira ticket (required)
[VOTE-968](https://bixal-projects.atlassian.net/browse/VOTE-968)

## Description (optional)
Implements `drush cron` job to run every hour in the background of the first application instance.