### PR TITLE
VOTE-349: fix mismatching visible label and accessible name

### DIFF
--- a/web/themes/custom/vote_gov/img/ballot_box-blue.svg
+++ b/web/themes/custom/vote_gov/img/ballot_box-blue.svg
@@ -1,5 +1,5 @@
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 170 210" enable-background="new 0 0 170 210" xml:space="preserve" role="img" aria-labelledby="vote-gov-title">
+	 viewBox="0 0 170 210" enable-background="new 0 0 170 210" xml:space="preserve" role="img" aria-labelledby="logo-sitename">
 	 <title id="vote-gov-title">Vote.gov</title>
 <polygon fill="#112E51" points="26.6,131.1 10.8,156 82.4,203.1 154,156 138.2,131.1 "/>
 <polygon fill="#0071BC" points="82.4,17.1 14,61.5 14,151.3 82.4,196.3 150.7,151.3 150.7,61.5 "/>

--- a/web/themes/custom/vote_gov/templates/partial/site-logo.html.twig
+++ b/web/themes/custom/vote_gov/templates/partial/site-logo.html.twig
@@ -1,5 +1,5 @@
 {% set logo_sitename = language != 'en' ? '@sitename in language' | t({ '@sitename': sitename }) | render : sitename %}
 <a class="site-logo" href="{{ '/' ~ (language != 'en' ? language) }}" aria-label="{{ logo_sitename | t }}">
-<div class="logo-text" data-test="vote-logo">{{ logo_sitename }}</div>
+<div class="logo-text" data-test="vote-logo" id="logo-sitename">{{ logo_sitename }}</div>
 <div id="SiteLogo">{{ source( directory ~ '/img/ballot_box-blue.svg' ) }}</div>
 </a>


### PR DESCRIPTION
[VOTE-349](https://cm-jira.usa.gov/browse/VOTE-349)

## Description

Issue is fixed by pointing the main logo svg aria-labelledby to the correct matching id

## Deployment and testing

### Pre-deploy

1. lando retune

### Post-deploy

1. ANDI testing

### QA/Test

1. Check that the exposed label of the large Vote.gov logo matches the accessible name given to it (Ex. Vote en Espanol should match Vote en Espanol)

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
