### PR TITLE
VOTE-764: Disable and remove auto_entitylabel module. We may need to …

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,6 @@
         "drupal-tome/tome_drush": "dev-master",
         "drupal/admin_toolbar": "^3.3",
         "drupal/allowed_formats": "^2.0",
-        "drupal/auto_entitylabel": "^3.0",
         "drupal/autologout": "^1.4",
         "drupal/block_content_permissions": "^1.11",
         "drupal/block_content_template": "^1.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d5493781bd037a812e5b6f32c07f2768",
+    "content-hash": "e17390730cfd2a42ec5c7c81be796a38",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1462,82 +1462,6 @@
             "support": {
                 "source": "http://cgit.drupalcode.org/allowed_formats",
                 "issues": "https://www.drupal.org/project/issues/allowed_formats"
-            }
-        },
-        {
-            "name": "drupal/auto_entitylabel",
-            "version": "3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/project/auto_entitylabel.git",
-                "reference": "8.x-3.0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/auto_entitylabel-8.x-3.0.zip",
-                "reference": "8.x-3.0",
-                "shasum": "8dd54d4b677f2c7259a15afd7b71d0d1b6f6b4a6"
-            },
-            "require": {
-                "drupal/core": "^9.3 || ^10"
-            },
-            "require-dev": {
-                "drupal/token": "^1.0"
-            },
-            "type": "drupal-module",
-            "extra": {
-                "drupal": {
-                    "version": "8.x-3.0",
-                    "datestamp": "1671545557",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "bforchhammer",
-                    "homepage": "https://www.drupal.org/user/216396"
-                },
-                {
-                    "name": "colan",
-                    "homepage": "https://www.drupal.org/user/58704"
-                },
-                {
-                    "name": "diqidoq",
-                    "homepage": "https://www.drupal.org/user/1001934"
-                },
-                {
-                    "name": "japerry",
-                    "homepage": "https://www.drupal.org/user/45640"
-                },
-                {
-                    "name": "Pravin Ajaaz",
-                    "homepage": "https://www.drupal.org/user/2910049"
-                },
-                {
-                    "name": "purushotam.rai",
-                    "homepage": "https://www.drupal.org/user/3193859"
-                },
-                {
-                    "name": "RenatoG",
-                    "homepage": "https://www.drupal.org/user/3326031"
-                },
-                {
-                    "name": "VladimirAus",
-                    "homepage": "https://www.drupal.org/user/673120"
-                }
-            ],
-            "description": "Allows hiding of entity label fields and automatic label creation.",
-            "homepage": "https://www.drupal.org/project/auto_entitylabel",
-            "support": {
-                "source": "https://git.drupalcode.org/project/auto_entitylabel",
-                "issues": "https://www.drupal.org/project/issues/auto_entitylabel"
             }
         },
         {

--- a/config/auto_entitylabel.settings.block_content.accordion_group.yml
+++ b/config/auto_entitylabel.settings.block_content.accordion_group.yml
@@ -1,9 +1,0 @@
-status: 2
-pattern: 'Accordion Group [block_content:id]'
-escape: false
-preserve_titles: false
-save: true
-chunk: 50
-dependencies:
-  config:
-    - block_content.type.accordion_group

--- a/config/auto_entitylabel.settings.block_content.basic.yml
+++ b/config/auto_entitylabel.settings.block_content.basic.yml
@@ -1,9 +1,0 @@
-status: 0
-pattern: ''
-escape: false
-preserve_titles: false
-save: false
-chunk: 50
-dependencies:
-  config:
-    - block_content.type.basic

--- a/config/auto_entitylabel.settings.block_content.registration_tool.yml
+++ b/config/auto_entitylabel.settings.block_content.registration_tool.yml
@@ -1,9 +1,0 @@
-status: 2
-pattern: 'Registration Tool [block_content:id]'
-escape: false
-preserve_titles: false
-save: false
-chunk: 50
-dependencies:
-  config:
-    - block_content.type.registration_tool

--- a/config/auto_entitylabel.settings.node.page.yml
+++ b/config/auto_entitylabel.settings.node.page.yml
@@ -1,9 +1,0 @@
-status: 0
-pattern: ''
-escape: false
-preserve_titles: false
-save: false
-chunk: 50
-dependencies:
-  config:
-    - node.type.page

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -4,7 +4,6 @@ module:
   new_relic_rpm: -20
   admin_toolbar: 0
   allowed_formats: 0
-  auto_entitylabel: 0
   autologout: 0
   block: 0
   block_content: 0


### PR DESCRIPTION


**_Delete all details that do not apply to this PR!_**

## Jira ticket (required)
[VOTE-764](https://bixal-projects.atlassian.net/browse/VOTE-764)

## Description (optional)
Disable and remove auto_entitylabel module which isn't in use. 

## Deployment and testing (required, if applicable)
### Pre-deploy steps
1. It would probably be best to disable the module on a given environment first before running into errors where the module files are not found due to composer removing them before config import is ran.

### Testing steps
1. Confirm that auto_entitylabel is disabled and removed from the system via admin modules page.
2. Confirm that no pages are broken as a result of the module being removed.
