### PR TITLE
VOTE-1072 Add js function to NVRF form download block

### DIFF
--- a/web/themes/custom/vote_gov/src/js/nvrf-pdf-download.js
+++ b/web/themes/custom/vote_gov/src/js/nvrf-pdf-download.js
@@ -1,0 +1,12 @@
+// Download function for the NVRF Registration form selector block
+(function (Drupal) {
+  Drupal.behaviors.nvrfPdfDownload = {
+    attach: function () {
+      document.getElementById('register_form_download').onsubmit = function (ev) {
+        ev.preventDefault();
+        var languageSelected = document.getElementById('js-user-selection').value;
+        window.open(languageSelected, '_blank');
+      };
+    },
+  };
+})(Drupal);

--- a/web/themes/custom/vote_gov/templates/block/block-content--registration-form-selector--full.html.twig
+++ b/web/themes/custom/vote_gov/templates/block/block-content--registration-form-selector--full.html.twig
@@ -17,11 +17,12 @@
   ]
 %}
 
+{{ attach_library('vote_gov/nvrf_pdf_download') }}
 <div{{ attributes.addClass(classes) }}>
   {{ title_prefix }}
   {{ title_suffix }}
   <div class="block-content__content">
-    <form class="state-download" method="get" id="register">
+    <form class="state-download" method="get" id="register_form_download">
       <h2>{{ content.field_heading | field_value | render | replace({"@state_name": currentnode.getTitle()}) }}</h2>
       <p>{{ content.field_description }}</p>
       <label class="usa-sr-only" for="js-user-selection">{{ content.field_default_option_label }}</label>

--- a/web/themes/custom/vote_gov/vote_gov.libraries.yml
+++ b/web/themes/custom/vote_gov/vote_gov.libraries.yml
@@ -42,3 +42,8 @@ registration_tool:
   version: VERSION
   js:
     dist/js/registration-tool.js: { minified: true }
+
+nvrf_pdf_download:
+  version: VERSION
+  js:
+    dist/js/nvrf-pdf-download.js: { minified: true }


### PR DESCRIPTION
## Jira ticket (required)
[VOTE-1072](https://bixal-projects.atlassian.net/browse/VOTE-1072)

## Description (optional)
Add JS function to NVRF form download block.

## Deployment and testing (required, if applicable)
### Post-deploy steps
1. cd in vote_gov theme and run `npm run build && lando drush cr`

### Testing steps
1. visit http://vote-gov.lndo.site/register/ar
2. test selecting a language and clicking download button
3. PDF link should open in a new tab

![Screen Shot 2023-05-17 at 10 25 52 AM](https://github.com/usagov/vote-gov-drupal/assets/19731897/a663b6da-ee8a-43b9-91e2-b116fdfaf72a)