### PR TITLE
VOTE-337 Fix font-weight inconsistencies

### DIFF
--- a/web/themes/custom/vote_gov/src/sass/drupal-system/form.scss
+++ b/web/themes/custom/vote_gov/src/sass/drupal-system/form.scss
@@ -11,8 +11,8 @@ legend,
 legend > span,
 label,
 .usa-label {
-  @include u-text('primary-dark');
-  font-weight: font-weight("bold");
+  //@include u-text('primary-dark');
+  //font-weight: font-weight("bold");
 }
 
 .usa-fieldset {

--- a/web/themes/custom/vote_gov/src/sass/uswds-overrides/_override-usa-form.scss
+++ b/web/themes/custom/vote_gov/src/sass/uswds-overrides/_override-usa-form.scss
@@ -1,4 +1,3 @@
-p,
 label#emailsub,
 .registered-resources li,
 .updated-date {


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

https://cm-jira.usa.gov/browse/VOTE-337

## Description

Font font-weight difference on the CMS.

## Deployment and testing

### Post-deploy

1. cd into vote_gov theme and run `npm run build`
2. run `lando drush cr`

### QA/Test

1. visit `/accessibility` and make sure the form labels weight matches what is on staging.vote.gov

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.
- [x] The result of these changes meet the JIRA ticket "definition of done".
- [x] This work meets the project [standards](/usagov/vote-gov-drupal/blob/dev/docs/standards.md).

## Checklist for the Peer Reviewers

- [x] The code has been reviewed.
- [x] The file changes are relevant to the task.
- [x] The author of the commits match the assignee.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps have been successfully completed and the results match "definition of done".
- [x] Drupal database log and browser console log are free of errors.
- [x] There are no known side-effects outside the expected behavior.
- [x] Code is readable and includes appropriate commenting.
