### PR TITLE
VOTE-1180 Update vote_gov theme dependencies

### DIFF
--- a/web/themes/custom/vote_gov/package-lock.json
+++ b/web/themes/custom/vote_gov/package-lock.json
@@ -9,16 +9,16 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@uswds/uswds": "^3.3.0",
+        "@uswds/uswds": "^3.4.1",
         "a11y-tabs": "^0.1.2"
       },
       "devDependencies": {
         "@uswds/compile": "^1.0.0-beta.3",
-        "browser-sync": "^2.28.1",
+        "browser-sync": "^2.29.1",
         "gulp": "^4.0.2",
         "gulp-stylelint": "^13.0.0",
         "gulp-uglify": "^3.0.2",
-        "uglify-es": "^3.3.9"
+        "uglify-es": "^3.3.10"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -771,9 +771,9 @@
       }
     },
     "node_modules/@uswds/uswds": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.3.0.tgz",
-      "integrity": "sha512-qiugkbwrO+eIIwi4lbEdH15LCHuAjfUMDRQNBBujakR99Ka3iqmrLpPllffdKaJJnnYkt75v0lltnJ5Nnd/obQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.4.1.tgz",
+      "integrity": "sha512-eLYbWUqf9eWUa2P6CO3ckIjtQyM3AylrIOHxN5gYG3P62TDd3FzRDyoACfvOe6CNk0w0PqXWJnuPzxpNoOgWNA==",
       "dependencies": {
         "classlist-polyfill": "1.0.3",
         "object-assign": "4.1.1",
@@ -1352,21 +1352,22 @@
       }
     },
     "node_modules/browser-sync": {
-      "version": "2.28.1",
-      "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.28.1.tgz",
-      "integrity": "sha512-XAd+jULGQ6TSdxA8ABnK6E0r4HHClnZn/p11sHOQ9dr5Qn4ay8TsrEkNUOiWlJOgLuf49QxlkwpqS7BvfGdCpQ==",
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.29.1.tgz",
+      "integrity": "sha512-WXy9HMJVQaNUTPjmai330E2fnDA6W84l/vBILGkYu9yHXIpWw1gJYjdQWDfEhLFljYUHNTN9jM3GCej2T55m+g==",
       "dev": true,
       "dependencies": {
-        "browser-sync-client": "^2.28.1",
-        "browser-sync-ui": "^2.28.1",
+        "browser-sync-client": "^2.29.1",
+        "browser-sync-ui": "^2.29.1",
         "bs-recipes": "1.3.4",
         "bs-snippet-injector": "^2.0.1",
+        "chalk": "4.1.2",
         "chokidar": "^3.5.1",
         "connect": "3.6.6",
         "connect-history-api-fallback": "^1",
         "dev-ip": "^1.0.1",
         "easy-extender": "^2.3.4",
-        "eazy-logger": "4.0.0",
+        "eazy-logger": "^4.0.1",
         "etag": "^1.8.1",
         "fresh": "^0.5.2",
         "fs-extra": "3.0.1",
@@ -1396,25 +1397,23 @@
       }
     },
     "node_modules/browser-sync-client": {
-      "version": "2.28.1",
-      "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.28.1.tgz",
-      "integrity": "sha512-srFIhUU6CtsLtvBsVmTgRtFt/kFbcl/PYvenpfxPIKTDSxQf35cCjYwYF1osyJdvRoeKoDlaK/fv6eN6/cXRKw==",
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.29.1.tgz",
+      "integrity": "sha512-aESnjt3rU7CZpzjyqzhIC2UJ3MVhzRis7cPKkGbyYWDf/wnbxyRa3fFenF3Qx9061/guY3HHhD67uiTVV26DVg==",
       "dev": true,
       "dependencies": {
         "etag": "1.8.1",
         "fresh": "0.5.2",
-        "mitt": "^1.1.3",
-        "rxjs": "^5.5.6",
-        "typescript": "^4.6.2"
+        "mitt": "^1.1.3"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/browser-sync-ui": {
-      "version": "2.28.1",
-      "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-2.28.1.tgz",
-      "integrity": "sha512-yPylRdTE8HS/MxcgGpYfcW/JVde+tVnoTIwotVqzqybW8Kg0e3GfFlS7fD0W+KtI/rS4U5GxVsqERxdqpAjCoQ==",
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-2.29.1.tgz",
+      "integrity": "sha512-MB7SAiUgVUrhipO2xyO1sheC9H0+LKXPQ3L1tQWcZ3AgizBnUNKAqDZPSwe4grNSa8o8ImSAwJp7lMS6XYy1Dw==",
       "dev": true,
       "dependencies": {
         "async-each-series": "0.1.1",
@@ -1427,6 +1426,22 @@
       }
     },
     "node_modules/browser-sync-ui/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/browser-sync/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
@@ -2474,12 +2489,31 @@
       }
     },
     "node_modules/eazy-logger": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-4.0.0.tgz",
