### PR TITLE
VOTE-1489 initialize Portuguese translation

### DIFF
--- a/config/language.entity.hi.yml
+++ b/config/language.entity.hi.yml
@@ -5,5 +5,5 @@ dependencies: {  }
 id: hi
 label: Hindi
 direction: ltr
-weight: -5
+weight: -4
 locked: false

--- a/config/language.entity.ht.yml
+++ b/config/language.entity.ht.yml
@@ -11,5 +11,5 @@ third_party_settings:
 id: ht
 label: 'Haitian Creole'
 direction: ltr
-weight: 3
+weight: -5
 locked: false

--- a/config/language.entity.km.yml
+++ b/config/language.entity.km.yml
@@ -5,5 +5,5 @@ dependencies: {  }
 id: km
 label: Khmer
 direction: ltr
-weight: -4
+weight: -3
 locked: false

--- a/config/language.entity.ko.yml
+++ b/config/language.entity.ko.yml
@@ -5,5 +5,5 @@ dependencies: {  }
 id: ko
 label: Korean
 direction: ltr
-weight: -3
+weight: -2
 locked: false

--- a/config/language.entity.nv.yml
+++ b/config/language.entity.nv.yml
@@ -11,5 +11,5 @@ third_party_settings:
 id: nv
 label: Navajo
 direction: ltr
-weight: -2
+weight: -1
 locked: false

--- a/config/language.entity.pt.yml
+++ b/config/language.entity.pt.yml
@@ -1,5 +1,5 @@
-uuid: 3d488e76-7cdd-4cbf-bd4c-21027dab973d
-langcode: en
+uuid: 1e6d0861-4abc-403a-bf58-09b3bafa6226
+langcode: pt
 status: true
 dependencies:
   module:
@@ -8,8 +8,8 @@ third_party_settings:
   disable_language:
     disable: true
     redirect_language: en
-id: ru
-label: Russian
+id: pt
+label: Portuguese
 direction: ltr
-weight: 1
+weight: 0
 locked: false

--- a/config/language.entity.tl.yml
+++ b/config/language.entity.tl.yml
@@ -5,5 +5,5 @@ dependencies: {  }
 id: tl
 label: Tagalog
 direction: ltr
-weight: -1
+weight: 2
 locked: false

--- a/config/language.entity.vi.yml
+++ b/config/language.entity.vi.yml
@@ -5,5 +5,5 @@ dependencies: {  }
 id: vi
 label: Vietnamese
 direction: ltr
-weight: 0
+weight: 3
 locked: false

--- a/config/language.entity.ypk.yml
+++ b/config/language.entity.ypk.yml
@@ -5,5 +5,5 @@ dependencies: {  }
 id: ypk
 label: Yupʼik-Akuzipik
 direction: ltr
-weight: 1
+weight: 4
 locked: false

--- a/config/language.negotiation.yml
+++ b/config/language.negotiation.yml
@@ -20,6 +20,7 @@ url:
     '': null
     ru: ru
     ht: ht
+    pt: pt
   domains:
     en: ''
     es: ''
@@ -35,4 +36,5 @@ url:
     ypk: ''
     ru: ''
     ht: ''
+    pt: ''
 selected_langcode: site_default

--- a/config/language/pt/core.date_format.revision_date.yml
+++ b/config/language/pt/core.date_format.revision_date.yml
@@ -1,0 +1,1 @@
+pattern: 'd \d\e F \d\e Y'

--- a/config/language/pt/metatag.metatag_defaults.front.yml
+++ b/config/language/pt/metatag.metatag_defaults.front.yml
@@ -1,0 +1,3 @@
+tags:
+  description: 'Encontre as opções de registro de eleitores no seu estado.'
+  title: 'Registro de Eleitores | [site:name]'

