### PR TITLE
VOTE-1191 add new env var for composer install

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -7,6 +7,7 @@ default_config: &defaults
     ENV: ${CIRCLE_BRANCH}
     LD_LIBRARY_PATH: /home/vcap/app/php/lib/
     PHP_INI_SCAN_DIR: /home/vcap/app/php/etc/:/home/vcap/app/php/etc/php.ini.d/
+    COMPOSER_NO_DEV: 1
   timeout: 180
   routes:
     - route: vote-drupal-${CIRCLE_BRANCH}.apps.internal


### PR DESCRIPTION
## Jira ticket (required)
https://bixal-projects.atlassian.net/browse/VOTE-1191

## Description (optional)
We need higher level environments, PROD and STAGE, to exclude composer dev dependencies from installing.
COMPOSER_NO_DEV should equal 1 on PROD and STAGE
COMPOSER_NO_DEV should equal 0 on DEV and TEST

@casey-rapnicki-bixal  please look this over and see if I applied it correctly.