### PR TITLE
VOTE-1480 Install and enable Translatable menu link uri module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,6 +67,7 @@
         "drupal/simple_sitemap": "^4.1",
         "drupal/stable": "^2.0",
         "drupal/tome": "^1.8",
+        "drupal/translatable_menu_link_uri": "^2.0@dev",
         "drupal/twig_field_value": "^2.0",
         "drupal/twig_tweak": "^3.2",
         "drush/drush": "^11.3"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7f4402352395b8dcb5a6ea6b584a8a67",
+    "content-hash": "85ce2f29d6cbcf189c4c1b21c6dc56e5",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3667,6 +3667,51 @@
             "homepage": "https://www.drupal.org/project/tome",
             "support": {
                 "source": "https://git.drupalcode.org/project/tome"
+            }
+        },
+        {
+            "name": "drupal/translatable_menu_link_uri",
+            "version": "dev-2.x",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/translatable_menu_link_uri.git",
+                "reference": "822d97123531cb3bfa5de75f18ec220f08d5d3bb"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9 || ^10"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                },
+                "drupal": {
+                    "version": "2.x-dev",
+                    "datestamp": "1675005734",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Dev releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "jsobiecki",
+                    "homepage": "https://www.drupal.org/user/112744"
+                },
+                {
+                    "name": "wiktorb",
+                    "homepage": "https://www.drupal.org/user/762836"
+                }
+            ],
+            "description": "This module enables support for translation of link field in menu_link_content entity.",
+            "homepage": "https://www.drupal.org/project/translatable_menu_link_uri",
+            "support": {
+                "source": "https://git.drupalcode.org/project/translatable_menu_link_uri"
             }
         },
         {
@@ -12574,6 +12619,7 @@
     "minimum-stability": "dev",
     "stability-flags": {
         "drupal-tome/tome_drush": 20,
+        "drupal/disable_language": 10,
         "drupal/log_stdout": 20,
         "drupal/node_revision_delete": 5,
         "drupal/pathauto": 20,

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -61,6 +61,7 @@ module:
   tome_base: 0
   tome_static: 0
   toolbar: 0
+  translatable_menu_link_uri: 0
   twig_field_value: 0
   twig_tweak: 0
   update: 0


### PR DESCRIPTION
## Jira ticket (required)
https://bixal-projects.atlassian.net/browse/VOTE-1480

## Description (optional)
Install module to allow for translatable links for menus.

## Deployment and testing (required, if applicable)
### Post-deploy steps
1. run `lando retune`

### Testing steps
1. Visit http://vote-gov.lndo.site/es and click on Privacy Policy link it should go to an english policy page
2. Visit http://vote-gov.lndo.site/es/admin/structure/menu/item/12/edit and add "Translatable External Link Override" value https://www.usa.gov/es/politicas-privacidad and save
3. Visit http://vote-gov.lndo.site/es and click on Privacy Policy link it should now go to the spanish policy page

**NOTE**: After installing the module there was a warning message of a deprecated function. This is related to a core issue as noted in the ticket.