### PR TITLE
VOTE-1115 update admin listings

### DIFF
--- a/config/language.negotiation.yml
+++ b/config/language.negotiation.yml
@@ -17,6 +17,7 @@ url:
     nv: nv
     vi: vi
     ypk: ypk
+    '': null
   domains:
     en: ''
     es: ''

--- a/config/views.view.block_content.yml
+++ b/config/views.view.block_content.yml
@@ -8,7 +8,7 @@ dependencies:
 _core:
   default_config_hash: jvd5Pu6jy-lra4oMr-mR7zuY6CVDv9CaNeoj0Y70gV4
 id: block_content
-label: 'Custom block library'
+label: 'Admin: Custom block library'
 module: views
 description: 'Find and manage custom blocks.'
 tag: default
@@ -523,19 +523,7 @@ display:
           entity_field: langcode
           plugin_id: language
           operator: in
-          value:
-            en: en
-            es: es
-            bn: bn
-            zh-hans: zh-hans
-            zh: zh
-            hi: hi
-            km: km
-            ko: ko
-            nv: nv
-            tl: tl
-            vi: vi
-            ypk: ypk
+          value: {  }
           group: 1
           exposed: true
           expose:
@@ -556,7 +544,7 @@ display:
               content_editor: '0'
               content_manager: '0'
               site_admin: '0'
-            reduce: true
+            reduce: false
           is_grouped: false
           group_info:
             label: ''

--- a/config/views.view.content.yml
+++ b/config/views.view.content.yml
@@ -8,7 +8,7 @@ dependencies:
 _core:
   default_config_hash: vBKWYGGDoAX-tFd1JErB8tZLSxx3lJ0foouVsgpcbB4
 id: content
-label: Content
+label: 'Admin: Content'
 module: node
 description: 'Find and manage content.'
 tag: default
@@ -127,6 +127,72 @@ display:
           empty_zero: false
           hide_alter_empty: true
           type: user_name
+        langcode:
+          id: langcode
+          table: node_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: langcode
+          plugin_id: field
+          label: Language
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: language
+          settings:
+            link_to_entity: false
+            native_language: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
         status:
           id: status
           table: node_field_data
@@ -401,11 +467,7 @@ display:
           entity_field: langcode
           plugin_id: language
           operator: in
-          value:
-            en: en
-            es: es
-            ko: ko
-            tl: tl
+          value: {  }
           group: 1
           exposed: true
           expose:
@@ -425,7 +487,8 @@ display:
               anonymous: '0'
               content_editor: '0'
               content_manager: '0'
-            reduce: true
+              site_admin: '0'
+            reduce: false
           is_grouped: false
           group_info:
             label: ''

--- a/config/views.view.files.yml
+++ b/config/views.view.files.yml
@@ -4,11 +4,12 @@ status: true
 dependencies:
   module:
     - file
+    - media
     - user
 _core:
   default_config_hash: DaGeEDJMcbbQtgV96AuPeZ-0irMc_Oa6Zzh2U3Kmul8
 id: files
-label: Files
+label: 'Admin: Files'
 module: file
 description: 'Find and manage files.'
 tag: default
@@ -739,9 +740,681 @@ display:
     display_plugin: page
     position: 1
     display_options:
