### PR TITLE
VOTE-1409 tracking tool updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,6 @@
         "drupal/core-composer-scaffold": "^10.0",
         "drupal/core-project-message": "^10.0",
         "drupal/core-recommended": "^10.0",
-        "drupal/crazyegg": "^1.4",
         "drupal/disable_language": "^1.0@beta",
         "drupal/double_field": "^4.1",
         "drupal/entity_reference_revisions": "^1.10",

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,6 @@
         "drupal/entity_reference_revisions": "^1.10",
         "drupal/field_group": "^3.4",
         "drupal/file_delete": "^2.0",
-        "drupal/google_tag": "^2.0",
         "drupal/language_switcher_extended": "^1.1",
         "drupal/log_stdout": "dev-3339853-drupal-10-compatibility",
         "drupal/metatag": "^1.22",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e0bfafaf14533d1092e096aa590deb27",
+    "content-hash": "6fad375e62b9ceda63aeb56286b6899e",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2068,58 +2068,6 @@
                 "source": "https://github.com/drupal/core-recommended/tree/10.0.8"
             },
             "time": "2023-04-19T16:14:25+00:00"
-        },
-        {
-            "name": "drupal/crazyegg",
-            "version": "1.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/project/crazyegg.git",
-                "reference": "8.x-1.4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/crazyegg-8.x-1.4.zip",
-                "reference": "8.x-1.4",
-                "shasum": "05d107313cbc65f098283d1d9ec6d9967d9fd817"
-            },
-            "require": {
-                "drupal/core": "^8 || ^9 || ^10"
-            },
-            "type": "drupal-module",
-            "extra": {
-                "drupal": {
-                    "version": "8.x-1.4",
-                    "datestamp": "1682505284",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "crazyegg",
-                    "homepage": "https://www.drupal.org/user/3561241"
-                },
-                {
-                    "name": "maxim.filipovich",
-                    "homepage": "https://www.drupal.org/user/3756986"
-                },
-                {
-                    "name": "shravan.crazyegg",
-                    "homepage": "https://www.drupal.org/user/3645723"
-                }
-            ],
-            "description": "The official Crazy Egg Plugin for Drupal. The easiest, free way to add your Crazy Egg tracking script to your Drupal site.",
-            "homepage": "https://drupal.org/project/crazyegg",
-            "support": {
-                "source": "https://git.drupalcode.org/project/crazyegg"
-            }
         },
         {
             "name": "drupal/ctools",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7f4402352395b8dcb5a6ea6b584a8a67",
+    "content-hash": "e0bfafaf14533d1092e096aa590deb27",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2508,79 +2508,6 @@
             "support": {
                 "source": "http://cgit.drupalcode.org/file_delete",
                 "issues": "https://www.drupal.org/project/issues/file_delete"
-            }
-        },
-        {
-            "name": "drupal/google_tag",
-            "version": "2.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/project/google_tag.git",
-                "reference": "2.0.1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/google_tag-2.0.1.zip",
-                "reference": "2.0.1",
-                "shasum": "708da7b70c0b8023feea6855fd4a4f4bc03e911f"
-            },
-            "require": {
-                "drupal/core": "^9.5 || ^10",
-                "php": "^7.4 || ^8"
-            },
-            "require-dev": {
-                "drupal/commerce": "^2.0",
-                "drupal/commerce_wishlist": "^3.0@beta",
-                "drupal/csp": "^1.0",
-                "drupal/google_analytics": "^4.0",
-                "drupal/search_api": "^1.28.0",
-                "drupal/token": "^1.11.0",
-                "drupal/webform": "^6.0"
-            },
-            "type": "drupal-module",
-            "extra": {
-                "drupal": {
-                    "version": "2.0.1",
-                    "datestamp": "1682446186",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
-                },
-                "branch-alias": {
-                    "dev-main": "2.x-dev"
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "acquia",
-                    "homepage": "https://www.drupal.org/user/1231722"
-                },
-                {
-                    "name": "japerry",
-                    "homepage": "https://www.drupal.org/user/45640"
-                },
-                {
-                    "name": "kaynen",
-                    "homepage": "https://www.drupal.org/user/733308"
-                },
-                {
-                    "name": "mglaman",
-                    "homepage": "https://www.drupal.org/user/2416470"
-                },
-                {
-                    "name": "solotandem",
-                    "homepage": "https://www.drupal.org/user/240748"
-                }
-            ],
-            "description": "Sets up Google Tag",
-            "homepage": "https://www.drupal.org/project/google_tag",
-            "support": {
-                "source": "https://git.drupalcode.org/project/google_tag"
             }
         },
         {
@@ -12574,6 +12501,7 @@
     "minimum-stability": "dev",
     "stability-flags": {
         "drupal-tome/tome_drush": 20,
+        "drupal/disable_language": 10,
         "drupal/log_stdout": 20,
         "drupal/node_revision_delete": 5,
         "drupal/pathauto": 20,

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -29,7 +29,6 @@ module:
   file: 0
   file_delete: 0
   filter: 0
-  google_tag: 0
   image: 0
   language: 0
   language_switcher_extended: 0

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -15,7 +15,6 @@ module:
   config: 0
   config_translation: 0
   content_moderation: 0
-  crazyegg: 0
   datetime: 0
   dblog: 0
   disable_language: 0

--- a/config/crazyegg.settings.yml
+++ b/config/crazyegg.settings.yml
@@ -1,7 +1,0 @@
-_core:
-  default_config_hash: rY-kntAO67J7BAmSb7e5Cgl8J9I4uQruKmR6PFV1kXc
-crazyegg_enabled: 1
-crazyegg_account_id: ''
-crazyegg_js_scope: header
-crazyegg_paths: ''
-crazyegg_roles_excluded: {  }

--- a/config/google_tag.settings.yml
+++ b/config/google_tag.settings.yml
@@ -1,4 +1,0 @@
-_core:
-  default_config_hash: cvh7di-mJogXOBiv_AoDN22DXIg3-OtzE5iLCIFAQ1s
-use_collection: false
-default_google_tag_entity: ''

--- a/web/themes/custom/vote_gov/templates/layout/html.html.twig
+++ b/web/themes/custom/vote_gov/templates/layout/html.html.twig
@@ -42,6 +42,7 @@
     <title>{{ head_title|safe_join(' | ') }}</title>
     <css-placeholder token="{{ placeholder_token }}">
       <js-placeholder token="{{ placeholder_token }}">
+        {% if not logged_in %}
         <!-- Google Tag Manager -->
         <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
               new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -49,13 +50,16 @@
             'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
           })(window,document,'script','dataLayer','GTM-TDRBDKS');</script>
         <!-- End Google Tag Manager -->
