### PR TITLE
VOTE-87 - added (in english) to stings as needed for wy pdf link

### DIFF
--- a/web/modules/custom/vote_utility/translations/ar.po
+++ b/web/modules/custom/vote_utility/translations/ar.po
@@ -146,7 +146,7 @@ msgstr "يمكنك تأكيد حالة تسجيل الناخب الخاص بك �
 
 # @link: data.translations.register.confirm_registration__link_WY
 msgid "Click here to view Wyoming's county clerk contact information (PDF)"
-msgstr "انقر هنا لعرض معلومات الاتصال بموظف مقاطعة وايومنغ (PDF)"
+msgstr "انقر هنا لعرض معلومات الاتصال بموظف مقاطعة وايومنغ (PDF) (باللغة الإنجليزية)"
 
 # data.translations.register.confirm_registration__intro (see accessibility updates)
 msgid "You can @link on @state_name’s election website."

--- a/web/modules/custom/vote_utility/translations/bn.po
+++ b/web/modules/custom/vote_utility/translations/bn.po
@@ -99,7 +99,7 @@ msgid "You can confirm your voter registration status by contacting your local r
 msgstr "আপনি আপনার স্থানীয় নিবন্ধন অফিসে যোগাযোগ করে আপনার ভোটার নিবন্ধন স্থিতি নিশ্চিত করতে পারেন। @link।"
 
 msgid "Click here to view Wyoming's county clerk contact information (PDF)"
-msgstr "Wyoming এর কাউন্টি ক্লার্ক যোগাযোগের তথ্য (PDF) দেখতে এখানে ক্লিকরুন"
+msgstr "Wyoming এর কাউন্টি ক্লার্ক যোগাযোগের তথ্য (PDF) দেখতে এখানে ক্লিকরুন (ইংরেজীতে)"
 
 msgid "Find out ways to register"
 msgstr "নিবন্ধন করার উপায় খুঁজে বের করুন"

--- a/web/modules/custom/vote_utility/translations/fr.po
+++ b/web/modules/custom/vote_utility/translations/fr.po
@@ -146,7 +146,7 @@ msgstr "Vous pouvez confirmer le statut de votre inscription au vote en contacta
 
 # @link: data.translations.register.confirm_registration__link_WY
 msgid "Click here to view Wyoming's county clerk contact information (PDF)"
-msgstr "Cliquez ici pour les coordonnées du greffier de comté du Wyoming (PDF)"
+msgstr "Cliquez ici pour les coordonnées du greffier de comté du Wyoming (PDF) (en anglais)"
 
 # data.translations.register.confirm_registration__intro (see accessibility updates)
 msgid "You can @link on @state_name’s election website."

--- a/web/modules/custom/vote_utility/translations/hi.po
+++ b/web/modules/custom/vote_utility/translations/hi.po
@@ -99,7 +99,7 @@ msgid "You can confirm your voter registration status by contacting your local r
 msgstr "आप अपने स्थानीय पंजीकरण कार्यालय से संपर्क करके अपने मतदाता पंजीकरण की स्थिति की पुष्टि कर सकते हैं। @link"
 
 msgid "Click here to view Wyoming's county clerk contact information (PDF)"
-msgstr "(व्योमिंग के काउंटी क्लर्क की संपर्क जानकारी (पीडीएफ) देखने के लिए यहां क्लिक करें)।"
+msgstr "(व्योमिंग के काउंटी क्लर्क की संपर्क जानकारी (पीडीएफ) देखने के लिए यहां क्लिक करें) (अंग्रेज़ी में)।"
 
 msgid "Find out ways to register"
 msgstr "पंजीकरण करने के तरीकों के बारे में जानकारी प्राप्त करें"

--- a/web/modules/custom/vote_utility/translations/ht.po
+++ b/web/modules/custom/vote_utility/translations/ht.po
@@ -146,7 +146,7 @@ msgstr "Ou ka konfime nan ki pwen enskripsyon votè w te fè a rive, lè w antre
 
 # @link: data.translations.register.confirm_registration__link_WY
 msgid "Click here to view Wyoming's county clerk contact information (PDF)"
-msgstr "Klike la a pou w wè enfòmasyon pou kontakte grefye Konte Wyoming la (PDF)"
+msgstr "Klike la a pou w wè enfòmasyon pou kontakte grefye Konte Wyoming la (PDF) (ann Anglè)"
 
 # data.translations.register.confirm_registration__intro (see accessibility updates)
 msgid "You can @link on @state_name’s election website."

