### PR TITLE
VOTE-1518: Fix pipeline for prod deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,7 +273,6 @@ workflows:
                 - dev
                 - stage
                 - test
-                - prod
       - deploy-test:
           filters:
             branches:


### PR DESCRIPTION
## Jira ticket (required)
[VOTE-1518](https://bixal-projects.atlassian.net/browse/VOTE-1518)

## Description (optional)
`build-theme` doesn't need to run on prod. It has it's own workflow.