-      "integrity": "sha512-ZnYemMI98cKlJt0Fkrw/7zVJYlnzVY22pbQJXmT1ZMmxnC732o7US9KaLXlf3x/g/ImS+uLIvF2R6nbcWP1uWw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-4.0.1.tgz",
+      "integrity": "sha512-2GSFtnnC6U4IEKhEI7+PvdxrmjJ04mdsj3wHZTFiw0tUtG4HCWzTr13ZYTk8XOGnA1xQMaDljoBOYlk3D/MMSw==",
       "dev": true,
+      "dependencies": {
+        "chalk": "4.1.2"
+      },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/eazy-logger/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/ee-first": {
@@ -7931,18 +7965,6 @@
       "integrity": "sha512-CiaiuN6gapkdl+cZUr67W6I8jquN4lkak3vtIsIWCl4XIPP8ffsoyN6/+PuGXnQy8Cu8W2y9Xxh31Rq4M6wUug==",
       "dev": true
     },
-    "node_modules/rxjs": {
-      "version": "5.5.12",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
-      "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
-      "dev": true,
-      "dependencies": {
-        "symbol-observable": "1.0.1"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
-      }
-    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -9362,15 +9384,6 @@
       "dev": true,
       "peer": true
     },
-    "node_modules/symbol-observable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
-      "integrity": "sha512-Kb3PrPYz4HanVF1LVGuAdW6LoVgIwjUYJGzFe7NDrBLCN4lsV/5J0MFurV+ygS4bRVwrCEt2c7MQ1R2a72oJDw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/table": {
       "version": "6.8.1",
       "resolved": "https://registry.npmjs.org/table/-/table-6.8.1.tgz",
@@ -9602,19 +9615,6 @@
         "is-typedarray": "^1.0.0"
       }
     },
-    "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "node_modules/ua-parser-js": {
       "version": "1.0.33",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.33.tgz",
@@ -9635,13 +9635,13 @@
       }
     },
     "node_modules/uglify-es": {
-      "version": "3.3.9",
-      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
-      "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.10.tgz",
+      "integrity": "sha512-rPzPisCzW68Okj1zNrfa2dR9uEm43SevDmpR6FChoZABFk9dANGnzzBMgHYUXI3609//63fnVkyQ1SQmAMyjww==",
       "deprecated": "support for ECMAScript is superseded by `uglify-js` as of v3.13.0",
       "dev": true,
       "dependencies": {
-        "commander": "~2.13.0",
+        "commander": "~2.14.1",
         "source-map": "~0.6.1"
       },
       "bin": {
@@ -9652,9 +9652,9 @@
       }
     },
     "node_modules/uglify-es/node_modules/commander": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-      "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
+      "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
       "dev": true
     },
     "node_modules/uglify-js": {
@@ -10904,9 +10904,9 @@
       }
     },
     "@uswds/uswds": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.3.0.tgz",
