### PR TITLE
VOTE-1268/Install Crazyegg module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
         "drupal/core-composer-scaffold": "^10.0",
         "drupal/core-project-message": "^10.0",
         "drupal/core-recommended": "^10.0",
+        "drupal/crazyegg": "^1.4",
         "drupal/double_field": "^4.1",
         "drupal/entity_reference_revisions": "^1.10",
         "drupal/field_group": "^3.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1edb989ea80cb6df530bed36ac58a022",
+    "content-hash": "fa13fc5a716e1000334d5e93c2d5030c",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2068,6 +2068,58 @@
                 "source": "https://github.com/drupal/core-recommended/tree/10.0.8"
             },
             "time": "2023-04-19T16:14:25+00:00"
+        },
+        {
+            "name": "drupal/crazyegg",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/crazyegg.git",
+                "reference": "8.x-1.4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/crazyegg-8.x-1.4.zip",
+                "reference": "8.x-1.4",
+                "shasum": "05d107313cbc65f098283d1d9ec6d9967d9fd817"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9 || ^10"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.4",
+                    "datestamp": "1682505284",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "crazyegg",
+                    "homepage": "https://www.drupal.org/user/3561241"
+                },
+                {
+                    "name": "maxim.filipovich",
+                    "homepage": "https://www.drupal.org/user/3756986"
+                },
+                {
+                    "name": "shravan.crazyegg",
+                    "homepage": "https://www.drupal.org/user/3645723"
+                }
+            ],
+            "description": "The official Crazy Egg Plugin for Drupal. The easiest, free way to add your Crazy Egg tracking script to your Drupal site.",
+            "homepage": "https://drupal.org/project/crazyegg",
+            "support": {
+                "source": "https://git.drupalcode.org/project/crazyegg"
+            }
         },
         {
             "name": "drupal/ctools",

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -15,6 +15,7 @@ module:
   config: 0
   config_translation: 0
   content_moderation: 0
+  crazyegg: 0
   datetime: 0
   dblog: 0
   double_field: 0

--- a/config/crazyegg.settings.yml
+++ b/config/crazyegg.settings.yml
@@ -1,0 +1,7 @@
+_core:
+  default_config_hash: rY-kntAO67J7BAmSb7e5Cgl8J9I4uQruKmR6PFV1kXc
+crazyegg_enabled: 1
+crazyegg_account_id: ''
+crazyegg_js_scope: header
+crazyegg_paths: ''
+crazyegg_roles_excluded: {  }


### PR DESCRIPTION
## Jira ticket (required)
https://bixal-projects.atlassian.net/browse/VOTE-1268

## Description (optional)
Installed an enabled the Crazyegg Integration module

## Deployment and testing (required, if applicable)
### Pre-deploy steps
1. lando retune

### Testing steps
1. Visit http://vote-gov.lndo.site/admin/config/system/crazyegg , and confirm you can view the admin configuration for the module.
