### PR TITLE
VOTE-350: make ballot box in footer decorative

### DIFF
--- a/web/themes/custom/vote_gov/templates/partial/footer-contact.html.twig
+++ b/web/themes/custom/vote_gov/templates/partial/footer-contact.html.twig
@@ -3,13 +3,13 @@
     <div class="grid-row">
       <div class="tablet:grid-col-auto">
         <div class="vote-txt">{{ 'Vote.gov' | t }}</div>
-        <img class="vote-logo" loading="lazy" width="130" height="160" src="{{ theme_path }}/img/ballot_box-blue.svg">
+        <img class="vote-logo" loading="lazy" width="130" height="160" src="{{ theme_path }}/img/ballot_box-blue.svg" alt="" />
     </div>
 
       <div class="tablet:grid-col-auto partnership-txt">{{ 'in partnership with' | t }}</div>
       <div class="tablet:grid-col-auto eac-container">
         <a href="{{ language == 'es' ? 'https://www.eac.gov/translations/spanish' : 'https://www.eac.gov/' }}" target="_blank">
-          <img class="eac-logo" width="146" height="48" src="{{ theme_path }}/img/eac-logo.webp" alt="{{ 'U.S. Election Assistance Commission logo which indicates a partnership with Vote.gov' | t }}">
+          <img class="eac-logo" width="146" height="48" src="{{ theme_path }}/img/eac-logo.webp" alt="{{ 'U.S. Election Assistance Commission logo which indicates a partnership with Vote.gov' | t }}" />
         </a>
       </div>
       <div class="tablet:grid-col"></div>

--- a/web/themes/custom/vote_gov/templates/partial/footer-contact.html.twig
+++ b/web/themes/custom/vote_gov/templates/partial/footer-contact.html.twig
@@ -3,7 +3,7 @@
     <div class="grid-row">
       <div class="tablet:grid-col-auto">
         <div class="vote-txt">{{ 'Vote.gov' | t }}</div>
-        <img class="vote-logo" loading="lazy" width="130" height="160" src="{{ theme_path }}/img/ballot_box-blue.svg" alt="{{ 'Illustration of voter box with checked ballot being inserted to indicate voting action' | t }}" aria-label="Vote.gov">
+        <img class="vote-logo" loading="lazy" width="130" height="160" src="{{ theme_path }}/img/ballot_box-blue.svg">
     </div>
 
       <div class="tablet:grid-col-auto partnership-txt">{{ 'in partnership with' | t }}</div>


### PR DESCRIPTION
[VOTE-350](https://cm-jira.usa.gov/browse/VOTE-350)

## Description

Remove alt text and aria labels from vote.gov logo in the footer so it is treated as decorative

## Deployment and testing

### Pre-deploy

1. Lando retune

### Post-deploy

1. ANDI testing

### QA/Test

1. Confirm tabbing and screen readers ignore the Vote.gov logo in footer

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
