### PR TITLE
VOTE-302: Cypress dependabot updates

### DIFF
--- a/testing/package-lock.json
+++ b/testing/package-lock.json
@@ -9,13 +9,13 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "cypress-real-events": "^1.10.0"
+        "cypress-real-events": "^1.10.3"
       },
       "devDependencies": {
-        "axe-core": "^4.7.2",
-        "cypress": "^12.17.4",
-        "cypress-axe": "^1.4.0",
-        "cypress-mochawesome-reporter": "^3.5.1"
+        "axe-core": "^4.8.1",
+        "cypress": "^13.2.0",
+        "cypress-axe": "^1.5.0",
+        "cypress-mochawesome-reporter": "^3.6.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -28,9 +28,9 @@
       }
     },
     "node_modules/@cypress/request": {
-      "version": "2.88.12",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.12.tgz",
-      "integrity": "sha512-tOn+0mDZxASFM+cuAP9szGUGPI1HwWVSvdzm7V4cCsPdFTx6qMj29CwaQmRAMIEhORIUBFBsYROYJcveK4uOjA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.1.tgz",
+      "integrity": "sha512-TWivJlJi8ZDx2wGOw1dbLuHJKUYX7bWySw377nlnGOW3hP9/MUKIsEdXT/YngWxVdgNCHRBmFlBipE+5/2ZZlQ==",
       "dependencies": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -45,7 +45,7 @@
         "json-stringify-safe": "~5.0.1",
         "mime-types": "~2.1.19",
         "performance-now": "^2.1.0",
-        "qs": "~6.10.3",
+        "qs": "6.10.4",
         "safe-buffer": "^5.1.2",
         "tough-cookie": "^4.1.3",
         "tunnel-agent": "^0.6.0",
@@ -73,9 +73,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "16.18.40",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.40.tgz",
-      "integrity": "sha512-+yno3ItTEwGxXiS/75Q/aHaa5srkpnJaH+kdkTVJ3DtJEwv92itpKbxU+FjPoh2m/5G9zmUQfrL4A4C13c+iGA=="
+      "version": "18.17.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.15.tgz",
+      "integrity": "sha512-2yrWpBk32tvV/JAd3HNHWuZn/VDN1P+72hWirHnvsvTGSqbANi+kSeuQR9yAHnbvaBvHDsoTdXV0Fe+iRtHLKA=="
     },
     "node_modules/@types/sinonjs__fake-timers": {
       "version": "8.1.1",
@@ -248,9 +248,9 @@
       "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
     },
     "node_modules/axe-core": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.7.2.tgz",
-      "integrity": "sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.8.1.tgz",
+      "integrity": "sha512-9l850jDDPnKq48nbad8SiEelCv4OrUWrKab/cPj0GScVg6cb6NbCCt/Ulk26QEq5jP9NnGr04Bit1BHyV6r5CQ==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -614,14 +614,14 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.17.4",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.17.4.tgz",
-      "integrity": "sha512-gAN8Pmns9MA5eCDFSDJXWKUpaL3IDd89N9TtIupjYnzLSmlpVr+ZR+vb4U/qaMp+lB6tBvAmt7504c3Z4RU5KQ==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.2.0.tgz",
+      "integrity": "sha512-AvDQxBydE771GTq0TR4ZUBvv9m9ffXuB/ueEtpDF/6gOcvFR96amgwSJP16Yhqw6VhmwqspT5nAGzoxxB+D89g==",
       "hasInstallScript": true,
       "dependencies": {
-        "@cypress/request": "2.88.12",
+        "@cypress/request": "^3.0.0",
         "@cypress/xvfb": "^1.2.4",
-        "@types/node": "^16.18.39",
+        "@types/node": "^18.17.5",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.2.0",
@@ -667,32 +667,36 @@
         "cypress": "bin/cypress"
       },
       "engines": {
-        "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
+        "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
       }
     },
     "node_modules/cypress-axe": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/cypress-axe/-/cypress-axe-1.4.0.tgz",