+      fields:
+        fid:
+          id: fid
+          table: file_managed
+          field: fid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: file
+          entity_field: fid
+          plugin_id: field
+          label: Fid
+          exclude: true
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            trim: false
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        filename:
+          id: filename
+          table: file_managed
+          field: filename
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: file
+          entity_field: filename
+          plugin_id: field
+          label: Name
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: file_link
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        filemime:
+          id: filemime
+          table: file_managed
+          field: filemime
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: file
+          entity_field: filemime
+          plugin_id: field
+          label: 'MIME type'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          type: file_filemime
+        filesize:
+          id: filesize
+          table: file_managed
+          field: filesize
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: file
+          entity_field: filesize
+          plugin_id: field
+          label: Size
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          type: file_size
+        langcode:
+          id: langcode
+          table: media_field_data
+          field: langcode
+          relationship: reverse_field_media_file_media
+          group_type: group
+          admin_label: ''
+          entity_type: media
+          entity_field: langcode
+          plugin_id: field
+          label: Language
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: language
+          settings:
+            link_to_entity: false
+            native_language: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        status:
+          id: status
+          table: file_managed
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: file
+          entity_field: status
+          plugin_id: field
+          label: Status
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          type: boolean
+          settings:
+            format: custom
+            format_custom_false: Temporary
+            format_custom_true: Permanent
+        created:
+          id: created
+          table: file_managed
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: file
+          entity_field: created
+          plugin_id: field
+          label: 'Upload date'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          type: timestamp
+          settings:
+            date_format: medium
+            custom_date_format: ''
+            timezone: ''
+        changed:
+          id: changed
+          table: file_managed
+          field: changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: file
+          entity_field: changed
+          plugin_id: field
+          label: 'Changed date'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          type: timestamp
+          settings:
+            date_format: medium
+            custom_date_format: ''
+            timezone: ''
+        count:
+          id: count
+          table: file_usage
+          field: count
+          relationship: fid
+          group_type: sum
+          admin_label: ''
+          plugin_id: numeric
+          label: 'Used in'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: true
+            path: 'admin/content/files/usage/{{ fid }}'
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ','
+          format_plural: true
+          format_plural_string: !!binary MSBwbGFjZQNAY291bnQgcGxhY2Vz
+          prefix: ''
+          suffix: ''
+      filters:
+        filename:
+          id: filename
+          table: file_managed
+          field: filename
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: file
+          entity_field: filename
+          plugin_id: string
+          operator: word
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: filemime_op
+            label: Filename
+            description: ''
+            use_operator: false
+            operator: filename_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: filename
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        filemime:
+          id: filemime
+          table: file_managed
+          field: filemime
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: file
+          entity_field: filemime
+          plugin_id: string
+          operator: word
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: filemime_op
+            label: 'MIME type'
+            description: ''
+            use_operator: false
+            operator: filemime_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: filemime
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        status:
+          id: status
+          table: file_managed
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: file
+          entity_field: status
+          plugin_id: file_status
+          operator: in
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: status_op
+            label: Status
+            description: ''
+            use_operator: false
+            operator: status_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: status
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        langcode:
+          id: langcode
+          table: media_field_data
+          field: langcode
+          relationship: reverse_field_media_file_media
+          group_type: group
+          admin_label: ''
+          entity_type: media
+          entity_field: langcode
+          plugin_id: language
+          operator: in
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: langcode_op
+            label: Language
+            description: ''
+            use_operator: false
+            operator: langcode_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: langcode
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              content_editor: '0'
+              content_manager: '0'
+              site_admin: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
       defaults:
         pager: true
         relationships: false
+        fields: false
+        filters: false
+        filter_groups: false
       relationships:
         fid:
           id: fid
@@ -750,6 +1423,16 @@ display:
           relationship: none
           group_type: group
           admin_label: 'File usage'
+          required: false
+        reverse_field_media_file_media:
+          id: reverse_field_media_file_media
+          table: file_managed
+          field: reverse_field_media_file_media
+          relationship: none
+          group_type: group
+          admin_label: field_media_file
+          entity_type: file
+          plugin_id: entity_reverse
           required: false
       display_description: ''
       display_extenders: {  }

--- a/config/views.view.global_blocks.yml
+++ b/config/views.view.global_blocks.yml
@@ -7,13 +7,14 @@ dependencies:
     - block_content.type.government_banner
     - block_content.type.registration_form_selector
     - block_content.type.search
+    - user.role.authenticated
   module:
     - block_content
     - user
 _core:
   default_config_hash: jvd5Pu6jy-lra4oMr-mR7zuY6CVDv9CaNeoj0Y70gV4
 id: global_blocks
-label: 'Global Blocks'
+label: 'Admin: Global Blocks'
 module: views
 description: 'Find and manage custom blocks.'
 tag: default
@@ -360,9 +361,10 @@ display:
           sort_asc_label: Asc
           sort_desc_label: Desc
       access:
