### PR TITLE
VOTE-67 setting site uri used to generate sitemap.xml to always be th…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,7 +157,7 @@ jobs:
             source ./scripts/pipeline/exports.sh ${CIRCLE_BRANCH}
             source ./scripts/pipeline/cloud-gov-login.sh
 
-            cf run-task ${project}-drupal-${CIRCLE_BRANCH} --command "drush --uri=${cms_uri} cron" --name "${project}-${CIRCLE_BRANCH}-cron"  -k "2G" -m 512M
+            cf run-task ${project}-drupal-${CIRCLE_BRANCH} --command "drush --uri=${ssg_uri} cron" --name "${project}-${CIRCLE_BRANCH}-cron"  -k "2G" -m 512M
   php-lint:
     docker:
       - image: php:8.2-alpine

--- a/scripts/build_static
+++ b/scripts/build_static
@@ -22,15 +22,11 @@ export bucket_endpoint=$(echo $VCAP_SERVICES | jq -r '.s3[] | select(.name | str
 
 export ssg_endpoint="https://ssg-${environment}.vote.gov"
 [ "${environment}" = "prod" ] && export ssg_endpoint="https://ssg.vote.gov"
-export cms_endpoint="https://cms-${environment}.vote.gov"
-[ "${environment}" = "prod" ] && export cms_endpoint="https://cms.vote.gov"
 
 cd ${app_path}
 echo "Running 'drush tome:static' in '${environment}'..."
-drush simple-sitemap:generate --uri=${ssg_endpoint}
 drush tome:static --uri=${ssg_endpoint} --process-count=2 --retry-count=0 -y
 drush tome:static-export-path '/sitemap.xml,/sitemap_generator/default/sitemap.xsl' --uri=${ssg_endpoint} --process-count=2 --retry-count=0 -y
-drush simple-sitemap:generate --uri=${cms_endpoint}
 echo "'drush tome:static' task completed!"
 
 echo "Adding missing Core assets vendor directory"

--- a/scripts/pipeline/exports.sh
+++ b/scripts/pipeline/exports.sh
@@ -8,6 +8,7 @@ if [ "${cf_env}" == "prod" ]; then
   export cms_uri=${prod_cms_uri}
   export drupal_instances=${prod_drupal_instances}
   export drupal_memory=${prod_drupal_memory}
+  export ssg_uri=${prod_ssg_uri}
   export sso_x509_cert=${prod_sso_x509_cert}
   export waf_name=${prod_waf_name}
   export waf_external_endpoint=${prod_waf_external_endpoint}
@@ -16,6 +17,7 @@ elif [ "${cf_env}" == "stage" ]; then
   export cms_uri=${stage_cms_uri}
   export drupal_instances=${stage_drupal_instances}
   export drupal_memory=${stage_drupal_memory}
+  export ssg_uri=${stage_ssg_uri}
   export sso_x509_cert=${stage_sso_x509_cert}
   export waf_name=${stage_waf_name}
   export waf_external_endpoint=${stage_waf_external_endpoint}
@@ -24,6 +26,7 @@ elif [ "${cf_env}" == "test" ]; then
   export cms_uri=${test_cms_uri}
   export drupal_memory=${test_drupal_memory}
   export drupal_instances=${test_drupal_instances}
+  export ssg_uri=${test_ssg_uri}
   export sso_x509_cert=${test_sso_x509_cert}
   export waf_name=${test_waf_name}
   export waf_external_endpoint=${test_waf_external_endpoint}
@@ -33,6 +36,7 @@ elif [ "${cf_env}" == "dev" ]; then
   export cms_uri=${dev_cms_uri}
   export drupal_instances=${dev_drupal_instances}
   export drupal_memory=${dev_drupal_memory}
+  export ssg_uri=${dev_ssg_uri}
   export sso_x509_cert=${dev_sso_x509_cert}
   export waf_name=${dev_waf_name}
   export waf_external_endpoint=${dev_waf_external_endpoint}


### PR DESCRIPTION


## Jira ticket

https://cm-jira.usa.gov/browse/VOTE-67

## Description

Investigate and resolve sitemap.xml domain error on the generated static site by making the static site URI the only one generating a sitemap.xml

## Deployment and testing

### Pre-deploy

1. Terraform changes need to be applied before merging to environments past dev once dev is confirmed working. 


### QA/Test

1. Allow deploy pipeline to complete and check the status of the sitemap.xml.

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.
- [x] The result of these changes meet the JIRA ticket "definition of done".
- [x] This work meets the project [standards](/usagov/vote-gov-drupal/blob/dev/docs/standards.md).

## Checklist for the Peer Reviewers

- [x] The code has been reviewed.
- [x] The file changes are relevant to the task.
- [x] The author of the commits match the assignee.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps have been successfully completed and the results match "definition of done".
- [x] Drupal database log and browser console log are free of errors.
- [x] There are no known side-effects outside the expected behavior.
- [x] Code is readable and includes appropriate commenting.