--- a/web/modules/custom/vote_utility/translations/km.po
+++ b/web/modules/custom/vote_utility/translations/km.po
@@ -99,7 +99,7 @@ msgid "You can confirm your voter registration status by contacting your local r
 msgstr "អ្នកអាចបញ្ជាក់ស្ថានភាពការចុះឈ្មោះបោះឆ្នោតរបស់អ្នកដោយទំនាក់ទំនងទៅការិយាល័យផ្នែកចុឈ្មោះក្នុងមូលដ្ឋានរបស់អ្នក។ @link។"
 
 msgid "Click here to view Wyoming's county clerk contact information (PDF)"
-msgstr " ចុចទីនេះដើម្បីមើលព័ត៌មានទំនាក់ទំនងទៅស្មៀនប្រចាំខោនធីរបស់រដ្ឋ Wyoming (PDF)"
+msgstr " ចុចទីនេះដើម្បីមើលព័ត៌មានទំនាក់ទំនងទៅស្មៀនប្រចាំខោនធីរបស់រដ្ឋ Wyoming (PDF) (ជាភាសាអង់គ្លេស)"
 
 msgid "Find out ways to register"
 msgstr "ស្វែងរកវិធីនានាដើម្បីចុះឈ្មោះ"

--- a/web/modules/custom/vote_utility/translations/ko.po
+++ b/web/modules/custom/vote_utility/translations/ko.po
@@ -102,7 +102,7 @@ msgid "You can confirm your voter registration status by contacting your local r
 msgstr "귀하의 유권자 등록 상태는 지역 등록 사무소에 연락하여 확인할 수 있습니다. @link."
 
 msgid "Click here to view Wyoming's county clerk contact information (PDF)"
-msgstr "와이오밍 카운티 기록 보관 사무소 연락처는 여기를 클릭하십시오 (PDF파일)"
+msgstr "와이오밍 카운티 기록 보관 사무소 연락처는 여기를 클릭하십시오 (PDF파일) (영어로 제공)"
 
 msgid "Find out ways to register"
 msgstr "등록 방법 검색하기"

--- a/web/modules/custom/vote_utility/translations/nv.po
+++ b/web/modules/custom/vote_utility/translations/nv.po
@@ -146,7 +146,7 @@ msgstr "I'ii'n77[ biniiy4 ha'dinilaago k44hon7t'98gi i'ii'n77[ bi[ na'anishgi b7
 
 # @link: data.translations.register.confirm_registration__link_WY
 msgid "Click here to view Wyoming's county clerk contact information (PDF)"
-msgstr "Kwe'4 bi[ ad7lch77d Wyoming hahoodzohj7 county clerk woly4ego bi[ da'7n77shj7 hane' &lt;PDF&gt; d7n77['88[go"
+msgstr "Kwe'4 bi[ ad7lch77d Wyoming hahoodzohj7 county clerk woly4ego bi[ da'7n77shj7 hane' &lt;PDF&gt; d7n77['88[go &lt;Bilag1ana k'ehj7&gt;"
 
 # data.translations.register.confirm_registration__intro 
 msgid "You can @link on @state_name’s election website."

--- a/web/modules/custom/vote_utility/translations/pt.po
+++ b/web/modules/custom/vote_utility/translations/pt.po
@@ -146,7 +146,7 @@ msgstr "Você pode confirmar seu status de registro de eleitor entrando em conta
 
 # @link: data.translations.register.confirm_registration__link_WY
 msgid "Click here to view Wyoming's county clerk contact information (PDF)"
-msgstr "Clique aqui para ver as informações de contato do secretário do condado de Wyoming (PDF)"
+msgstr "Clique aqui para ver as informações de contato do secretário do condado de Wyoming (PDF) (em inglês)"
 
 # data.translations.register.confirm_registration__intro (see accessibility updates)
 msgid "You can @link on @state_name’s election website."

--- a/web/modules/custom/vote_utility/translations/ru.po
+++ b/web/modules/custom/vote_utility/translations/ru.po
@@ -146,7 +146,7 @@ msgstr "Вы можете подтвердить свой статус реги�
 
 # @link: data.translations.register.confirm_registration__link_WY
 msgid "Click here to view Wyoming's county clerk contact information (PDF)"
-msgstr "Нажмите здесь, чтобы просмотреть контактную информацию клерка округа Вайоминг (PDF)"
+msgstr "Нажмите здесь, чтобы просмотреть контактную информацию клерка округа Вайоминг (PDF) (по-английски)"
 
 # data.translations.register.confirm_registration__intro (see accessibility updates)
 msgid "You can @link on @state_name’s election website."

--- a/web/modules/custom/vote_utility/translations/tl.po
+++ b/web/modules/custom/vote_utility/translations/tl.po
@@ -100,7 +100,7 @@ msgid "You can confirm your voter registration status by contacting your local r
 msgstr "Maaari ninyong kumpirmahin ang estado ng inyong rehistrasyon ng botante sa pamamagitan ng pakikipag-ugnayan sa inyong lokal na opisina ng rehistrasyon. @link"
 
 msgid "Click here to view Wyoming's county clerk contact information (PDF)"
