### PR TITLE
VOTE-1555 Language switcher mobile label bug

### DIFF
--- a/web/themes/custom/vote_gov/php-includes/preprocess.inc
+++ b/web/themes/custom/vote_gov/php-includes/preprocess.inc
@@ -49,9 +49,11 @@ function vote_gov_preprocess(&$variables) {
 function vote_gov_preprocess_links__language_block(&$variables) {
 
   // Send the untranslated english language names to the template.
+  $original_language = \Drupal::languageManager()->getConfigOverrideLanguage();
   $en = \Drupal::languageManager()->getLanguage('en');
-  $languages = \Drupal::languageManager()->getLanguages();
   \Drupal::languageManager()->setConfigOverrideLanguage($en);
+  $languages = \Drupal::languageManager()->getLanguages();
+  \Drupal::languageManager()->setConfigOverrideLanguage($original_language);
 
   foreach ($variables['links'] as $i => $link) {
     // Append the english language name after the translated one


### PR DESCRIPTION
## Jira ticket (required)
[Insert Jira ticket link
](https://bixal-projects.atlassian.net/browse/VOTE-1555)

## Description (optional)
Fix a bug in preprocess.inc that resulted in the English language names not printing in the switcher.

## Deployment and testing (required, if applicable)
### Pre-deploy steps
1. lando retune

### Testing steps
1. View the language switcher in desktop.
2. Verify all labels follow the format [native name (English name)] if the names are different.
3. Switch languages a few times, verifying the labels stay the same.
4. Repeat for mobile.

<!-- Pull Request Checklist (Reference only)

Please ensure you have addressed all concerns below before marking this PR "ready for review".

- No merge conflicts exist with the target branch.
- branch name follows the branch naming conventions **feature/VOTE-###-add-short-description** matching the Jira ticket number.
- Primary commit message is of the format **VOTE-### Add short description of the task** matching the Jira ticket number.
- PR title either matches primary commit message or is of the format **VOTE-### Add short description of the task** matching the Jira ticket number (i.e. "VOTE-123 Implement feature X").
- Automated pipeline tests have passed.
- At least one “Reviewer has been specified.

-->
