### PR TITLE
Vote-411 -> Bug fix on French Accessibility Page

### DIFF
--- a/web/themes/custom/vote_gov/templates/content/page-title.html.twig
+++ b/web/themes/custom/vote_gov/templates/content/page-title.html.twig
@@ -12,10 +12,10 @@
  *   displayed after the main title tag that appears in the template.
  */
 #}
-{% set title = title | render | striptags | trim %}
 {% set node_type = currentnode.bundle() %}
 
 {% if node_type == "state_territory" %}
+  {% set title = title | render | striptags | trim %}
   {% if language == 'ko' and currentnode.field_is_state.value %}
     {% set korean_state_char = "state" | t %}
     {% set title = title ~ " " ~ korean_state_char %}


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[Vote-411](https://cm-jira.usa.gov/browse/VOTE-411)

## Description

This PR will fix the French title on the accessibility page that was rendering an HTML entity instead of `'`.  

before:
<img width="1009" alt="Screenshot 2023-10-25 at 2 19 23 PM" src="https://github.com/usagov/vote-gov-drupal/assets/88721460/6cd6608e-0949-496f-ab0b-aabd70a733be">

after:
<img width="860" alt="Screenshot 2023-10-26 at 10 58 29 AM" src="https://github.com/usagov/vote-gov-drupal/assets/88721460/2fd3f19f-f30a-4403-866c-cb075de8be61">

## Deployment and testing

### Pre-deploy

n/a

### Post-deploy

n/a

### QA/Test

1. pull down branch 
2. run `lando rebuild -y`
3. visit `http://vote-gov.lndo.site/fr/accessibility` and verify that the title does not include the HTML entity `&#039;`
4. also spot check other pages and translations to ensure that the fix did not break any other strings  

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
