### PR TITLE
VOTE-1054: Enable Remove HTTP headers contrib module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
         "drupal/pathauto": "^1.11",
         "drupal/publication_date": "^2.0@beta",
         "drupal/redirect": "^1.8",
+        "drupal/remove_http_headers": "^2.0",
         "drupal/s3fs": "^3.1",
         "drupal/simple_sitemap": "^4.1",
         "drupal/stable": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "96b0baf4d5d0d965b6e1de66cd10588e",
+    "content-hash": "91b93ef0e1b1fd0066338ca8277d9f5f",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2927,6 +2927,61 @@
             "homepage": "https://www.drupal.org/project/redirect",
             "support": {
                 "source": "https://git.drupalcode.org/project/redirect"
+            }
+        },
+        {
+            "name": "drupal/remove_http_headers",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/remove_http_headers.git",
+                "reference": "2.0.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/remove_http_headers-2.0.0.zip",
+                "reference": "2.0.0",
+                "shasum": "f6e43ae63cbcd22ac12b4edaa7c0e559269719e1"
+            },
+            "require": {
+                "drupal/core": "^10.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.0.0",
+                    "datestamp": "1672956096",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Orlando Thöny",
+                    "homepage": "https://www.drupal.org/user/3396620",
+                    "email": "orlando.thoeny@gmail.com",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "milovan",
+                    "homepage": "https://www.drupal.org/user/2018332"
+                }
+            ],
+            "description": "Removes configured HTTP Response headers.",
+            "homepage": "https://drupal.org/project/remove_http_headers",
+            "keywords": [
+                "Drupal",
+                "HTTP headers",
+                "Security"
+            ],
+            "support": {
+                "source": "https://git.drupalcode.org/project/remove_http_headers"
             }
         },
         {

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -49,6 +49,7 @@ module:
   path: 0
   path_alias: 0
   redirect: 0
+  remove_http_headers: 0
   s3fs: 0
   simple_sitemap: 0
   system: 0

--- a/config/remove_http_headers.settings.yml
+++ b/config/remove_http_headers.settings.yml
@@ -1,0 +1,10 @@
+_core:
+  default_config_hash: LNYrEZMNvotD7ZS_X0b59tq3Jyl-f5lNMUOZWTLuC9A
+headers_to_remove:
+  - X-Generator
+  - X-Drupal-Dynamic-Cache
+  - X-Drupal-Cache
+dependencies:
+  enforced:
+    module:
+      - remove_http_headers


### PR DESCRIPTION
## Jira ticket (required)
[VOTE-1054](https://bixal-projects.atlassian.net/browse/VOTE-1054)

## Description (optional)
Install & Enable Remove HTTP Headers contrib module.

## Deployment and testing (required, if applicable)
### Testing steps
1. Go to /admin/config/system/remove-http-headers and be sure the module is configured correctly.