--- a/config/language/pt/metatag.metatag_defaults.global.yml
+++ b/config/language/pt/metatag.metatag_defaults.global.yml
@@ -1,0 +1,3 @@
+tags:
+  description: 'Encontre as opções de registro de eleitores no seu estado.'
+  title: 'Registro de Eleitores | [site:name]'

--- a/config/language/pt/metatag.metatag_defaults.node__landing.yml
+++ b/config/language/pt/metatag.metatag_defaults.node__landing.yml
@@ -1,0 +1,3 @@
+tags:
+  description: 'Encontre as opções de registro de eleitores no seu estado.'
+  title: 'Registro de Eleitores | [site:name]'

--- a/config/language/pt/metatag.metatag_defaults.node__state_territory.yml
+++ b/config/language/pt/metatag.metatag_defaults.node__state_territory.yml
@@ -1,0 +1,3 @@
+tags:
+  description: 'Encontre como puder registrar-se para votar em [current-page:title]'
+  title: 'Registro de Eleitores em [current-page:title] | [site:name]'

--- a/web/modules/custom/vote_utility/translations/pt.po
+++ b/web/modules/custom/vote_utility/translations/pt.po
@@ -1,0 +1,292 @@
+# Portuguese translation of Vote.gov
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Vote.gov Utility\\n"
+"MIME-Version: 1.0\\n"
+"Content-Type: text/plain; charset=utf-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\\n"
+
+# config.languages.languageName
+msgid "Portuguese"
+msgstr "Português"
+
+# config.languages.params.select_language
+msgid "Select language"
+msgstr "Selecionar a língua"
+
+# config.languages.params.Owner
+msgid "@sitename in language"
+msgstr "@sitename em Português"
+
+# config.languages.params.go_back
+msgid "Go back"
+msgstr "Voltar"
+
+# config.languages.params.last_updated
+msgid "Last updated:"
+msgstr "Última Atualização:"
+
+# config.languages.params.ext_link_title
+msgid "External link opens in new window"
+msgstr "Links externos abrem novas páginas web"
+
+# config.languages.params.skip_text
+msgid "Skip to main content"
+msgstr "Saltar para o conteúdo principal"
+
+# config.languages.params.english_only
+msgid "(in English)"
+msgstr "(em inglês)"
+
+# data.translations.footer.vote_logo_alt_text (see accessibility updates)
+msgid "Illustration of voter box with checked ballot being inserted to indicate voting action"
+msgstr "Ilustração da caixa do eleitor com voto marcado ao ser inserido para indicar ação de votação"
+
+# data.translations.footer.identifier_gsa_txt
+msgid "An official website of the @link."
+msgstr "Uma página web oficial da @link"
+
+# data.translations.footer.identifier_gsa_txt__1
+msgid "General Services Administration"
+msgstr "Administração dos Serviços Gerais"
+
+# data.translations.footer.identifier_more_info
+msgid "Looking for U.S. government information and services? @link."
+msgstr "Você procura informação e serviços do governo dos EUA? @link"
+
+# data.translations.footer.identifier_more_info__1
+msgid "Visit USA.gov"
+msgstr "Visite USA.gov (em inglês)"
+
+# data.translations.footer.identifier_aria
+msgid "Agency identifier"
+msgstr "Identificador da agência"
+
+# data.translations.footer.identifier_gsa_txt_aria
+msgid "Agency description"
+msgstr "Descrição da agência"
+
+# data.translations.footer.identifier_link_aria
+msgid "Important links"
+msgstr "Links importantes"
+
+# data.translations.footer.identifier_more_info_aria
+msgid "Government information and services"
+msgstr "Informação e serviços do governo"
+
+# data.translations.footer.eac_text
+msgid "in partnership with"
+msgstr "em parceria com"
+
+# data.translations.footer.eac_logo_alt_text (see accessibility updates)
+msgid "U.S. Election Assistance Commission logo which indicates a partnership with Vote.gov"
+msgstr "Logomarca da Comissão de Assistência das Eleições dos EUA que indica uma parceria com Vote.gov"
+
+# data.translations.footer.twitter_text
+msgid "Follow Vote.gov on Twitter"
+msgstr "Siga Vote.gov no Twitter (em inglês)"
+
+# data.translations.footer.section_sign_up
+msgid "Email sign-up"
+msgstr "Inscrição por e-mail"
+
+# data.translations.footer.section_contact
+msgid "Contact"
+msgstr "Contato"
+
+# data.translations.footer.gsa_logo_alt
+msgid "GSA logo"
+msgstr "Logotipo do GSA"
+
+# data.translations.homepage.search_placeholder
+msgid "Search Vote.gov"
+msgstr "Pesquisar Vote.gov"
+
+# data.translations.homepage.section_banner
+msgid "Official government website"
+msgstr "Página web oficial do governo"
+
+# data.translations.register.heading
+msgid "Register to vote in @state_name"
+msgstr "Registrar-se para votar em @state_name"
+
+# data.translations.register.heading2
+msgid "How to register to vote in @state_name"
+msgstr "Como registrar-se para votar"
+
+# data.translations.register.other_language_selection__heading
+msgid "Other ways to register to vote in @state_name"
+msgstr "Outras maneiras de registrar-se para votar"
+
+# data.translations.register.dates__bymail_deadline
+msgid "Register by mail deadline:"
+msgstr "Prazo final para registrar-se por correspondência:"
+
+# data.translations.register.dates__byonline_deadline
+msgid "Online registration deadline:"
+msgstr "Prazo final para registrar-se on-line:"
+
+# data.translations.register.dates__inperson_deadline
+msgid "In person registration deadline:"
+msgstr "Prazo final de registro em pessoa:"
+
+# data.translations.register.dates__heading
+msgid "Voter registration deadlines in @state_name"
+msgstr "Os prazos de registro de eleitores"
+
+# data.translations.register.confirm_registration__heading
+msgid "How to check your voter registration"
+msgstr "Como você pode verificar seu registro de eleitor"
+
+# data.translations.register.confirm_registration__intro_WY
+msgid "You can confirm your voter registration status by contacting your local registration office. @link."
+msgstr "Você pode confirmar seu status de registro de eleitor entrando em contato com o cartório de registro local. @link."
+
+# @link: data.translations.register.confirm_registration__link_WY
+msgid "Click here to view Wyoming's county clerk contact information (PDF)"
+msgstr "Clique aqui para ver as informações de contato do secretário do condado de Wyoming (PDF)"
+
+# data.translations.register.confirm_registration__intro (see accessibility updates)
+msgid "You can @link on @state_name’s election website."
+msgstr "Também pode @link na página web de eleição estadual do @state_name"
+
+# @link: data.translations.register.confirm_registration__intro (see accessibility updates)
+msgid "confirm your voter registration status"
+msgstr "confirmar o status do seu registro de eleitor"
+
+# data.translations.register.by_mail__intro (see accessibility updates)
+msgid "Online registration is currently not available. @link to vote at @state_name’s election website."
+msgstr "O registro on-line não está disponível no momento. @link para votar na página web de eleição estadual do @state_name."
+
+# @link: data.translations.register.by_mail__intro (see accessibility updates)
+msgid "Find out ways to register"
+msgstr "Descubra maneiras de registrar-se"
+
+# data.translations.register.in_person__intro (see accessibility updates)
+msgid "Register in person at your local election office. @link on @state_name’s election website."
+msgstr "Registre-se em pessoa no seu escritório de eleições local. @link na página web de eleição estadual do @state_name."
+
+# @link: data.translations.register.in_person__intro (see accessibility updates)
+msgid "Learn more about how to register"
+msgstr "Aprenda mais sobre como registrar-se"
+
+# data.translations.register.not_needed__intro (see accessibility updates)
+msgid "Voter registration is not required in @state_name. @link on @state_name’s election website."
+msgstr "O registro de eleitores não é mandatório em @state_name. @link na página web de eleição estadual de @state_name."
+
+# @link: data.translations.register.not_needed__intro (see accessibility updates)
+msgid "Learn more about voting"
+msgstr "Aprenda mais sobre a votação"
+
+# data.translations.register.online__answer1 (see accessibility updates)
+msgid "@link on @state_name’s election website."
+msgstr "@link na página web de eleição estadual do @state_name"
+
+# @link: data.translations.register.online__answer1 (see accessibility updates)
+msgid "Start your online registration"
+msgstr "Comece o seu registro on-line"
+
+# data.translations.register.online__answer2 (see accessibility updates)
+msgid "You can also @link on @state_name’s election website."
+msgstr "Também pode @link na página web de eleição estadual do @state_name"
+
+# @link: data.translations.register.online__answer2 (see accessibility updates)
+msgid "register to vote by mail or in person"
+msgstr "registrar-se para votar por correspondência ou em pessoa"
+
+# data.translations.months.january
+msgctxt "Long month name"
+msgid "January"
+msgstr "janeiro"
+
+# data.translations.months.february
+msgctxt "Long month name"
+msgid "February"
+msgstr "fevereiro"
+
+# data.translations.months.march
+msgctxt "Long month name"
+msgid "March"
+msgstr "março"
+
+# data.translations.months.april
+msgctxt "Long month name"
+msgid "April"
+msgstr "abril"
+
+# data.translations.months.may
+msgctxt "Long month name"
+msgid "May"
+msgstr "maio"
+
+# data.translations.months.june
+msgctxt "Long month name"
+msgid "June"
+msgstr "junho"
+
+# data.translations.months.july
+msgctxt "Long month name"
+msgid "July"
+msgstr "julho"
+
+# data.translations.months.august
+msgctxt "Long month name"
+msgid "August"
+msgstr "agosto"
+
+# data.translations.months.september
+msgctxt "Long month name"
+msgid "September"
+msgstr "setembro"
+
+# data.translations.months.october
+msgctxt "Long month name"
+msgid "October"
+msgstr "outubro"
+
+# data.translations.months.november
+msgctxt "Long month name"
+msgid "November"
+msgstr "novembro"
+
+# data.translations.months.december
+msgctxt "Long month name"
+msgid "December"
+msgstr "dezembro"
+
+# data.translations.days.sunday
+msgctxt "day name"
+msgid "Sunday"
+msgstr "domingo"
+
+# data.translations.days.monday
+msgctxt "day name"
+msgid "Monday"
+msgstr "segunda-feira"
+
+# data.translations.days.tuesday
+msgctxt "day name"
+msgid "Tuesday"
+msgstr "terça-feira"
+
+# data.translations.days.wednesday
+msgctxt "day name"
+msgid "Wednesday"
+msgstr "quarta-feira"
+
+# data.translations.days.thursday
+msgctxt "day name"
+msgid "Thursday"
+msgstr "quinta-feira"
+
+# data.translations.days.friday
+msgctxt "day name"
+msgid "Friday"
+msgstr "sexta-feira"
+
+# data.translations.days.saturday
+msgctxt "day name"
+msgid "Saturday"
+msgstr "sábado"


### PR DESCRIPTION
## Jira ticket (required)
https://bixal-projects.atlassian.net/browse/VOTE-1489

## Description (optional)

- Config/code:
  - Create new language in Drupal and disable
  - String translations
  - Date format
  - Metatags

## Deployment and testing (required, if applicable)
### Post-deploy steps
1. `lando retune`

### Testing steps
1. Visit http://vote-gov.lndo.site/admin/config/regional/language and confirm Portuguese is created and disabled
2. Visit http://vote-gov.lndo.site/admin/config/regional/translate and confirm Portuguese content interface translations exist
3. Visit http://vote-gov.lndo.site/admin/config/regional/date-time/formats/manage/revision_date/translate/pt/edit and confirm the Portuguese date format