### PR TITLE
VOTE-1065: Site alert publish filter

### DIFF
--- a/config/core.entity_form_display.block_content.sitewide_alert.default.yml
+++ b/config/core.entity_form_display.block_content.sitewide_alert.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - block_content.type.sitewide_alert
     - field.field.block_content.sitewide_alert.field_alert_content
     - field.field.block_content.sitewide_alert.field_alert_type
+    - field.field.block_content.sitewide_alert.field_publish
   module:
     - text
 id: block_content.sitewide_alert.default
@@ -26,6 +27,13 @@ content:
     weight: 3
     region: content
     settings: {  }
+    third_party_settings: {  }
+  field_publish:
+    type: boolean_checkbox
+    weight: 26
+    region: content
+    settings:
+      display_label: true
     third_party_settings: {  }
   info:
     type: string_textfield

--- a/config/core.entity_view_display.block_content.sitewide_alert.default.yml
+++ b/config/core.entity_view_display.block_content.sitewide_alert.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - block_content.type.sitewide_alert
     - field.field.block_content.sitewide_alert.field_alert_content
     - field.field.block_content.sitewide_alert.field_alert_type
+    - field.field.block_content.sitewide_alert.field_publish
   module:
     - options
     - text
@@ -27,6 +28,16 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 1
+    region: content
+  field_publish:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 3
     region: content
 hidden:
   langcode: true

--- a/config/field.field.block_content.sitewide_alert.field_publish.yml
+++ b/config/field.field.block_content.sitewide_alert.field_publish.yml
@@ -1,0 +1,23 @@
+uuid: 600c6906-d597-4e7e-8a2f-d8162f7ea5da
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.sitewide_alert
+    - field.storage.block_content.field_publish
+id: block_content.sitewide_alert.field_publish
+field_name: field_publish
+entity_type: block_content
+bundle: sitewide_alert
+label: Publish
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/field.storage.block_content.field_publish.yml
+++ b/config/field.storage.block_content.field_publish.yml
@@ -1,0 +1,18 @@
+uuid: 314aba64-fd42-4dc8-8c36-e3aa04db580e
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+id: block_content.field_publish
+field_name: field_publish
+entity_type: block_content
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/views.view.site_alerts.yml
+++ b/config/views.view.site_alerts.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - block_content.type.sitewide_alert
+    - field.storage.block_content.field_publish
   module:
     - block_content
 id: site_alerts
@@ -86,71 +87,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-        type:
-          id: type
-          table: block_content_field_data
-          field: type
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: block_content
-          entity_field: type
-          plugin_id: field
-          label: 'Block type'
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: target_id
-          type: entity_reference_label
-          settings:
-            link: false
-          group_column: target_id
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
         langcode:
           id: langcode
           table: block_content_field_data
@@ -207,6 +143,71 @@ display:
           settings:
             link_to_entity: false
             native_language: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_publish:
+          id: field_publish
+          table: block_content__field_publish
+          field: field_publish
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: Status
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: boolean
+          settings:
+            format: custom
+            format_custom_false: Unpublished
+            format_custom_true: Published
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -494,6 +495,51 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        field_publish_value:
+          id: field_publish_value
+          table: block_content__field_publish
+          field: field_publish_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: boolean
+          operator: '='
+          value: All
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: Published
+            description: ''
+            use_operator: false
+            operator: field_publish_value_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: status
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              content_editor: '0'
+              content_manager: '0'
+              site_admin: '0'
+          is_grouped: false
+          group_info:
+            label: 'Publish (field_publish)'
+            description: null
+            identifier: field_publish_value
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items:
+              1: {  }
+              2: {  }
+              3: {  }
         langcode:
           id: langcode
           table: block_content_field_data
@@ -551,44 +597,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-        field_publish_value:
-          id: field_publish_value
-          table: block_content__field_publish
-          field: field_publish_value
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: boolean
-          operator: '='
-          value: '1'
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
       filter_groups:
         operator: AND
         groups:
@@ -627,7 +635,8 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-      tags: {  }
+      tags:
+        - 'config:field.storage.block_content.field_publish'
   page_1:
     id: page_1
     display_title: Page
@@ -652,4 +661,5 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-      tags: {  }
+      tags:
+        - 'config:field.storage.block_content.field_publish'

--- a/config/views.view.site_alerts.yml
+++ b/config/views.view.site_alerts.yml
@@ -551,6 +551,44 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        field_publish_value:
+          id: field_publish_value
+          table: block_content__field_publish
+          field: field_publish_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       filter_groups:
         operator: AND
         groups:

