### PR TITLE
VOTE-105 alter basic text format to allow id attr on heading 2

### DIFF
--- a/config/sync/editor.editor.basic_html.yml
+++ b/config/sync/editor.editor.basic_html.yml
@@ -48,6 +48,7 @@ settings:
     ckeditor5_sourceEditing:
       allowed_tags:
         - '<div id class>'
+        - '<h2 id>'
     ckeditor5_style:
       styles:
         -

--- a/config/sync/editor.editor.full_html.yml
+++ b/config/sync/editor.editor.full_html.yml
@@ -1,6 +1,6 @@
 uuid: e657bf50-0484-4285-983a-2436f497e9bc
 langcode: en
-status: true
+status: false
 dependencies:
   config:
     - filter.format.full_html

--- a/config/sync/filter.format.basic_html.yml
+++ b/config/sync/filter.format.basic_html.yml
@@ -23,7 +23,7 @@ filters:
     status: true
     weight: -10
     settings:
-      allowed_html: '<br> <p class="text-align-left text-align-center text-align-right"> <h2 class="text-align-left text-align-center text-align-right"> <h3 class="text-align-left text-align-center text-align-right"> <h4 class="text-align-left text-align-center text-align-right"> <h5 class="text-align-left text-align-center text-align-right"> <h6 class="text-align-left text-align-center text-align-right"> <a class="usa-button" href> <div id class> <strong> <em> <u> <ul> <ol reversed start> <li> <drupal-media data-entity-type data-entity-uuid alt data-align> <embedded-content data-plugin-config data-plugin-id>'
+      allowed_html: '<br> <p class="text-align-left text-align-center text-align-right"> <h2 id class="text-align-left text-align-center text-align-right"> <h3 class="text-align-left text-align-center text-align-right"> <h4 class="text-align-left text-align-center text-align-right"> <h5 class="text-align-left text-align-center text-align-right"> <h6 class="text-align-left text-align-center text-align-right"> <a class="usa-button" href> <div id class> <strong> <em> <u> <ul> <ol reversed start> <li> <drupal-media data-entity-type data-entity-uuid alt data-align> <embedded-content data-plugin-config data-plugin-id>'
       filter_html_help: true
       filter_html_nofollow: false
   media_embed:

--- a/config/sync/filter.format.full_html.yml
+++ b/config/sync/filter.format.full_html.yml
@@ -1,6 +1,6 @@
 uuid: 4e070004-703d-4c9e-8cff-cbd58935d9fb
 langcode: en
-status: true
+status: false
 dependencies:
   config:
     - core.entity_view_mode.media.media_library


### PR DESCRIPTION
Disable unused full text format

<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

https://cm-jira.usa.gov/browse/VOTE-105

## Description

Allow h2 id attribute for basic html text format when editing source. Also disable full html text format that is unused.

## Deployment and testing

### Post-deploy

1. run `lando retune`

### QA/Test

1. Visit http://vote-gov.lndo.site/node/add/page and add a heading 2 tag with text `TEST` to the wysiwyg
2. Edit the wysiwyg source using the toolbar button and add a id attribute value `test`
3. Save and publish the page
4. View it on the frontend and inspect the heading2 tag and make sure the id attribute is present
5. Visit http://vote-gov.lndo.site/admin/config/content/formats and confirm the Full html text format is missing

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.
- [x] The result of these changes meet the JIRA ticket "definition of done".
- [x] This work meets the project [standards](/usagov/vote-gov-drupal/blob/dev/docs/standards.md).

## Checklist for the Peer Reviewers

- [x] The code has been reviewed.
- [x] The file changes are relevant to the task.
- [x] The author of the commits match the assignee.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps have been successfully completed and the results match "definition of done".
- [x] Drupal database log and browser console log are free of errors.
- [x] There are no known side-effects outside the expected behavior.
- [x] Code is readable and includes appropriate commenting.