-      "integrity": "sha512-qiugkbwrO+eIIwi4lbEdH15LCHuAjfUMDRQNBBujakR99Ka3iqmrLpPllffdKaJJnnYkt75v0lltnJ5Nnd/obQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.4.1.tgz",
+      "integrity": "sha512-eLYbWUqf9eWUa2P6CO3ckIjtQyM3AylrIOHxN5gYG3P62TDd3FzRDyoACfvOe6CNk0w0PqXWJnuPzxpNoOgWNA==",
       "requires": {
         "classlist-polyfill": "1.0.3",
         "object-assign": "4.1.1",
@@ -11335,21 +11335,22 @@
       }
     },
     "browser-sync": {
-      "version": "2.28.1",
-      "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.28.1.tgz",
-      "integrity": "sha512-XAd+jULGQ6TSdxA8ABnK6E0r4HHClnZn/p11sHOQ9dr5Qn4ay8TsrEkNUOiWlJOgLuf49QxlkwpqS7BvfGdCpQ==",
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.29.1.tgz",
+      "integrity": "sha512-WXy9HMJVQaNUTPjmai330E2fnDA6W84l/vBILGkYu9yHXIpWw1gJYjdQWDfEhLFljYUHNTN9jM3GCej2T55m+g==",
       "dev": true,
       "requires": {
-        "browser-sync-client": "^2.28.1",
-        "browser-sync-ui": "^2.28.1",
+        "browser-sync-client": "^2.29.1",
+        "browser-sync-ui": "^2.29.1",
         "bs-recipes": "1.3.4",
         "bs-snippet-injector": "^2.0.1",
+        "chalk": "4.1.2",
         "chokidar": "^3.5.1",
         "connect": "3.6.6",
         "connect-history-api-fallback": "^1",
         "dev-ip": "^1.0.1",
         "easy-extender": "^2.3.4",
-        "eazy-logger": "4.0.0",
+        "eazy-logger": "^4.0.1",
         "etag": "^1.8.1",
         "fresh": "^0.5.2",
         "fs-extra": "3.0.1",
@@ -11370,25 +11371,35 @@
         "socket.io": "^4.4.1",
         "ua-parser-js": "^1.0.33",
         "yargs": "^17.3.1"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        }
       }
     },
     "browser-sync-client": {
-      "version": "2.28.1",
-      "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.28.1.tgz",
-      "integrity": "sha512-srFIhUU6CtsLtvBsVmTgRtFt/kFbcl/PYvenpfxPIKTDSxQf35cCjYwYF1osyJdvRoeKoDlaK/fv6eN6/cXRKw==",
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.29.1.tgz",
+      "integrity": "sha512-aESnjt3rU7CZpzjyqzhIC2UJ3MVhzRis7cPKkGbyYWDf/wnbxyRa3fFenF3Qx9061/guY3HHhD67uiTVV26DVg==",
       "dev": true,
       "requires": {
         "etag": "1.8.1",
         "fresh": "0.5.2",
-        "mitt": "^1.1.3",
-        "rxjs": "^5.5.6",
-        "typescript": "^4.6.2"
+        "mitt": "^1.1.3"
       }
     },
     "browser-sync-ui": {
-      "version": "2.28.1",
-      "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-2.28.1.tgz",
-      "integrity": "sha512-yPylRdTE8HS/MxcgGpYfcW/JVde+tVnoTIwotVqzqybW8Kg0e3GfFlS7fD0W+KtI/rS4U5GxVsqERxdqpAjCoQ==",
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-2.29.1.tgz",
+      "integrity": "sha512-MB7SAiUgVUrhipO2xyO1sheC9H0+LKXPQ3L1tQWcZ3AgizBnUNKAqDZPSwe4grNSa8o8ImSAwJp7lMS6XYy1Dw==",
       "dev": true,
       "requires": {
         "async-each-series": "0.1.1",
@@ -12195,10 +12206,25 @@
       }
     },
     "eazy-logger": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-4.0.0.tgz",