-        type: perm
+        type: role
         options:
-          perm: 'administer blocks'
+          role:
+            authenticated: authenticated
       cache:
         type: tag
         options: {  }
@@ -609,19 +611,7 @@ display:
           entity_field: langcode
           plugin_id: language
           operator: in
-          value:
-            en: en
-            es: es
-            bn: bn
-            zh-hans: zh-hans
-            zh: zh
-            hi: hi
-            km: km
-            ko: ko
-            nv: nv
-            tl: tl
-            vi: vi
-            ypk: ypk
+          value: {  }
           group: 1
           exposed: true
           expose:
@@ -642,7 +632,7 @@ display:
               content_editor: '0'
               content_manager: '0'
               site_admin: '0'
-            reduce: true
+            reduce: false
           is_grouped: false
           group_info:
             label: ''
@@ -727,7 +717,7 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-        - user.permissions
+        - user.roles
       tags: {  }
   page_1:
     id: page_1
@@ -753,5 +743,5 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-        - user.permissions
+        - user.roles
       tags: {  }

--- a/config/views.view.media.yml
+++ b/config/views.view.media.yml
@@ -11,7 +11,7 @@ dependencies:
 _core:
   default_config_hash: diywn6VdMoQOlDA-xslKdKrDko3SsTKfaK3WBG45UAg
 id: media
-label: Media
+label: 'Admin: Media'
 module: views
 description: 'Find and manage media.'
 tag: ''
@@ -315,6 +315,72 @@ display:
           settings:
             link: true
           group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        langcode:
+          id: langcode
+          table: media_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: media
+          entity_field: langcode
+          plugin_id: field
+          label: Language
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: language
+          settings:
+            link_to_entity: false
+            native_language: false
+          group_column: value
           group_columns: {  }
           group_rows: true
           delta_limit: 0
@@ -779,7 +845,9 @@ display:
             remember_roles:
               authenticated: authenticated
               anonymous: '0'
-              administrator: '0'
+              content_editor: '0'
+              content_manager: '0'
+              site_admin: '0'
             reduce: false
           is_grouped: false
           group_info:

--- a/config/views.view.media_library.yml
+++ b/config/views.view.media_library.yml
@@ -16,7 +16,7 @@ dependencies:
 _core:
   default_config_hash: GDIFCs-lTKQIMvaNZ95zofFcqpTxDYakxx02_zZFkmM
 id: media_library
-label: 'Media library'
+label: 'Admin: Media library'
 module: views
 description: 'Find and manage media.'
 tag: ''
@@ -478,13 +478,22 @@ display:
     cache_metadata:
       max-age: 0
       contexts:
+        - 'languages:language_content'
         - 'languages:language_interface'
         - url
         - url.query_args
         - 'url.query_args:sort_by'
         - user
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:core.entity_view_display.media.audio.default'
+        - 'config:core.entity_view_display.media.audio.media_library'
+        - 'config:core.entity_view_display.media.document.default'
+        - 'config:core.entity_view_display.media.document.media_library'
+        - 'config:core.entity_view_display.media.image.default'
+        - 'config:core.entity_view_display.media.image.media_library'
+        - 'config:core.entity_view_display.media.remote_video.default'
+        - 'config:core.entity_view_display.media.remote_video.media_library'
   page:
     id: page
     display_title: Page
@@ -781,7 +790,15 @@ display:
         - 'url.query_args:sort_by'
         - user
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:core.entity_view_display.media.audio.default'
+        - 'config:core.entity_view_display.media.audio.media_library'
+        - 'config:core.entity_view_display.media.document.default'
+        - 'config:core.entity_view_display.media.document.media_library'
+        - 'config:core.entity_view_display.media.image.default'
+        - 'config:core.entity_view_display.media.image.media_library'
+        - 'config:core.entity_view_display.media.remote_video.default'
+        - 'config:core.entity_view_display.media.remote_video.media_library'
   widget:
     id: widget
     display_title: Widget
