### PR TITLE
VOTE-1652 Add NVRF download block to all state pages that accept it

### DIFF
--- a/config/core.entity_view_display.node.state_territory.full.yml
+++ b/config/core.entity_view_display.node.state_territory.full.yml
@@ -47,7 +47,7 @@ content:
     type: boolean
     label: hidden
     settings:
-      format: true-false
+      format: boolean
       format_custom_false: ''
       format_custom_true: ''
     third_party_settings: {  }

--- a/web/themes/custom/vote_gov/templates/node/node--state-territory--full.html.twig
+++ b/web/themes/custom/vote_gov/templates/node/node--state-territory--full.html.twig
@@ -28,6 +28,13 @@
     {% include '@vote_gov/partial/register/registration-type--in-person.html.twig' %}
 {% endif %}
 
+
+
+  {# NVRF Selector and download button #}
+  {% if content.field_accepts_nvrf.0["#markup"] == 1 %}
+    {{ drupal_entity('block_content', 3) }}
+  {% endif %}
+
 <p>{{'Last updated:' | t }} {{ node.revision_timestamp.value | date('U') | format_date('revision_date') }}</p>
 
 {% endblock %}

--- a/web/themes/custom/vote_gov/templates/partial/register/registration-type--mail.html.twig
+++ b/web/themes/custom/vote_gov/templates/partial/register/registration-type--mail.html.twig
@@ -49,8 +49,3 @@
       </p>
     {% endif %}
 {% endif %}
-
-    {# NVRF Selector and download button #}
-{% if state_abrev != 'wy' %}
-  {{ drupal_entity('block_content', 3) }}
-{% endif %}


### PR DESCRIPTION
## Jira ticket (required)
https://bixal-projects.atlassian.net/browse/VOTE-1652

## Description (optional)
Add NVRF download block to all state pages that have the "Accepts NVRF" checkbox checked. Note that the filed data for this is not migrated yet.

## Deployment and testing (required, if applicable)
### Post-deploy steps
1. `lando retune`

### Testing steps
1. visit http://vote-gov.lndo.site/register/ak the NVRF download block should not be displaying
2. edit the page and check the box for "Accepts NVRF" and save
3. view the page again http://vote-gov.lndo.site/register/ak and see the download block is displaying

<!-- Pull Request Checklist (Reference only)

Please ensure you have addressed all concerns below before marking this PR "ready for review".

- No merge conflicts exist with the target branch.
- branch name follows the branch naming conventions **feature/VOTE-###-add-short-description** matching the Jira ticket number.
- Primary commit message is of the format **VOTE-### Add short description of the task** matching the Jira ticket number.
- PR title either matches primary commit message or is of the format **VOTE-### Add short description of the task** matching the Jira ticket number (i.e. "VOTE-123 Implement feature X").
- Automated pipeline tests have passed.
- At least one “Reviewer has been specified.

-->
