### PR TITLE
VOTE-1245: migrate logo text translations

### DIFF
--- a/web/modules/custom/vote_utility/translations/bn.po
+++ b/web/modules/custom/vote_utility/translations/bn.po
@@ -16,6 +16,9 @@ msgid "Select language"
 msgstr "ভাষা নির্বাচন করুন"
 
 #main
+msgid "@sitename in language"
+msgstr "বাংলায় @sitename"
+
 msgid "Go back"
 msgstr "ফিরে যাও"
 

--- a/web/modules/custom/vote_utility/translations/es.po
+++ b/web/modules/custom/vote_utility/translations/es.po
@@ -16,6 +16,9 @@ msgid "Select language"
 msgstr "Seleccione el idioma"
 
 #main
+msgid "@sitename in language"
+msgstr "@sitename en Español"
+
 msgid "Go back"
 msgstr "Volver"
 

--- a/web/modules/custom/vote_utility/translations/hi.po
+++ b/web/modules/custom/vote_utility/translations/hi.po
@@ -16,6 +16,9 @@ msgid "Select language"
 msgstr "भाषा चुनें"
 
 #main
+msgid "@sitename in language"
+msgstr "@sitename हिन्दी में"
+
 msgid "Go back"
 msgstr "वापस जाएं"
 

--- a/web/modules/custom/vote_utility/translations/km.po
+++ b/web/modules/custom/vote_utility/translations/km.po
@@ -16,6 +16,9 @@ msgid "Select language"
 msgstr "ជ្រើសរើសភាសា"
 
 #main
+msgid "@sitename in language"
+msgstr "@sitename ជាភាសាខ្មែរ"
+
 msgid "Go back"
 msgstr "ត្រឡប់ក្រោយ"
 

--- a/web/modules/custom/vote_utility/translations/ko.po
+++ b/web/modules/custom/vote_utility/translations/ko.po
@@ -16,6 +16,9 @@ msgid "Select language"
 msgstr "언어 선택"
 
 #main
+msgid "@sitename in language"
+msgstr "@sitename 한국어 "
+
 msgid "Go back"
 msgstr "이전 화면"
 

--- a/web/modules/custom/vote_utility/translations/nv.po
+++ b/web/modules/custom/vote_utility/translations/nv.po
@@ -21,6 +21,9 @@ msgid "Select language"
 msgstr "Saad choid77['88[7g77"
 
 #main
+msgid "@sitename in language"
+msgstr "@sitename Diné"
+
 msgid "Go back"
 msgstr "N1t'33'"
 

--- a/web/modules/custom/vote_utility/translations/tl.po
+++ b/web/modules/custom/vote_utility/translations/tl.po
@@ -17,6 +17,9 @@ msgid "Select language"
 msgstr "Pumili ng wika"
 
 #main
+msgid "@sitename in language"
+msgstr "@sitename sa Tagalog"
+
 msgid "Go back"
 msgstr "Bumalik"
 

--- a/web/modules/custom/vote_utility/translations/vi.po
+++ b/web/modules/custom/vote_utility/translations/vi.po
@@ -16,6 +16,9 @@ msgid "Select language"
 msgstr "Lựa chọn ngôn ngữ"
 
 #main
+msgid "@sitename in language"
+msgstr "@sitename bằng Tiếng Việt"
+
 msgid "Go back"
 msgstr "Quay lại"
 

--- a/web/modules/custom/vote_utility/translations/ypk.po
+++ b/web/modules/custom/vote_utility/translations/ypk.po
@@ -16,6 +16,9 @@ msgid "Select language"
 msgstr "Ulu nakmiighhu"
 
 #main
+msgid "@sitename in language"
+msgstr "@sitename Akuzipigestun"
+
 msgid "Go back"
 msgstr "Uteghten"
 

--- a/web/modules/custom/vote_utility/translations/zh-hans.po
+++ b/web/modules/custom/vote_utility/translations/zh-hans.po
@@ -16,6 +16,9 @@ msgid "Select language"
 msgstr "选择语言"
 
 #main
+msgid "@sitename in language"
+msgstr "@sitename 中文"
+
 msgid "Go back"
 msgstr "回去"
 

--- a/web/modules/custom/vote_utility/translations/zh.po
+++ b/web/modules/custom/vote_utility/translations/zh.po
@@ -16,6 +16,9 @@ msgid "Select language"
 msgstr "選擇語言"
 
 #main
+msgid "@sitename in language"
+msgstr "@sitename 中文"
+
 msgid "Go back"
 msgstr "上一頁"
 

--- a/web/themes/custom/vote_gov/templates/paragraph/paragraph--registration-tool.html.twig
+++ b/web/themes/custom/vote_gov/templates/paragraph/paragraph--registration-tool.html.twig
@@ -12,7 +12,7 @@
     <div class="grid-container">
       <div class="grid-row grid-gap">
         <div class="tablet:grid-col-4">
-          {% set logo_sitename = language != 'en' ? sitename ~ ' in ' ~ languagename : sitename %}
+          {% set logo_sitename = language != 'en' ? '@sitename in language' | t({ '@sitename': sitename }) | render : sitename %}
           <a class="site-logo" href="{{ '/' ~ (language != 'en' ? language) }}" aria-label="{{ logo_sitename | t }}">
             <div class="logo-text">{{ logo_sitename }}</div>
             <div id="SiteLogo">{{ source( directory ~ '/img/ballot_box-blue.svg' ) }}</div>


### PR DESCRIPTION
## Jira ticket (required)
[VOTE-1245](https://bixal-projects.atlassian.net/browse/VOTE-1246)

## Description (optional)
This migrates the translations for the site name text above the logo

## Deployment and testing (required, if applicable)
### Pre-deploy steps
1. lando retune

### Post-deploy steps
1. Check each language's logo text is translated accurately the Jira ticket number (i.e. "VOTE-123 Implement feature X").
- Automated pipeline tests have passed.
- At least one “Reviewer has been specified.