-msgstr "I-click ito upang makita ang impormasyon sa pakikipag-ugnayan sa clerk ng county (PDF) ng Wyoming."
+msgstr "I-click ito upang makita ang impormasyon sa pakikipag-ugnayan sa clerk ng county (PDF) ng Wyoming (sa Ingles)."
 
 msgid "Find out ways to register"
 msgstr "Alamin ang mga paraan para magparehistro"

--- a/web/modules/custom/vote_utility/translations/vi.po
+++ b/web/modules/custom/vote_utility/translations/vi.po
@@ -99,7 +99,7 @@ msgid "You can confirm your voter registration status by contacting your local r
 msgstr "Ban có thể xác nhận tình trạng đăng ký bầu cử của mình bằng cách liên lạc với văn phòng đăng ký địa phương. @link."
 
 msgid "Click here to view Wyoming's county clerk contact information (PDF)"
-msgstr "Nhấp vào đây để xem thông tin liên lạc của thư ký quận Wyoming (PDF)"
+msgstr "Nhấp vào đây để xem thông tin liên lạc của thư ký quận Wyoming (PDF) (bằng Tiếng Anh)"
 
 msgid "Find out ways to register"
 msgstr "Tìm hiểu cách đăng ký"

--- a/web/modules/custom/vote_utility/translations/ypk.po
+++ b/web/modules/custom/vote_utility/translations/ypk.po
@@ -99,7 +99,7 @@ msgid "You can confirm your voter registration status by contacting your local r
 msgstr "Ipapighqesaghngaaghpegu nakmikillgheghpek ilatellghan natetulnga tuqluquvgu negpek ilatfigan qepghaghviga. @link."
 
 msgid "Click here to view Wyoming's county clerk contact information (PDF)"
-msgstr "Click here to view Wyoming's county clerk contact information (PDF)"
+msgstr "Click here to view Wyoming's county clerk contact information (PDF) (Laluramkestun)"
 
 msgid "Find out ways to register"
 msgstr "Naalkigu naten alla ilatelleghqan"

--- a/web/modules/custom/vote_utility/translations/zh-hans.po
+++ b/web/modules/custom/vote_utility/translations/zh-hans.po
@@ -99,7 +99,7 @@ msgid "You can confirm your voter registration status by contacting your local r
 msgstr "您可以聯繫當地的登記處確認您的選民登記狀態。@link。"
 
 msgid "Click here to view Wyoming's county clerk contact information (PDF)"
-msgstr "點擊此處查看懷俄明州縣書記聯繫資訊 (PDF）"
+msgstr "點擊此處查看懷俄明州縣書記聯繫資訊 (PDF）(英语)"
 
 msgid "Find out ways to register"
 msgstr "了解如何注册"

--- a/web/modules/custom/vote_utility/translations/zh.po
+++ b/web/modules/custom/vote_utility/translations/zh.po
@@ -99,7 +99,7 @@ msgid "You can confirm your voter registration status by contacting your local r
 msgstr "您可以聯繫當地的登記處確認您的選民登記狀態。 @link。"
 
 msgid "Click here to view Wyoming's county clerk contact information (PDF)"
-msgstr "點擊此處查看懷俄明州縣書記聯繫資訊 (PDF)"
+msgstr "點擊此處查看懷俄明州縣書記聯繫資訊 (PDF) (英語)"
 
 msgid "Find out ways to register"
 msgstr "瞭解如何註冊"


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[VOTE-87](https://cm-jira.usa.gov/secure/RapidBoard.jspa?rapidView=4046&projectKey=VOTE&view=detail&selectedIssue=VOTE-87&quickFilter=23166)

## Description

After testing new languages that were migrated over i found that the Wy pdf link was missing the `(in english)` string for the links.  This PR updated string translations.

## Deployment and testing

### Pre-deploy

n/a

### Post-deploy

n/a

### QA/Test

1. pull down branch 
2. start local 
3. run `lando import-translations` or `lando retune` to import the updated strings 
4. visit the Wyoming page and check that for all languages besides English and Spanish has the `(in english)` added to the link 

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.
- [x] The result of these changes meet the JIRA ticket "definition of done".
- [x] This work meets the project [standards](/usagov/vote-gov-drupal/blob/dev/docs/standards.md).

## Checklist for the Peer Reviewers

- [x] The code has been reviewed.
- [x] The file changes are relevant to the task.
- [x] The author of the commits match the assignee.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps have been successfully completed and the results match "definition of done".
- [x] Drupal database log and browser console log are free of errors.
- [x] There are no known side-effects outside the expected behavior.
- [x] Code is readable and includes appropriate commenting.
