### PR TITLE
Bug/vote 293/nv font lang switcher

### DIFF
--- a/web/themes/custom/vote_gov/php-includes/preprocess.inc
+++ b/web/themes/custom/vote_gov/php-includes/preprocess.inc
@@ -63,8 +63,8 @@ function vote_gov_preprocess_links__language_block(&$variables) {
     // Append the english language name after the translated one
     // if they are unique.
     if (isset($languages[$i])
-        && $variables['links'][$i]['link']['#title'] != $languages[$i]->getName()) {
-        $variables['links'][$i]['link']['#english'] = "({$languages[$i]->getName()})";
+      && $variables['links'][$i]['link']['#title'] != $languages[$i]->getName()) {
+      $variables['links'][$i]['link']['#english'] = "({$languages[$i]->getName()})";
     }
   }
 }

--- a/web/themes/custom/vote_gov/php-includes/preprocess.inc
+++ b/web/themes/custom/vote_gov/php-includes/preprocess.inc
@@ -64,13 +64,7 @@ function vote_gov_preprocess_links__language_block(&$variables) {
     // if they are unique.
     if (isset($languages[$i])
         && $variables['links'][$i]['link']['#title'] != $languages[$i]->getName()) {
-      if ($variables['language'] == "nv") {
-        $getName = str_replace("-", "", $languages[$i]->getName());
-        $variables['links'][$i]['link']['#title'] .= " <{$getName}>";
-      }
-      else {
         $variables['links'][$i]['link']['#english'] = "({$languages[$i]->getName()})";
-      }
     }
   }
 }

--- a/web/themes/custom/vote_gov/src/sass/pages/_index.scss
+++ b/web/themes/custom/vote_gov/src/sass/pages/_index.scss
@@ -2,4 +2,3 @@
 @forward "homepage";
 @forward "state-page";
 @forward "sitemap";
-

--- a/web/themes/custom/vote_gov/src/sass/uswds-overrides/_override-usa-alert.scss
+++ b/web/themes/custom/vote_gov/src/sass/uswds-overrides/_override-usa-alert.scss
@@ -23,7 +23,6 @@
 [dir="rtl"] .usa-alert--info {
   .grid-container {
     background-position: calc(100% - 1rem) 1rem;
-
   }
 }
 

--- a/web/themes/custom/vote_gov/src/sass/uswds-overrides/_override-usa-language-selector.scss
+++ b/web/themes/custom/vote_gov/src/sass/uswds-overrides/_override-usa-language-selector.scss
@@ -31,6 +31,10 @@
 .usa-language__submenu-item {
   padding: 4px 8px;
   border: unset;
+
+  * {
+    font-family: "Source Sans Pro Web", "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif;
+  }
 }
 
 .switcher-desktop {


### PR DESCRIPTION
## Jira ticket

[VOTE-293](https://cm-jira.usa.gov/browse/VOTE-293)

## Description

Remove the Navajo font from the language dropdown, so that all the language names display correctly.

## Deployment and testing

### Pre-deploy

1. lando retune
2. Might have to rebuild the vote theme folder 

### Post-deploy
1. Sign into the CMS (hidden languages will not show up without signing in)

### QA/Test

1. Navigate to http://vote-gov.lndo.site/nv
2. Click the language dropdown and confirm each language uses the default site font (not the Navajo font)
3. Repeat for tablet and mobile screen size

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.
- [ ] The result of these changes meet the JIRA ticket "definition of done".
- [ ] This work meets the project [standards](/usagov/vote-gov-drupal/blob/dev/docs/standards.md).

## Checklist for the Peer Reviewers

- [ ] The code has been reviewed.
- [ ] The file changes are relevant to the task.
- [ ] The author of the commits match the assignee.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps have been successfully completed and the results match "definition of done".
- [ ] Drupal database log and browser console log are free of errors.
- [ ] There are no known side-effects outside the expected behavior.
- [ ] Code is readable and includes appropriate commenting.
