### PR TITLE
VOTE-1476 fix homepage language selector links

### DIFF
--- a/web/themes/custom/vote_gov/php-includes/preprocess.inc
+++ b/web/themes/custom/vote_gov/php-includes/preprocess.inc
@@ -30,6 +30,9 @@ function vote_gov_preprocess(&$variables) {
   if (!empty($node)) {
     $variables['currentnode'] = $node;
   }
+
+  // Set variable for frontpage
+  $variables['is_frontpage'] = \Drupal::service('path.matcher')->isFrontPage();
 }
 
 /**

--- a/web/themes/custom/vote_gov/php-includes/preprocess.inc
+++ b/web/themes/custom/vote_gov/php-includes/preprocess.inc
@@ -31,7 +31,7 @@ function vote_gov_preprocess(&$variables) {
     $variables['currentnode'] = $node;
   }
 
-  // Set variable for frontpage
+  // Set variable for frontpage.
   $variables['is_frontpage'] = \Drupal::service('path.matcher')->isFrontPage();
 }
 

--- a/web/themes/custom/vote_gov/templates/navigation/links--language-block.html.twig
+++ b/web/themes/custom/vote_gov/templates/navigation/links--language-block.html.twig
@@ -31,22 +31,29 @@
  * @see template_preprocess_links()
  */
 #}
- {% if links -%}
+{% if links -%}
   {% if links|length == 2 %}
-    {% for key, item in links %}  
+    {% for key, item in links %}
       {%- if item.link -%}
         {% if language != key %}
           <div class='usa-button'>
-              {{ item.link|merge({'#attributes': {'lang': key, 'xml:lang': key} }) }}    
+            {{ item.link|merge({'#attributes': {'lang': key, 'xml:lang': key} }) }}
           </div>
         {% endif %}
       {%- endif -%}
     {% endfor %}
   {% elseif links|length > 2 %}
     {%- for key, item in links -%}
-      <li class="usa-language__submenu-item" {{ item.attributes.removeAttribute('hreflang') }} data-lang="lang-{{ key }}">
+      <li class="usa-language__submenu-item" {{ item.attributes.removeAttribute('hreflang') }}
+          data-lang="lang-{{ key }}">
         {%- if item.link -%}
-          {{ item.link|merge({'#attributes': {'lang': key, 'xml:lang': key}}) }}    
+          {# Create a custom override for the frontpage links. #}
+          {%- if is_frontpage -%}
+            <a href="/{{ key != 'en' ? key }}" class="language-link" lang="{{ key }}" xml:lang="{{ key }}"
+               hreflang="{{ key }}" data-drupal-link-system-path="{{ path('<current>') }}">{{ item.link['#title'] }}</a>
+          {%- else -%}
+            {{ item.link|merge({'#attributes': {'lang': key, 'xml:lang': key}}) }}
+          {%- endif -%}
         {%- endif -%}
       </li>
     {%- endfor -%}


### PR DESCRIPTION
## Jira ticket (required)
https://bixal-projects.atlassian.net/browse/VOTE-1476

## Description (optional)
Current language selector on the homepage produces links like this.
English: /votegov-homepage
Spanish: /es/votegov-homepage

We do not want a redirects to correct paths so we need to update them to be
English: /
Spanish: /es

## Deployment and testing (required, if applicable)
### Post-deploy steps
1. `lando drush cr`

### Testing steps
1. visit http://vote-gov.lndo.site/
2. check the links in the language selector to make sure they do not contain "votegov-homepage"
3. make sure the links work