@@ -1101,7 +1118,15 @@ display:
         - url.query_args
         - 'url.query_args:sort_by'
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:core.entity_view_display.media.audio.default'
+        - 'config:core.entity_view_display.media.audio.media_library'
+        - 'config:core.entity_view_display.media.document.default'
+        - 'config:core.entity_view_display.media.document.media_library'
+        - 'config:core.entity_view_display.media.image.default'
+        - 'config:core.entity_view_display.media.image.media_library'
+        - 'config:core.entity_view_display.media.remote_video.default'
+        - 'config:core.entity_view_display.media.remote_video.media_library'
   widget_table:
     id: widget_table
     display_title: 'Widget (table)'

--- a/config/views.view.moderated_content.yml
+++ b/config/views.view.moderated_content.yml
@@ -14,7 +14,7 @@ dependencies:
 _core:
   default_config_hash: upi3_YaKY1MjDALjDauLNPXfHakisQNehC9Dj6icMPQ
 id: moderated_content
-label: 'Moderated content'
+label: 'Admin: Moderated content'
 module: views
 description: 'Find and moderate content.'
 tag: ''
@@ -214,6 +214,72 @@ display:
           type: user_name
           settings:
             link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        langcode:
+          id: langcode
+          table: node_field_data
+          field: langcode
+          relationship: nid
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: langcode
+          plugin_id: field
+          label: Language
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: language
+          settings:
+            link_to_entity: false
+            native_language: false
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -637,11 +703,7 @@ display:
           entity_field: langcode
           plugin_id: language
           operator: in
-          value:
-            en: en
-            es: es
-            ko: ko
-            tl: tl
+          value: {  }
           group: 1
           exposed: true
           expose:
@@ -661,7 +723,8 @@ display:
               anonymous: '0'
               content_editor: '0'
               content_manager: '0'
-            reduce: true
+              site_admin: '0'
+            reduce: false
           is_grouped: false
           group_info:
             label: ''

--- a/config/views.view.redirect.yml
+++ b/config/views.view.redirect.yml
@@ -9,7 +9,7 @@ dependencies:
 _core:
   default_config_hash: 7-f_3ASk-Ly7MqcUiwREHB0r0l-jkq7bKwjRLTMhDEs
 id: redirect
-label: Redirect
+label: 'Admin: Redirect'
 module: views
 description: 'List of redirects'
 tag: ''
@@ -17,122 +17,12 @@ base_table: redirect
 base_field: rid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'administer redirects'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Filter
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: full
-        options:
-          items_per_page: 50
-          offset: 0
-          id: 0
-          total_pages: null
-          tags:
-            previous: '‹ previous'
-            next: 'next ›'
-            first: '« first'
-            last: 'last »'
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          quantity: 9
-      style:
-        type: table
-        options:
-          grouping: {  }
-          row_class: ''
-          default_row_class: true
-          override: true
-          sticky: false
-          caption: ''
-          summary: ''
-          description: ''
-          columns:
-            redirect_source__path: redirect_source__path
-            redirect_redirect__uri: redirect_redirect__uri
-            status_code: status_code
-            language: language
-            created: created
-            operations: operations
-          info:
-            redirect_source__path:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            redirect_redirect__uri:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            status_code:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            language:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            created:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            operations:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-          default: created
-          empty_table: false
-      row:
-        type: fields
+      title: Redirect
       fields:
         redirect_bulk_form:
           id: redirect_bulk_form
@@ -141,6 +31,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: redirect
+          plugin_id: redirect_bulk_form
           label: ''
           exclude: false
           alter:
@@ -185,8 +77,6 @@ display:
           action_title: 'With selection'
           include_exclude: exclude
           selected_actions: {  }
-          entity_type: redirect
-          plugin_id: redirect_bulk_form
         redirect_source__path:
           id: redirect_source__path
           table: redirect
@@ -194,6 +84,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: redirect
+          entity_field: redirect_source
+          plugin_id: field
           label: From
           exclude: false
           alter:
@@ -248,9 +141,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: redirect
-          entity_field: redirect_source
-          plugin_id: field
         redirect_redirect__uri:
           id: redirect_redirect__uri
           table: redirect
