### PR TITLE
VOTE-1424 Incorrect Korean translation of "not needed" text on North Dakota page

### DIFF
--- a/web/modules/custom/vote_utility/translations/ko.po
+++ b/web/modules/custom/vote_utility/translations/ko.po
@@ -120,7 +120,7 @@ msgid "Learn more about voting"
 msgstr "투표에 대해 자세히 알아보기 (영어로 제공)"
 
 msgid "Voter registration is not required in @state_name. @link on @state_name’s election website."
-msgstr "버지니아 주에서는 유권자 등록이 필요하지 않습니다.  @state_name 선거국 웹사이트에서 @link를 이용하시기 바랍니다."
+msgstr "@state_name 는 유권자 등록이 필요하지 않습니다. @state_name 선거국 웹사이트에서 @link를 이용하시기 바랍니다."
 
 msgid "Start your online registration"
 msgstr "온라인 등록 시작하기 (영어로 제공)"


### PR DESCRIPTION
## Jira ticket (required)
[Insert Jira ticket link](https://bixal-projects.atlassian.net/browse/VOTE-1424)

## Description (optional)
The string 'Virginia' has been replaced with the state name variable.

## Deployment and testing (required, if applicable)
### Pre-deploy steps
1. lando retune
2. lando import-translations

### Testing steps
1. Go to http://vote-gov.lndo.site/ko/register/nd
2. Verify the not needed string is pulling in the state name North Dakota
3. Using Google translate, verify the string 'Virginia' in Korean characters is no longer in the string.

<!-- Pull Request Checklist (Reference only)

Please ensure you have addressed all concerns below before marking this PR "ready for review".

- No merge conflicts exist with the target branch.
- branch name follows the branch naming conventions **feature/VOTE-###-add-short-description** matching the Jira ticket number.
- Primary commit message is of the format **VOTE-### Add short description of the task** matching the Jira ticket number.
- PR title either matches primary commit message or is of the format **VOTE-### Add short description of the task** matching the Jira ticket number (i.e. "VOTE-123 Implement feature X").
- Automated pipeline tests have passed.
- At least one “Reviewer has been specified.

-->
