### PR TITLE
VOTE-1592 Render and style inline alert block type

### DIFF
--- a/config/views.view.inline_alert.yml
+++ b/config/views.view.inline_alert.yml
@@ -1,0 +1,371 @@
+uuid: 8c6d3ab6-6433-4827-87d5-622aaaa51e1e
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.inline_alert
+    - field.storage.block_content.field_alert_content
+    - field.storage.block_content.field_heading
+  module:
+    - block_content
+    - text
+    - user
+id: inline_alert
+label: 'Inline Alert'
+module: views
+description: ''
+tag: ''
+base_table: block_content_field_data
+base_field: id
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'Inline Alert'
+      fields:
+        field_heading:
+          id: field_heading
+          table: block_content__field_heading
+          field: field_heading
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_alert_content:
+          id: field_alert_content
+          table: block_content__field_alert_content
+          field: field_alert_content
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: text_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      pager:
+        type: none
+        options:
+          offset: 0
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
+        id:
+          id: id
+          table: block_content_field_data
+          field: id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: block_content
+          entity_field: id
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+      arguments: {  }
+      filters:
+        status:
+          id: status
+          table: block_content_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: block_content
+          entity_field: status
+          plugin_id: boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        type:
+          id: type
+          table: block_content_field_data
+          field: type
+          entity_type: block_content
+          entity_field: type
+          plugin_id: bundle
+          value:
+            inline_alert: inline_alert
+        langcode:
+          id: langcode
+          table: block_content_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: block_content
+          entity_field: langcode
+          plugin_id: language
+          operator: in
+          value:
+            '***LANGUAGE_language_interface***': '***LANGUAGE_language_interface***'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        field_publish_value:
+          id: field_publish_value
+          table: block_content__field_publish
+          field: field_publish_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: 'entity:block_content'
+        options:
+          relationship: none
+          view_mode: default
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user.permissions
+      tags:
+        - 'config:field.storage.block_content.field_alert_content'
+        - 'config:field.storage.block_content.field_heading'
+  embed_1:
+    id: embed_1
+    display_title: Embed
+    display_plugin: embed
+    position: 1
+    display_options:
+      rendering_language: '***LANGUAGE_language_interface***'
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - user.permissions
+      tags:
+        - 'config:field.storage.block_content.field_alert_content'
+        - 'config:field.storage.block_content.field_heading'

--- a/web/themes/custom/vote_gov/src/sass/uswds-overrides/_index.scss
+++ b/web/themes/custom/vote_gov/src/sass/uswds-overrides/_index.scss
@@ -8,4 +8,5 @@
 @forward "override-usa-language-selector";
 @forward "override-usa-form";
 @forward "override-usa-accordion";
+@forward "override-usa-alert";
 // ****** Do not write any custom CSS on this file ****** //

--- a/web/themes/custom/vote_gov/src/sass/uswds-overrides/_override-usa-alert.scss
+++ b/web/themes/custom/vote_gov/src/sass/uswds-overrides/_override-usa-alert.scss
@@ -24,9 +24,6 @@
   .grid-container {
     background-position: calc(100% - 1rem) 1rem;
 
-    @include at-media('tablet') {
-      background-position: calc(100% - 1rem) 0.3rem;
-    }
   }
 }
 

--- a/web/themes/custom/vote_gov/templates/block/block-content--inline-alert.html.twig
+++ b/web/themes/custom/vote_gov/templates/block/block-content--inline-alert.html.twig
@@ -1,0 +1,22 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display a block content.
+ *
+ * @see template_preprocess_block_content_template()
+ *
+ * @ingroup themeable
+ */
+#}
+{% set classes = [
+  'usa-alert',
+  'usa-alert--warning',
+  content.field_alert_type | render ? 'usa-alert--' ~ content.field_alert_type | field_value | render
+] %}
+
+<div{{ attributes.addClass(classes)}}>
+    <div class="usa-alert__body">
+      <h4 class="usa-alert__heading">{{ content.field_heading | field_value }}</h4>
+      <p class="usa-alert__text">{{ content.field_alert_content | field_value }}</p>
+    </div>
+</div>

--- a/web/themes/custom/vote_gov/templates/node/node--state-territory--full.html.twig
+++ b/web/themes/custom/vote_gov/templates/node/node--state-territory--full.html.twig
@@ -7,6 +7,10 @@
 #}
 {% extends 'node.html.twig' %}
 
+{% block alert %}
+    {{ drupal_view('inline_alert', 'embed_1') }}
+{% endblock %}
+
 {% block content %}
 {% set reg_type = content.field_registration_type | field_value | column('#markup') %}
 {% set state_name = label | field_value | render %}

--- a/web/themes/custom/vote_gov/templates/node/node.html.twig
+++ b/web/themes/custom/vote_gov/templates/node/node.html.twig
@@ -81,6 +81,9 @@
 
 <article{{ attributes.addClass(classes) }}>
   <div{{ content_attributes.addClass('node__content') }}>
+    {% block alert %}
+    {% endblock %}
+
     {% block content %}
 
       {{ title_prefix }}


### PR DESCRIPTION
## Jira ticket (required)
[Insert Jira ticket link
](https://bixal-projects.atlassian.net/browse/VOTE-1592)
## Description (optional)
Create view to display published inline alert as a list based on language

## Deployment and testing (required, if applicable)
### Pre-deploy steps
1. lando retune

### Post-deploy steps
1. Create one block of type inline alert with an unpublished state (English)
2. Create two blocks of type inline alert with a published state (Navajo and Yup'ik)

### Testing steps
1. Navigate to a state page
2. Confirm the Navajo alert is visible only on the Navajo page
3. Confirm the Yup'ik alert is visible only on the Yup'ik page
4. Confirm the English block is not visible on any language page
5. Delete all inline alert blocks and confirm they are no longer displaying.

<!-- Pull Request Checklist (Reference only)

Please ensure you have addressed all concerns below before marking this PR "ready for review".

- No merge conflicts exist with the target branch.
- branch name follows the branch naming conventions **feature/VOTE-###-add-short-description** matching the Jira ticket number.
- Primary commit message is of the format **VOTE-### Add short description of the task** matching the Jira ticket number.
- PR title either matches primary commit message or is of the format **VOTE-### Add short description of the task** matching the Jira ticket number (i.e. "VOTE-123 Implement feature X").
- Automated pipeline tests have passed.
- At least one “Reviewer has been specified.

-->
