### PR TITLE
VOTE-975: Delete block_content revisions greater than 10 revisions

### DIFF
--- a/web/modules/custom/vote_utility/inc/block_content_revisions.inc
+++ b/web/modules/custom/vote_utility/inc/block_content_revisions.inc
@@ -16,7 +16,7 @@ function vote_utility_block_content_update(EntityInterface $entity) {
     SELECT revision_id from block_content_revision
     WHERE id = :entity_id
 	ORDER BY revision_created DESC
-	LIMIT 10, 18446744073709551615', [
+	LIMIT 50, 18446744073709551615', [
    ':entity_id' => $entity->id(),
  ]);
   foreach ($query->fetchAllAssoc('revision_id') as $version) {

--- a/web/modules/custom/vote_utility/inc/block_content_revisions.inc
+++ b/web/modules/custom/vote_utility/inc/block_content_revisions.inc
@@ -8,7 +8,7 @@
 use Drupal\Core\Entity\EntityInterface;
 
 /**
- * Implements hook_ENTITY_TYPE_update() {.
+ * Implements hook_ENTITY_TYPE_update().
  */
 function vote_utility_block_content_update(EntityInterface $entity) {
 

--- a/web/modules/custom/vote_utility/inc/block_content_revisions.inc
+++ b/web/modules/custom/vote_utility/inc/block_content_revisions.inc
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @file
+ * Defines custom block_content revisions behavior.
+ */
+
+use Drupal\Core\Entity\EntityInterface;
+
+/**
+ * Implements hook_ENTITY_TYPE_update() {.
+ */
+function vote_utility_block_content_update(EntityInterface $entity) {
+
+  $query = \Drupal::database()->query('
+    SELECT revision_id from block_content_revision
+    WHERE id = :entity_id
+	ORDER BY revision_created DESC
+	LIMIT 10, 18446744073709551615', [
+   ':entity_id' => $entity->id(),
+ ]);
+  foreach ($query->fetchAllAssoc('revision_id') as $version) {
+    \Drupal::entityTypeManager()->getStorage('block_content')->deleteRevision($version->revision_id);
+  }
+}

--- a/web/modules/custom/vote_utility/vote_utility.module
+++ b/web/modules/custom/vote_utility/vote_utility.module
@@ -5,4 +5,5 @@
  * Custom functions.
  */
 
+require_once dirname(__FILE__) . '/inc/block_content_revisions.inc';
 require_once dirname(__FILE__) . '/inc/token.inc';


### PR DESCRIPTION
## Jira ticket (required)
[VOTE-975](https://bixal-projects.atlassian.net/browse/VOTE-975)

## Description (optional)
Add custom code to remove block_content revisions above 10 revisions per block.

## Deployment and testing (required, if applicable)
### Testing steps
1. Create 10 revisions for a block and run a sql command **SELECT count(*) FROM block_content_revision WHERE id={  block_id }** to be sure future saves/revisions do not exceed 10.
2. Also **SELECT * FROM block_content_revision WHERE id={ block_id } ORDER BY revision_created DESC;** lists the latest revisions left in descending order.