@@ -279,6 +169,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: redirect
+          entity_field: created
+          plugin_id: date
           label: Created
           exclude: false
           alter:
@@ -323,15 +216,64 @@ display:
           date_format: fallback
           custom_date_format: ''
           timezone: ''
-          entity_type: redirect
-          entity_field: created
-          plugin_id: date
         operations:
           id: operations
           table: redirect
           field: operations
           entity_type: redirect
           plugin_id: entity_operations
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 50
+          total_pages: null
+          id: 0
+          tags:
+            next: 'next ›'
+            previous: '‹ previous'
+            first: '« first'
+            last: 'last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Filter
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'administer redirects'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: 'There is no redirect yet.'
+          tokenize: false
+      sorts: {  }
+      arguments: {  }
       filters:
         redirect_source__path:
           id: redirect_source__path
@@ -340,6 +282,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: redirect
+          entity_field: redirect_source
+          plugin_id: string
           operator: contains
           value: ''
           group: 1
@@ -350,6 +295,8 @@ display:
             description: ''
             use_operator: false
             operator: redirect_source__path_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: redirect_source__path
             required: false
             remember: false
@@ -358,8 +305,6 @@ display:
               authenticated: authenticated
               anonymous: '0'
               administrator: '0'
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -372,9 +317,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: redirect
-          entity_field: redirect_source
-          plugin_id: string
         redirect_redirect__uri:
           id: redirect_redirect__uri
           table: redirect
@@ -382,6 +324,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: redirect
+          entity_field: redirect_redirect
+          plugin_id: string
           operator: contains
           value: ''
           group: 1
@@ -392,6 +337,8 @@ display:
             description: ''
             use_operator: false
             operator: redirect_redirect__uri_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: redirect_redirect__uri
             required: false
             remember: false
@@ -400,8 +347,6 @@ display:
               authenticated: authenticated
               anonymous: '0'
               administrator: '0'
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -414,9 +359,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: redirect
-          entity_field: redirect_redirect
-          plugin_id: string
         status_code:
           id: status_code
           table: redirect
@@ -424,6 +366,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: redirect
+          entity_field: status_code
+          plugin_id: numeric
           operator: '='
           value:
             min: ''
@@ -437,6 +382,8 @@ display:
             description: ''
             use_operator: false
             operator: status_code_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: status_code
             required: false
             remember: false
@@ -445,8 +392,6 @@ display:
               authenticated: authenticated
               anonymous: '0'
               administrator: '0'
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: true
           group_info:
             label: 'Status code'
@@ -463,54 +408,51 @@ display:
                 title: '300 Multiple Choices'
                 operator: '='
                 value:
-                  value: '300'
                   min: ''
                   max: ''
+                  value: '300'
               2:
                 title: '301 Moved Permanently'
                 operator: '='
                 value:
-                  value: '301'
                   min: ''
                   max: ''
+                  value: '301'
               3:
                 title: '302 Found'
                 operator: '='
                 value:
-                  value: '302'
                   min: ''
                   max: ''
+                  value: '302'
               4:
                 title: '303 See Other'
                 operator: '='
                 value:
-                  value: '303'
                   min: ''
                   max: ''
+                  value: '303'
               5:
                 title: '304 Not Modified'
                 operator: '='
                 value:
-                  value: '304'
                   min: ''
                   max: ''
+                  value: '304'
               6:
                 title: '305 Use Proxy'
                 operator: '='
                 value:
-                  value: '305'
                   min: ''
                   max: ''
+                  value: '305'
               7:
                 title: '307 Temporary Redirect'
                 operator: '='
                 value:
-                  value: '307'
                   min: ''
                   max: ''
-          entity_type: redirect
-          entity_field: status_code
-          plugin_id: numeric
+                  value: '307'
         language:
           id: language
           table: redirect
@@ -518,6 +460,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: redirect
+          entity_field: language
+          plugin_id: language
           operator: in
           value: {  }
           group: 1
@@ -528,6 +473,8 @@ display:
             description: ''
             use_operator: false
             operator: language_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: language
             required: false
             remember: false
