### PR TITLE
VOTE-37 Chinese simplified search page

### DIFF
--- a/web/themes/custom/vote_gov/templates/block/block-content--search.html.twig
+++ b/web/themes/custom/vote_gov/templates/block/block-content--search.html.twig
@@ -22,7 +22,9 @@
 <div class="bg-lightblue search-container" role="search" aria-label="{{ content.field_search_placeholder | field_value }}">
   <div class="grid-container">
     <form class="usa-search usa-search--small search-bar" role="search" id="search_form" action="https://search.vote.gov/search" accept-charset="UTF-8" method="get">
-      <input type="hidden" name="affiliate" id="affiliate" value="vote_{{ affiliated_search == '1' ? language : 'en' }}" autocomplete="off">
+      {# if current language is chinese simplified, change the search to use Chinese tradional 'zh' #}
+      {% set searchLanguage = language == 'zh-hans' ? 'zh' : language %}
+      <input type="hidden" name="affiliate" id="affiliate" value="vote_{{ affiliated_search == '1' ? searchLanguage : 'en' }}" autocomplete="off">
 
       <label class="usa-sr-only" for="search-field-en-small">{{ content.field_search_placeholder | field_value }}</label>
 


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket
https://cm-jira.usa.gov/browse/VOTE-37

## Description
The Chinese-simplified search page goes to 404. Changed the search results page to direct to Chinese-traditional.

## Deployment and testing

### Pre-deploy

1. lando retune

### QA/Test

1. Switch homepage to Chinese-simplified
2. Right-click the search box and inspect source code. Verify the input language value is "vote_zh"
3. Search 'vote' in the search page and verify the results page is in Chinese-traditional

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been included above.
- [ ] No merge conflicts exist with the target branch.
- [ ] Automated tests have passed on this PR.
- [ ] A reviewer has been designated.
- [ ] Deployment and testing steps have been documented above, if applicable.
- [ ] The result of these changes meet the JIRA ticket "definition of done".
- [ ] This work meets the project [standards](/usagov/vote-gov-drupal/blob/dev/docs/standards.md).

## Checklist for the Peer Reviewers

- [ ] The code has been reviewed.
- [ ] The file changes are relevant to the task.
- [ ] The author of the commits match the assignee.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps have been successfully completed and the results match "definition of done".
- [ ] Drupal database log and browser console log are free of errors.
- [ ] There are no known side-effects outside the expected behavior.
- [ ] Code is readable and includes appropriate commenting.