-      "integrity": "sha512-Ut7NKfzjyKm0BEbt2WxuKtLkIXmx6FD2j0RwdvO/Ykl7GmB/qRQkwbKLk3VP35+83hiIr8GKD04PDdrTK5BnyA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/cypress-axe/-/cypress-axe-1.5.0.tgz",
+      "integrity": "sha512-Hy/owCjfj+25KMsecvDgo4fC/781ccL+e8p+UUYoadGVM2ogZF9XIKbiM6KI8Y3cEaSreymdD6ZzccbI2bY0lQ==",
       "dev": true,
       "engines": {
         "node": ">=10"
       },
       "peerDependencies": {
         "axe-core": "^3 || ^4",
-        "cypress": "^10 || ^11 || ^12"
+        "cypress": "^10 || ^11 || ^12 || ^13"
       }
     },
     "node_modules/cypress-mochawesome-reporter": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/cypress-mochawesome-reporter/-/cypress-mochawesome-reporter-3.5.1.tgz",
-      "integrity": "sha512-/5ahFTyTxLujdzfTvmQrzKrJ8GWv12rUbOHvzWfVRYlAp/088ffU/1QbcfacEa2HTs28onSIIBiIKqSOID/bTw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/cypress-mochawesome-reporter/-/cypress-mochawesome-reporter-3.6.0.tgz",
+      "integrity": "sha512-NeYpeZVB5YCU10I3a1yA2qHt+YREo0jZw4Gj83JTJ7YX/ZLFfd8MYKl2O19d/yYC8np/fpMufp5gt3ympd9DWQ==",
       "dev": true,
       "dependencies": {
+        "commander": "^10.0.1",
         "fs-extra": "^10.0.1",
         "mochawesome": "^7.1.3",
         "mochawesome-merge": "^4.2.1",
         "mochawesome-report-generator": "^6.2.0"
+      },
+      "bin": {
+        "generate-mochawesome-report": "cli.js"
       },
       "engines": {
         "node": ">=14"
@@ -702,6 +706,15 @@
       },
       "peerDependencies": {
         "cypress": ">=6.2.0"
+      }
+    },
+    "node_modules/cypress-mochawesome-reporter/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/cypress-mochawesome-reporter/node_modules/fs-extra": {
@@ -719,14 +732,11 @@
       }
     },
     "node_modules/cypress-real-events": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/cypress-real-events/-/cypress-real-events-1.10.0.tgz",
-      "integrity": "sha512-ALSdCiG+Rj3Sl6qooqTFeFGBxOIe8QJUcgIuJ6ZVBanTEijXRzqxqstMC2ZKfixqj1TyNjolyZU4zOoN/jtHpg==",
-      "dependencies": {
-        "prettier": "^3.0.0"
-      },
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/cypress-real-events/-/cypress-real-events-1.10.3.tgz",
+      "integrity": "sha512-YN3fn+CJIAM638sE6uMvv2/n3PsWowdd0rOiN6ZoyezNAMyENfuQHvccLKZpN+apGfQZYetCml6QXLYgDid2fg==",
       "peerDependencies": {
-        "cypress": "^4.x || ^5.x || ^6.x || ^7.x || ^8.x || ^9.x || ^10.x || ^11.x || ^12.x"
+        "cypress": "^4.x || ^5.x || ^6.x || ^7.x || ^8.x || ^9.x || ^10.x || ^11.x || ^12.x || ^13.x"
       }
     },
     "node_modules/dashdash": {
@@ -2305,20 +2315,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/prettier": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.0.tgz",
-      "integrity": "sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
     "node_modules/pretty-bytes": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
@@ -2974,9 +2970,9 @@
       "optional": true
     },
     "@cypress/request": {
-      "version": "2.88.12",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.12.tgz",
-      "integrity": "sha512-tOn+0mDZxASFM+cuAP9szGUGPI1HwWVSvdzm7V4cCsPdFTx6qMj29CwaQmRAMIEhORIUBFBsYROYJcveK4uOjA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.1.tgz",
+      "integrity": "sha512-TWivJlJi8ZDx2wGOw1dbLuHJKUYX7bWySw377nlnGOW3hP9/MUKIsEdXT/YngWxVdgNCHRBmFlBipE+5/2ZZlQ==",
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -2991,7 +2987,7 @@
         "json-stringify-safe": "~5.0.1",
         "mime-types": "~2.1.19",
         "performance-now": "^2.1.0",
-        "qs": "~6.10.3",
+        "qs": "6.10.4",
         "safe-buffer": "^5.1.2",
         "tough-cookie": "^4.1.3",
         "tunnel-agent": "^0.6.0",
@@ -3018,9 +3014,9 @@
       }
     },
     "@types/node": {
-      "version": "16.18.40",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.40.tgz",
-      "integrity": "sha512-+yno3ItTEwGxXiS/75Q/aHaa5srkpnJaH+kdkTVJ3DtJEwv92itpKbxU+FjPoh2m/5G9zmUQfrL4A4C13c+iGA=="
+      "version": "18.17.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.15.tgz",
+      "integrity": "sha512-2yrWpBk32tvV/JAd3HNHWuZn/VDN1P+72hWirHnvsvTGSqbANi+kSeuQR9yAHnbvaBvHDsoTdXV0Fe+iRtHLKA=="
     },
     "@types/sinonjs__fake-timers": {
       "version": "8.1.1",
@@ -3143,9 +3139,9 @@
       "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
     },
     "axe-core": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.7.2.tgz",
