### PR TITLE
VOTE-1454 -> update config to allow email link to be translated 

### DIFF
--- a/config/field.field.block_content.email_signup.field_link.yml
+++ b/config/field.field.block_content.email_signup.field_link.yml
@@ -14,7 +14,7 @@ bundle: email_signup
 label: 'Subscribe email link'
 description: ''
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:


### PR DESCRIPTION
**_Delete all details that do not apply to this PR!_**

## Jira ticket (required)
[Vote-1454](https://bixal-projects.atlassian.net/jira/software/c/projects/VOTE/boards/254?modal=detail&selectedIssue=VOTE-1454&assignee=611272e0eb7aef00694b8a97)

## Description (optional)
This Pr will update the config file to allow the email subscribe link to be translatable.
## Deployment and testing (required, if applicable)

### Post Deploy 
1. import new config db 
2. update the email subscribe link on home page to have all translations to be English link and Spanish translations has Spanish link [English Link](https://connect.usa.gov/subscribe) and [Spanish Link](https://conectate.gobiernousa.gov/suscripciones)

### Testing steps
1. Very within file that `translatable` is now set to `true`
2. visit the home page and check that the email sign-up button is taking the user to the correct page (the expected result is every translation goes to English and Spanish translations go to Spanish page)

<!-- Pull Request Checklist (Reference only)

Please ensure you have addressed all concerns below before marking this PR "ready for review".

- No merge conflicts exist with the target branch.
- branch name follows the branch naming conventions **feature/VOTE-###-add-short-description** matching the Jira ticket number.
- Primary commit message is of the format **VOTE-### Add short description of the task** matching the Jira ticket number.
- PR title either matches primary commit message or is of the format **VOTE-### Add short description of the task** matching the Jira ticket number (i.e. "VOTE-123 Implement feature X").
- Automated pipeline tests have passed.
- At least one “Reviewer has been specified.

-->