--- a/testing/cypress/e2e/externalLinks/english-external-links-validator.cy.js
+++ b/testing/cypress/e2e/externalLinks/english-external-links-validator.cy.js
@@ -1,6 +1,5 @@
 /// <reference types="Cypress" />
 
-
 const allPages = require("../../fixtures/testing-page.json");
 
 const excludedlinks = [
@@ -47,20 +46,16 @@ describe("External Link Validator Test", () => {
         cy.visit({
           url: page.route,
         });
-          // the follow code will be brought back in once content is on site
-        // cy.get("div[role='main'] a[href^='https://']").each(link => {
-        //   if (excludedlinks.indexOf(link.prop('href')) == -1) {
-        //     cy.request({
-        //       url: link.prop('href'),
-        //       failOnStatusCode: false
-        //     }).then((response) => {
-        //       expect(response.status).to.eq(200)
-        //     })
-        //   }
-        // })
-
-          // the follow is to just verify the test is set up correctly and can fucntion 
-          cy.get('a').should('be.visible')
+        cy.get("a[href^='https://']").each(link => {
+          if (excludedlinks.indexOf(link.prop('href')) == -1) {
+            cy.request({
+              url: link.prop('href'),
+              failOnStatusCode: false
+            }).then((response) => {
+              expect(response.status).to.eq(200)
+            })
+          }
+        })
       }
     );
   });    

--- a/testing/cypress/e2e/internalLinks/english-internal-links-validator.cy.js
+++ b/testing/cypress/e2e/internalLinks/english-internal-links-validator.cy.js
@@ -1,25 +1,6 @@
 /// <reference types="Cypress" />
 
-
 const allPages = require("../../fixtures/testing-page.json");
-
-const excludedlinks = [
-  'https://voterregistration.ct.gov/OLVR/welcome.do?ref=voteusa_en',
-  // the above link will throw error code "read ECONNRESET" this will not pass through cypress test and has been checked manually but has not been added to `excluded-links.cy.js` test 
-  'https://voterservices.elections.maryland.gov/OnlineVoterRegistration/InstructionsStep1?ref=voteusa_en',
-  'https://www.sec.state.ma.us/ovr/?ref=voteusa_en',
-  'https://olvr.ohiosos.gov/?ref=voteusa_en',
-  'https://voterlookup.ohiosos.gov/voterlookup.aspx?ref=voteusa_en',
-  'https://olvr.hawaii.gov/?ref=voteusa_en',
-  'https://elections.hawaii.gov/voters/registration/?ref=voteusa_en',
-  'https://vote.sos.ri.gov/Home/RegistertoVote?ref=voteusa_en',
-  'https://vote.sos.ri.gov/Voter/RegisterToVote?ref=voteusa_en',
-  'https://vote.sos.ri.gov/Home/UpdateVoterRecord?ActiveFlag=0&?ref=voteusa_en',
-  // sc links
-  'https://vrems.scvotes.sc.gov/Voter/Login?ref=voteusa_en',
-  'https://scvotes.gov/voters/register-to-vote/?ref=voteusa_en',
-  'https://info.scvotes.sc.gov/eng/ovr/start.aspx?ref=voteusa_en'
-];
 
 describe("Internal Link Validator Test", () => {
   const singlePage =
@@ -47,18 +28,14 @@ describe("Internal Link Validator Test", () => {
         cy.visit({
           url: page.route,
         });
-          // the follow code will be brought back in once content is on site
-        //   cy.get("a[href^='/']").each(link => {
-        //     cy.request({
-        //       url: link.prop('href'),
-        //       failOnStatusCode: false
-        //     }).then((response) => {
-        //       expect(response.status).to.eq(200)
-        //     })
-        // })
-
-          // the follow is to just verify the test is set up correctly and can fucntion 
-          cy.get('a').should('be.visible')
+          cy.get("a[href^='/']").each(link => {
+            cy.request({
+              url: link.prop('href'),
+              failOnStatusCode: false
+            }).then((response) => {
+              expect(response.status).to.eq(200)
+            })
+        })
       }
     );
   });    


### PR DESCRIPTION
## Jira ticket (required)
[VOTE-1065](https://bixal-projects.atlassian.net/jira/software/c/projects/VOTE/boards/254?modal=detail&selectedIssue=VOTE-1065&assignee=609161faf6c0960069bf61b3)

## Description (optional)
Adds publish checkbox to site alerts and then filters by publish in site alerts view page

## Deployment and testing (required, if applicable)
### Pre-deploy steps
1. Pull branch
2. Run lando retune

### Testing steps
1. Create content for a site alert block and select the publish checkbox
2. Visit /admin/content/site-alerts and see that the block appears in the list
3. Un-publish the block and see that it no longer appears in the list