-      "integrity": "sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.8.1.tgz",
+      "integrity": "sha512-9l850jDDPnKq48nbad8SiEelCv4OrUWrKab/cPj0GScVg6cb6NbCCt/Ulk26QEq5jP9NnGr04Bit1BHyV6r5CQ==",
       "dev": true
     },
     "balanced-match": {
@@ -3395,13 +3391,13 @@
       }
     },
     "cypress": {
-      "version": "12.17.4",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.17.4.tgz",
-      "integrity": "sha512-gAN8Pmns9MA5eCDFSDJXWKUpaL3IDd89N9TtIupjYnzLSmlpVr+ZR+vb4U/qaMp+lB6tBvAmt7504c3Z4RU5KQ==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.2.0.tgz",
+      "integrity": "sha512-AvDQxBydE771GTq0TR4ZUBvv9m9ffXuB/ueEtpDF/6gOcvFR96amgwSJP16Yhqw6VhmwqspT5nAGzoxxB+D89g==",
       "requires": {
-        "@cypress/request": "2.88.12",
+        "@cypress/request": "^3.0.0",
         "@cypress/xvfb": "^1.2.4",
-        "@types/node": "^16.18.39",
+        "@types/node": "^18.17.5",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.2.0",
@@ -3445,24 +3441,31 @@
       }
     },
     "cypress-axe": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/cypress-axe/-/cypress-axe-1.4.0.tgz",
-      "integrity": "sha512-Ut7NKfzjyKm0BEbt2WxuKtLkIXmx6FD2j0RwdvO/Ykl7GmB/qRQkwbKLk3VP35+83hiIr8GKD04PDdrTK5BnyA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/cypress-axe/-/cypress-axe-1.5.0.tgz",
+      "integrity": "sha512-Hy/owCjfj+25KMsecvDgo4fC/781ccL+e8p+UUYoadGVM2ogZF9XIKbiM6KI8Y3cEaSreymdD6ZzccbI2bY0lQ==",
       "dev": true,
       "requires": {}
     },
     "cypress-mochawesome-reporter": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/cypress-mochawesome-reporter/-/cypress-mochawesome-reporter-3.5.1.tgz",
