### PR TITLE
VOTE-1857 Add new Russian translation for sitename

### DIFF
--- a/web/modules/custom/vote_utility/translations/ru.po
+++ b/web/modules/custom/vote_utility/translations/ru.po
@@ -18,7 +18,7 @@ msgstr "Выберите Язык"
 
 # config.languages.params.Owner
 msgid "@sitename in language"
-msgstr "@sitename in Русский"
+msgstr "@sitename по-русски"
 
 # config.languages.params.go_back
 msgid "Go back"


### PR DESCRIPTION
## Jira ticket (required)
https://bixal-projects.atlassian.net/browse/VOTE-1857

## Deployment and testing (required, if applicable)
### Post-deploy steps
1. `lando import-translations`

### Testing steps
1. log into the site
2. visit http://vote-gov.lndo.site/ru and make sure the new Russian sitename above the logo is displaying.