@@ -537,8 +484,6 @@ display:
               anonymous: '0'
               administrator: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -551,57 +496,112 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: redirect
-          entity_field: language
-          plugin_id: language
-      sorts: {  }
-      title: Redirect
-      header: {  }
-      footer: {  }
-      empty:
-        area_text_custom:
-          id: area_text_custom
-          table: views
-          field: area_text_custom
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content: 'There is no redirect yet.'
-          plugin_id: text_custom
-      relationships: {  }
-      arguments: {  }
-      display_extenders: {  }
       filter_groups:
         operator: AND
         groups:
           1: AND
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            redirect_source__path: redirect_source__path
+            redirect_redirect__uri: redirect_redirect__uri
+            status_code: status_code
+            language: language
+            created: created
+            operations: operations
+          default: created
+          info:
+            redirect_source__path:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            redirect_redirect__uri:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            status_code:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            language:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            created:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            operations:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: false
+          caption: ''
+          description: ''
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
     cache_metadata:
+      max-age: 0
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
         - url.query_args
         - user.permissions
-      cacheable: false
-      max-age: 0
       tags: {  }
+      cacheable: false
   page_1:
-    display_plugin: page
     id: page_1
     display_title: Page
+    display_plugin: page
     position: 1
     display_options:
       display_extenders: {  }
       path: admin/config/search/redirect
     cache_metadata:
+      max-age: 0
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
         - url.query_args
         - user.permissions
-      cacheable: false
-      max-age: 0
       tags: {  }
+      cacheable: false

--- a/config/views.view.site_alerts.yml
+++ b/config/views.view.site_alerts.yml
@@ -10,7 +10,7 @@ dependencies:
     - block_content
     - user
 id: site_alerts
-label: 'Site Alerts'
+label: 'Admin: Site Alerts'
 module: views
 description: 'Find and manage custom sitewide alerts.'
 tag: ''
@@ -555,19 +555,7 @@ display:
           entity_field: langcode
           plugin_id: language
           operator: in
-          value:
-            en: en
-            es: es
-            bn: bn
-            zh-hans: zh-hans
-            zh: zh
-            hi: hi
-            km: km
-            ko: ko
-            nv: nv
-            tl: tl
-            vi: vi
-            ypk: ypk
+          value: {  }
           group: 1
           exposed: true
           expose:
@@ -588,7 +576,7 @@ display:
               content_editor: '0'
               content_manager: '0'
               site_admin: '0'
-            reduce: true
+            reduce: false
           is_grouped: false
           group_info:
             label: ''

--- a/config/views.view.user_admin_people.yml
+++ b/config/views.view.user_admin_people.yml
@@ -7,7 +7,7 @@ dependencies:
 _core:
   default_config_hash: njaZigMvB4ap21Fg_tQcJhWgYJCGNi49Z5rRL_N6RI0
 id: user_admin_people
-label: People
+label: 'Admin: People'
 module: user
 description: 'Find and manage people interacting with your site.'
 tag: default

--- a/config/views.view.watchdog.yml
+++ b/config/views.view.watchdog.yml
@@ -8,7 +8,7 @@ dependencies:
 _core:
   default_config_hash: j0txIxY4nkJT_dscmXckM-1vanygDkJAeHPawZKfyH0
 id: watchdog
-label: Watchdog
+label: 'Admin: Watchdog'
 module: views
 description: 'Recent log messages'
 tag: ''


### PR DESCRIPTION
Exposed all translation options to listing pages that apply Update admin listing page titles to be explicit

## Jira ticket (required)
https://bixal-projects.atlassian.net/browse/VOTE-1115

## Description (optional)
Update admin listings for translations

## Deployment and testing (required, if applicable)
### Pre-deploy steps
1. delete block content: Accordion Group, Basic & Registration tool
2. Uninstall inline_entity_form
3. Uninstall migrate module and related migration modules

### Post-deploy steps
1. run `lando retune`

### Testing steps
1. Visit http://vote-gov.lndo.site/admin/content and make sure the translation filter has all options visible.
2. Visit http://vote-gov.lndo.site/admin/content/media and make sure the translation filter has all options visible.