### PR TITLE
VOTE-1655 Add boolean value to track which state/territory accepts th…

### DIFF
--- a/config/core.entity_form_display.node.state_territory.default.yml
+++ b/config/core.entity_form_display.node.state_territory.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.state_territory.body
+    - field.field.node.state_territory.field_accepts_nvrf
     - field.field.node.state_territory.field_confirm_registration_link
     - field.field.node.state_territory.field_election_homepage_link
     - field.field.node.state_territory.field_g_in_person_deadline
@@ -161,6 +162,13 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_accepts_nvrf:
+    type: boolean_checkbox
+    weight: 3
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
   field_confirm_registration_link:
     type: link_default
     weight: 12
@@ -234,7 +242,7 @@ content:
     third_party_settings: {  }
   field_is_state:
     type: boolean_checkbox
-    weight: 3
+    weight: 2
     region: content
     settings:
       display_label: true
@@ -338,7 +346,7 @@ content:
     third_party_settings: {  }
   field_state_abbreviation:
     type: string_textfield
-    weight: 2
+    weight: 1
     region: content
     settings:
       size: 2
@@ -383,7 +391,7 @@ content:
     third_party_settings: {  }
   title:
     type: string_textfield
-    weight: 1
+    weight: 0
     region: content
     settings:
       size: 60

--- a/config/core.entity_view_display.node.state_territory.default.yml
+++ b/config/core.entity_view_display.node.state_territory.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.state_territory.body
+    - field.field.node.state_territory.field_accepts_nvrf
     - field.field.node.state_territory.field_confirm_registration_link
     - field.field.node.state_territory.field_election_homepage_link
     - field.field.node.state_territory.field_g_in_person_deadline
@@ -40,6 +41,16 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 0
+    region: content
+  field_accepts_nvrf:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 20
     region: content
   field_confirm_registration_link:
     type: link

--- a/config/core.entity_view_display.node.state_territory.full.yml
+++ b/config/core.entity_view_display.node.state_territory.full.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.full
     - field.field.node.state_territory.body
+    - field.field.node.state_territory.field_accepts_nvrf
     - field.field.node.state_territory.field_confirm_registration_link
     - field.field.node.state_territory.field_election_homepage_link
     - field.field.node.state_territory.field_g_in_person_deadline
@@ -42,6 +43,16 @@ content:
     third_party_settings: {  }
     weight: 0
     region: content
+  field_accepts_nvrf:
+    type: boolean
+    label: hidden
+    settings:
+      format: true-false
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 20
+    region: content
   field_confirm_registration_link:
     type: link
     label: hidden
@@ -52,7 +63,7 @@ content:
       rel: '0'
       target: '0'
     third_party_settings: {  }
-    weight: 15
+    weight: 14
     region: content
   field_election_homepage_link:
     type: link
@@ -64,7 +75,7 @@ content:
       rel: '0'
       target: '0'
     third_party_settings: {  }
-    weight: 2
+    weight: 1
     region: content
   field_g_in_person_deadline:
     type: string
@@ -72,7 +83,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 14
+    weight: 13
     region: content
   field_g_mail_postmarked_deadline:
     type: string
@@ -80,7 +91,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 10
+    weight: 9
     region: content
   field_g_mail_received_deadline:
     type: string
@@ -88,7 +99,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 12
+    weight: 11
     region: content
   field_g_online_deadline:
     type: string
@@ -96,7 +107,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 8
+    weight: 7
     region: content
   field_in_person_deadline:
     type: double_field_unformatted_list
@@ -118,7 +129,7 @@ content:
         scale: 2
       inline: true
     third_party_settings: {  }
-    weight: 13
+    weight: 12
     region: content
   field_is_state:
     type: boolean
@@ -128,7 +139,7 @@ content:
       format_custom_false: ''
       format_custom_true: ''
     third_party_settings: {  }
-    weight: 19
+    weight: 18
     region: content
   field_mail_postmarked_deadline:
     type: datetime_default
@@ -137,7 +148,7 @@ content:
       timezone_override: ''
       format_type: long_date
     third_party_settings: {  }
-    weight: 9
+    weight: 8
     region: content
   field_mail_received_deadline:
     type: datetime_default