+        {% endif %}
 </head>
 
 <body{{ attributes.addClass(body_classes) }}>
+{% if not logged_in %}
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TDRBDKS"
                   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
+{% endif %}
 {#
 Keyboard navigation/accessibility link to main content section in
 page.html.twig.

--- a/web/themes/custom/vote_gov/templates/layout/html.html.twig
+++ b/web/themes/custom/vote_gov/templates/layout/html.html.twig
@@ -42,9 +42,20 @@
     <title>{{ head_title|safe_join(' | ') }}</title>
     <css-placeholder token="{{ placeholder_token }}">
       <js-placeholder token="{{ placeholder_token }}">
+        <!-- Google Tag Manager -->
+        <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+              new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+            j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+            'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+          })(window,document,'script','dataLayer','GTM-TDRBDKS');</script>
+        <!-- End Google Tag Manager -->
 </head>
 
 <body{{ attributes.addClass(body_classes) }}>
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TDRBDKS"
+                  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
 {#
 Keyboard navigation/accessibility link to main content section in
 page.html.twig.


### PR DESCRIPTION
## Jira ticket (required)
https://bixal-projects.atlassian.net/browse/VOTE-1409

## Description (optional)
This removes 2 modules from the codebase: Google Tag and crazyegg. After doing testing and research Google Tag module would be harder to maintain than the hardcoded value. Additionally, google tag can implement crazy egg remotely without the need for a module so we are removing crazyegg module from the codebase. Finally we are hardcoding in GTM code for logged out users.

## Deployment and testing (required, if applicable)
### Post-deploy steps
1. run `lando retune`

### Testing steps
1. VIsit http://vote-gov.lndo.site/ open the inspector and look at the sources tab to confirm googletagmanager.com is there.
![Screen Shot 2023-05-31 at 3 02 18 PM](https://github.com/usagov/vote-gov-drupal/assets/19731897/e80d2482-2205-4f6a-9e24-23c9343fa5ce)