### PR TITLE
VOTE-221 Disable page description fields on content types

### DIFF
--- a/config/sync/core.entity_form_display.node.landing.default.yml
+++ b/config/sync/core.entity_form_display.node.landing.default.yml
@@ -13,22 +13,11 @@ dependencies:
     - paragraphs
     - path
     - publication_date
-    - text
 id: node.landing.default
 targetEntityType: node
 bundle: landing
 mode: default
 content:
-  body:
-    type: text_textarea_with_summary
-    weight: 10
-    region: content
-    settings:
-      rows: 9
-      summary_rows: 3
-      placeholder: ''
-      show_summary: false
-    third_party_settings: {  }
   created:
     type: datetime_timestamp
     weight: 2
@@ -37,7 +26,7 @@ content:
     third_party_settings: {  }
   field_metatags:
     type: metatag_firehose
-    weight: 14
+    weight: 12
     region: content
     settings:
       sidebar: true
@@ -45,7 +34,7 @@ content:
     third_party_settings: {  }
   field_paragraph_components:
     type: paragraphs
-    weight: 12
+    weight: 10
     region: content
     settings:
       title: Component
@@ -64,7 +53,7 @@ content:
     third_party_settings: {  }
   langcode:
     type: language_select
-    weight: 13
+    weight: 11
     region: content
     settings:
       include_locked: true
@@ -128,5 +117,6 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  body: true
   promote: true
   sticky: true

--- a/config/sync/core.entity_form_display.node.page.default.yml
+++ b/config/sync/core.entity_form_display.node.page.default.yml
@@ -19,7 +19,13 @@ targetEntityType: node
 bundle: page
 mode: default
 content:
-  body:
+  created:
+    type: datetime_timestamp
+    weight: 5
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_body:
     type: text_textarea_with_summary
     weight: 10
     region: content
@@ -29,25 +35,9 @@ content:
       placeholder: ''
       show_summary: false
     third_party_settings: {  }
-  created:
-    type: datetime_timestamp
-    weight: 5
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  field_body:
-    type: text_textarea_with_summary
-    weight: 11
-    region: content
-    settings:
-      rows: 9
-      summary_rows: 3
-      placeholder: ''
-      show_summary: false
-    third_party_settings: {  }
   field_metatags:
     type: metatag_firehose
-    weight: 13
+    weight: 12
     region: content
     settings:
       sidebar: true
@@ -55,7 +45,7 @@ content:
     third_party_settings: {  }
   langcode:
     type: language_select
-    weight: 12
+    weight: 11
     region: content
     settings:
       include_locked: true
@@ -119,5 +109,6 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  body: true
   promote: true
   sticky: true

--- a/config/sync/core.entity_form_display.node.state_territory.default.yml
+++ b/config/sync/core.entity_form_display.node.state_territory.default.yml
@@ -38,7 +38,6 @@ dependencies:
     - metatag
     - path
     - publication_date
-    - text
 third_party_settings:
   field_group:
     group_links:
@@ -148,16 +147,6 @@ targetEntityType: node
 bundle: state_territory
 mode: default
 content:
-  body:
-    type: text_textarea_with_summary
-    weight: 17
-    region: content
-    settings:
-      rows: 9
-      summary_rows: 3
-      placeholder: ''
-      show_summary: false
-    third_party_settings: {  }
   created:
     type: datetime_timestamp
     weight: 7
@@ -271,7 +260,7 @@ content:
     third_party_settings: {  }
   field_metatags:
     type: metatag_firehose
-    weight: 20
+    weight: 19
     region: content
     settings:
       sidebar: true
@@ -372,7 +361,7 @@ content:
     third_party_settings: {  }
   langcode:
     type: language_select
-    weight: 19
+    weight: 18
     region: content
     settings:
       include_locked: true
@@ -416,7 +405,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   translation:
-    weight: 18
+    weight: 17
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -436,5 +425,6 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  body: true
   promote: true
   sticky: true

--- a/config/sync/field.field.node.landing.body.yml
+++ b/config/sync/field.field.node.landing.body.yml
@@ -14,7 +14,7 @@ entity_type: node
 bundle: landing
 label: 'Page description'
 description: ''
-required: true
+required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''

--- a/config/sync/field.field.node.page.body.yml
+++ b/config/sync/field.field.node.page.body.yml
@@ -14,7 +14,7 @@ entity_type: node
 bundle: page
 label: 'Page Description'
 description: ''
-required: true
+required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''

--- a/config/sync/field.field.node.state_territory.body.yml
+++ b/config/sync/field.field.node.state_territory.body.yml
@@ -14,7 +14,7 @@ entity_type: node
 bundle: state_territory
 label: 'Page description'
 description: ''
-required: true
+required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''

--- a/config/sync/language/fr/metatag.metatag_defaults.global.yml
+++ b/config/sync/language/fr/metatag.metatag_defaults.global.yml
@@ -1,3 +1,3 @@
 tags:
-  title: 'Inscrivez-vous pour voter | [site:name]'
   description: "Découvrez les modes d'inscription au vote dans votre État"
+  title: 'Inscrivez-vous pour voter | [site:name]'

--- a/config/sync/language/fr/metatag.metatag_defaults.global.yml
+++ b/config/sync/language/fr/metatag.metatag_defaults.global.yml
@@ -1,3 +1,3 @@
 tags:
-  description: "Découvrez les modes d'inscription au vote dans votre État"
   title: 'Inscrivez-vous pour voter | [site:name]'
+  description: "Découvrez les modes d'inscription au vote dans votre État"


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->
## JIRA Ticket
https://cm-jira.usa.gov/browse/VOTE-221

## Description

Page description fields were introduced in anticipation of teaser content or metadata descriptions. Teasers are not required for launch and the metadata descriptions can already be manipulated on each node. Until further requirement becomes necessary we are disabling.

## Deployment and testing

### Post-deploy

1. `lando retune`

### QA/Test

1. Visit http://vote-gov.lndo.site/node/add and view the add form for each content type
2. Make sure there is no page description field displaying in the add form

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.
- [x] The result of these changes meet the JIRA ticket "definition of done".
- [x] This work meets the project [standards](/usagov/vote-gov-drupal/blob/dev/docs/standards.md).

## Checklist for the Peer Reviewers

- [x] The code has been reviewed.
- [ ] The file changes are relevant to the task.
- [x] The author of the commits match the assignee.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps have been successfully completed and the results match "definition of done".
- [x] Drupal database log and browser console log are free of errors.
- [x] There are no known side-effects outside the expected behavior.
- [x] Code is readable and includes appropriate commenting.