@@ -146,7 +157,7 @@ content:
       timezone_override: ''
       format_type: long_date
     third_party_settings: {  }
-    weight: 11
+    weight: 10
     region: content
   field_more_info_link:
     type: link
@@ -158,7 +169,7 @@ content:
       rel: '0'
       target: '0'
     third_party_settings: {  }
-    weight: 6
+    weight: 5
     region: content
   field_online_deadline:
     type: double_field_unformatted_list
@@ -180,7 +191,7 @@ content:
         scale: 2
       inline: true
     third_party_settings: {  }
-    weight: 7
+    weight: 6
     region: content
   field_override_confirm_reg_link:
     type: link
@@ -192,7 +203,7 @@ content:
       rel: '0'
       target: '0'
     third_party_settings: {  }
-    weight: 16
+    weight: 15
     region: content
   field_override_election_hp_link:
     type: link
@@ -204,7 +215,7 @@ content:
       rel: '0'
       target: '0'
     third_party_settings: {  }
-    weight: 3
+    weight: 2
     region: content
   field_override_more_info_link:
     type: link
@@ -216,7 +227,7 @@ content:
       rel: '0'
       target: '0'
     third_party_settings: {  }
-    weight: 17
+    weight: 16
     region: content
   field_override_registration_link:
     type: link
@@ -228,7 +239,7 @@ content:
       rel: '0'
       target: '0'
     third_party_settings: {  }
-    weight: 5
+    weight: 4
     region: content
   field_registration_link:
     type: link
@@ -240,14 +251,14 @@ content:
       rel: '0'
       target: '0'
     third_party_settings: {  }
-    weight: 4
+    weight: 3
     region: content
   field_registration_type:
     type: list_key
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 18
+    weight: 17
     region: content
   field_state_abbreviation:
     type: string
@@ -255,7 +266,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 20
+    weight: 19
     region: content
 hidden:
   body: true

--- a/config/core.entity_view_display.node.state_territory.teaser.yml
+++ b/config/core.entity_view_display.node.state_territory.teaser.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.state_territory.body
+    - field.field.node.state_territory.field_accepts_nvrf
     - field.field.node.state_territory.field_confirm_registration_link
     - field.field.node.state_territory.field_election_homepage_link
     - field.field.node.state_territory.field_g_in_person_deadline
@@ -45,6 +46,7 @@ content:
     region: content
 hidden:
   body: true
+  field_accepts_nvrf: true
   field_confirm_registration_link: true
   field_election_homepage_link: true
   field_g_in_person_deadline: true

--- a/config/field.field.node.state_territory.field_accepts_nvrf.yml
+++ b/config/field.field.node.state_territory.field_accepts_nvrf.yml
@@ -1,0 +1,23 @@
+uuid: e06968c9-d7a4-4956-8c0e-2b7efdd6a0dd
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_accepts_nvrf
+    - node.type.state_territory
+id: node.state_territory.field_accepts_nvrf
+field_name: field_accepts_nvrf
+entity_type: node
+bundle: state_territory
+label: 'This state/territory accepts the NVRF'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/field.storage.node.field_accepts_nvrf.yml
+++ b/config/field.storage.node.field_accepts_nvrf.yml
@@ -1,0 +1,18 @@
+uuid: 499fb10a-3003-4eac-8471-e9b664335bec
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_accepts_nvrf
+field_name: field_accepts_nvrf
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
…e NVRF

## Jira ticket (required)
[VOTE-1655](https://bixal-projects.atlassian.net/browse/VOTE-1655)

## Description (optional)
Add boolean to state/territory content type to track which state/territories accept the NVRF

## Deployment and testing (required, if applicable)
### Post-deploy steps
1. `lando retune`

### Testing steps
1. Visit http://vote-gov.lndo.site/node/add/state_territory
2. See the new checkbox labeled "This state/territory accepts the NVRF"

<img width="410" alt="Screenshot 2023-07-06 at 2 47 19 PM" src="https://github.com/usagov/vote-gov-drupal/assets/19731897/b42ffe63-6ed3-43d0-a7fa-41c6109027e0">