-      "integrity": "sha512-/5ahFTyTxLujdzfTvmQrzKrJ8GWv12rUbOHvzWfVRYlAp/088ffU/1QbcfacEa2HTs28onSIIBiIKqSOID/bTw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/cypress-mochawesome-reporter/-/cypress-mochawesome-reporter-3.6.0.tgz",
+      "integrity": "sha512-NeYpeZVB5YCU10I3a1yA2qHt+YREo0jZw4Gj83JTJ7YX/ZLFfd8MYKl2O19d/yYC8np/fpMufp5gt3ympd9DWQ==",
       "dev": true,
       "requires": {
+        "commander": "^10.0.1",
         "fs-extra": "^10.0.1",
         "mochawesome": "^7.1.3",
         "mochawesome-merge": "^4.2.1",
         "mochawesome-report-generator": "^6.2.0"
       },
       "dependencies": {
+        "commander": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+          "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+          "dev": true
+        },
         "fs-extra": {
           "version": "10.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -3477,12 +3480,10 @@
       }
     },
     "cypress-real-events": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/cypress-real-events/-/cypress-real-events-1.10.0.tgz",
-      "integrity": "sha512-ALSdCiG+Rj3Sl6qooqTFeFGBxOIe8QJUcgIuJ6ZVBanTEijXRzqxqstMC2ZKfixqj1TyNjolyZU4zOoN/jtHpg==",
-      "requires": {
-        "prettier": "^3.0.0"
-      }
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/cypress-real-events/-/cypress-real-events-1.10.3.tgz",
+      "integrity": "sha512-YN3fn+CJIAM638sE6uMvv2/n3PsWowdd0rOiN6ZoyezNAMyENfuQHvccLKZpN+apGfQZYetCml6QXLYgDid2fg==",
+      "requires": {}
     },
     "dashdash": {
       "version": "1.14.1",
@@ -4640,11 +4641,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="
-    },
-    "prettier": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.0.tgz",
-      "integrity": "sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g=="
     },
     "pretty-bytes": {
       "version": "5.6.0",

--- a/testing/package.json
+++ b/testing/package.json
@@ -4,10 +4,10 @@
   "description": "## Requirements",
   "main": "index.js",
   "devDependencies": {
-    "axe-core": "^4.7.2",
-    "cypress": "^12.17.4",
-    "cypress-axe": "^1.4.0",
-    "cypress-mochawesome-reporter": "^3.5.1"
+    "axe-core": "^4.8.1",
+    "cypress": "^13.2.0",
+    "cypress-axe": "^1.5.0",
+    "cypress-mochawesome-reporter": "^3.6.0"
   },
   "scripts": {
     "cy:open": "cypress open",
@@ -37,6 +37,6 @@
   },
   "homepage": "https://github.com/usagov/vote-gov-drupal#readme",
   "dependencies": {
-    "cypress-real-events": "^1.10.0"
+    "cypress-real-events": "^1.10.3"
   }
 }


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[Vote-302](https://cm-jira.usa.gov/browse/VOTE-302)

## Description

This PR will compete dependabot updates for Cypress and will close out the following PRs
https://github.com/usagov/vote-gov-drupal/pull/376, https://github.com/usagov/vote-gov-drupal/pull/375, https://github.com/usagov/vote-gov-drupal/pull/374, https://github.com/usagov/vote-gov-drupal/pull/369, https://github.com/usagov/vote-gov-drupal/pull/368

## Deployment and testing

### Pre-deploy

n/a

### Post-deploy

n/a

### QA/Test

1. pull down branch 
2. start local 
3. cd into `testing`
4. run `npm install`
5. run the following commands and ensure there are no errors or issues -> `npm run cy:fullTests`, `npm run cy:axe` and `npm run cy:open` and make sure the runner loads and tests run 

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.
- [x] The result of these changes meet the JIRA ticket "definition of done".
- [x] This work meets the project [standards](/usagov/vote-gov-drupal/blob/dev/docs/standards.md).

## Checklist for the Peer Reviewers

- [x] The code has been reviewed.
- [x] The file changes are relevant to the task.
- [x] The author of the commits match the assignee.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps have been successfully completed and the results match "definition of done".
- [x] Drupal database log and browser console log are free of errors.
- [x] There are no known side-effects outside the expected behavior.
- [x] Code is readable and includes appropriate commenting.