-      "integrity": "sha512-ZnYemMI98cKlJt0Fkrw/7zVJYlnzVY22pbQJXmT1ZMmxnC732o7US9KaLXlf3x/g/ImS+uLIvF2R6nbcWP1uWw==",
-      "dev": true
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-4.0.1.tgz",
+      "integrity": "sha512-2GSFtnnC6U4IEKhEI7+PvdxrmjJ04mdsj3wHZTFiw0tUtG4HCWzTr13ZYTk8XOGnA1xQMaDljoBOYlk3D/MMSw==",
+      "dev": true,
+      "requires": {
+        "chalk": "4.1.2"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        }
+      }
     },
     "ee-first": {
       "version": "1.1.1",
@@ -16465,15 +16491,6 @@
       "integrity": "sha512-CiaiuN6gapkdl+cZUr67W6I8jquN4lkak3vtIsIWCl4XIPP8ffsoyN6/+PuGXnQy8Cu8W2y9Xxh31Rq4M6wUug==",
       "dev": true
     },
-    "rxjs": {
-      "version": "5.5.12",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
-      "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
-      "dev": true,
-      "requires": {
-        "symbol-observable": "1.0.1"
-      }
-    },
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -17571,12 +17588,6 @@
       "dev": true,
       "peer": true
     },
-    "symbol-observable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
-      "integrity": "sha512-Kb3PrPYz4HanVF1LVGuAdW6LoVgIwjUYJGzFe7NDrBLCN4lsV/5J0MFurV+ygS4bRVwrCEt2c7MQ1R2a72oJDw==",
-      "dev": true
-    },
     "table": {
       "version": "6.8.1",
       "resolved": "https://registry.npmjs.org/table/-/table-6.8.1.tgz",
@@ -17761,12 +17772,6 @@
         "is-typedarray": "^1.0.0"
       }
     },
-    "typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true
-    },
     "ua-parser-js": {
       "version": "1.0.33",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.33.tgz",
@@ -17774,19 +17779,19 @@
       "dev": true
     },
     "uglify-es": {
-      "version": "3.3.9",
-      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
-      "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.10.tgz",
+      "integrity": "sha512-rPzPisCzW68Okj1zNrfa2dR9uEm43SevDmpR6FChoZABFk9dANGnzzBMgHYUXI3609//63fnVkyQ1SQmAMyjww==",
       "dev": true,
       "requires": {
-        "commander": "~2.13.0",
+        "commander": "~2.14.1",
         "source-map": "~0.6.1"
       },
       "dependencies": {
         "commander": {
-          "version": "2.13.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-          "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
+          "version": "2.14.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
+          "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
           "dev": true
         }
       }

--- a/web/themes/custom/vote_gov/package.json
+++ b/web/themes/custom/vote_gov/package.json
@@ -12,15 +12,15 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@uswds/uswds": "^3.3.0",
+    "@uswds/uswds": "^3.4.1",
     "a11y-tabs": "^0.1.2"
   },
   "devDependencies": {
     "@uswds/compile": "^1.0.0-beta.3",
-    "browser-sync": "^2.28.1",
+    "browser-sync": "^2.29.1",
     "gulp": "^4.0.2",
     "gulp-stylelint": "^13.0.0",
     "gulp-uglify": "^3.0.2",
-    "uglify-es": "^3.3.9"
+    "uglify-es": "^3.3.10"
   }
 }


### PR DESCRIPTION
Bump uswds to 3.4.1
Bump browser-sync to 2.29.1
Bump uglify-es to 3.3.10

## Jira ticket (required)
https://bixal-projects.atlassian.net/browse/VOTE-1180

## Description (optional)
Update vote_gov theme npm dependencies

## Deployment and testing (required, if applicable)
### Post-deploy steps
1. cd into vote_gov theme
2. run `npm i`

### Testing steps
1. run `npm run dev`
2. run `npm run build`
3. Make sure neither script is failing