### PR TITLE
VOTE-1105 Basic-page-full-html-wysiwyg

### DIFF
--- a/config/editor.editor.full_html.yml
+++ b/config/editor.editor.full_html.yml
@@ -1,0 +1,57 @@
+uuid: e657bf50-0484-4285-983a-2436f497e9bc
+langcode: en
+status: true
+dependencies:
+  config:
+    - filter.format.full_html
+  module:
+    - ckeditor5
+format: full_html
+editor: ckeditor5
+settings:
+  toolbar:
+    items:
+      - bold
+      - italic
+      - underline
+      - heading
+      - style
+      - removeFormat
+      - '|'
+      - bulletedList
+      - numberedList
+      - indent
+      - outdent
+      - alignment
+      - '|'
+      - link
+      - drupalMedia
+      - '|'
+      - sourceEditing
+  plugins:
+    ckeditor5_alignment:
+      enabled_alignments:
+        - center
+        - justify
+        - left
+        - right
+    ckeditor5_heading:
+      enabled_headings:
+        - heading2
+        - heading3
+        - heading4
+        - heading5
+        - heading6
+    ckeditor5_list:
+      reversed: true
+      startIndex: true
+    ckeditor5_sourceEditing:
+      allowed_tags: {  }
+    ckeditor5_style:
+      styles:
+        -
+          label: 'Button styled link'
+          element: '<a class="usa-button">'
+    media_media:
+      allow_view_mode_override: false
+image_upload: {  }

--- a/config/field.field.node.page.field_body.yml
+++ b/config/field.field.node.page.field_body.yml
@@ -12,6 +12,7 @@ third_party_settings:
   allowed_formats:
     allowed_formats:
       - basic_html
+      - full_html
 id: node.page.field_body
 field_name: field_body
 entity_type: node

--- a/config/filter.format.full_html.yml
+++ b/config/filter.format.full_html.yml
@@ -1,0 +1,32 @@
+uuid: 4e070004-703d-4c9e-8cff-cbd58935d9fb
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.media_library
+  module:
+    - media
+name: 'Full HTML'
+format: full_html
+weight: 0
+filters:
+  filter_html:
+    id: filter_html
+    provider: filter
+    status: false
+    weight: -10
+    settings:
+      allowed_html: '<a class="usa-button">'
+      filter_html_help: true
+      filter_html_nofollow: false
+  media_embed:
+    id: media_embed
+    provider: media
+    status: true
+    weight: 100
+    settings:
+      default_view_mode: default
+      allowed_view_modes:
+        default: default
+        media_library: media_library
+      allowed_media_types: {  }


### PR DESCRIPTION
## Jira ticket (required)
https://bixal-projects.atlassian.net/browse/VOTE-1105

## Description (optional)
A site admin can add a basic page with full markup and styles. The basic page will display with all styles added via the WYSIWYG.

## Deployment and testing (required, if applicable)

### Post-deploy steps
run lando composer install
run lando drush cr

### Testing steps
1. In the admin panel (logged in as admin), create a basic page type
2. In the content wysiwyg editor, click the source button. Add in the markup for the slick-sheet accordion.
3. Publish the page and view the accordion on the page.
