### PR TITLE
VOTE-995: adds uswds alert variants

### DIFF
--- a/config/core.entity_view_display.block_content.sitewide_alert.default.yml
+++ b/config/core.entity_view_display.block_content.sitewide_alert.default.yml
@@ -22,7 +22,7 @@ content:
     weight: 2
     region: content
   field_alert_type:
-    type: list_default
+    type: list_key
     label: hidden
     settings: {  }
     third_party_settings: {  }

--- a/web/themes/custom/vote_gov/templates/block/block-content--sitewide-alert.html.twig
+++ b/web/themes/custom/vote_gov/templates/block/block-content--sitewide-alert.html.twig
@@ -9,7 +9,9 @@
  */
 #}
 
-<div class="usa-alert usa-alert--info">
+{% set variant = content.field_alert_type.0 | render == 'Informational' ? 'info' : 'emergency' %}
+
+<div class="usa-alert usa-alert--{{ variant }}">
   <div class="grid-container">
     <div class="usa-alert__body">
       <div class="usa-alert__text">

--- a/web/themes/custom/vote_gov/templates/block/block-content--sitewide-alert.html.twig
+++ b/web/themes/custom/vote_gov/templates/block/block-content--sitewide-alert.html.twig
@@ -11,7 +11,7 @@
 
 {% set classes = [
   'usa-alert',
-  content.field_alert_type.0 | render == 'Informational' ? 'usa-alert--info' : 'usa-alert--emergency'
+  content.field_alert_type | render ? 'usa-alert--' ~ content.field_alert_type | field_value | render
 ] %}
 
 <div{{ attributes.addClass(classes)}}>

--- a/web/themes/custom/vote_gov/templates/block/block-content--sitewide-alert.html.twig
+++ b/web/themes/custom/vote_gov/templates/block/block-content--sitewide-alert.html.twig
@@ -9,9 +9,12 @@
  */
 #}
 
-{% set variant = content.field_alert_type.0 | render == 'Informational' ? 'info' : 'emergency' %}
+{% set classes = [
+  'usa-alert',
+  content.field_alert_type.0 | render == 'Informational' ? 'usa-alert--info' : 'usa-alert--emergency'
+] %}
 
-<div class="usa-alert usa-alert--{{ variant }}">
+<div{{ attributes.addClass(classes)}}>
   <div class="grid-container">
     <div class="usa-alert__body">
       <div class="usa-alert__text">


### PR DESCRIPTION
## Jira ticket (required)
[VOTE-995](https://bixal-projects.atlassian.net/jira/software/c/projects/VOTE/boards/254?modal=detail&selectedIssue=VOTE-995&assignee=609161faf6c0960069bf61b3)

## Description (optional)
Implements use of both informational and emergency variants from USWDS for alert styling.

## Deployment and testing (required, if applicable)
### Pre-deploy steps
1. Pull branch
2. Run lando retune

### Testing steps
1. Create content for both an informational alert and an emergency alert
2. Check any site page to see that they are styled according to their variant