### PR TITLE
VOTE-574 prepopulate nvrf fields

### DIFF
--- a/web/modules/custom/vote_state_nvrf_fields/vote_state_nvrf_fields.info.yml
+++ b/web/modules/custom/vote_state_nvrf_fields/vote_state_nvrf_fields.info.yml
@@ -1,0 +1,5 @@
+name: 'Vote state nvrf fields'
+type: module
+description: 'presave action'
+core_version_requirement: ^9 || ^10
+package: Custom

--- a/web/modules/custom/vote_state_nvrf_fields/vote_state_nvrf_fields.module
+++ b/web/modules/custom/vote_state_nvrf_fields/vote_state_nvrf_fields.module
@@ -1,0 +1,22 @@
+<?php
+
+use Drupal\Core\Entity\EntityInterface;
+
+/*
+ * Implements hook_ENTITY_TYPE_presave().
+ */
+function vote_state_nvrf_fields_node_presave(EntityInterface $entity) {
+  if ($entity->bundle() === 'state_territory' && $entity->language()->getId() == 'en') {
+    $values_array = [];
+    // Exclude these terms. They are not relevant to states.
+    $excluded_terms = [1, 7, 21, 22, 23, 33, 41, 42];
+
+    for ($i = 1; $i <= 42; $i++) {
+      if (!in_array($i, $excluded_terms)) {
+        $values_array[] = ['nvrf_field' => $i, 'required' => 1];
+      }
+    }
+
+    $entity->set('field_nvrf_fields', $values_array);
+  }
+}


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

https://cm-jira.usa.gov/browse/VOTE-574

## Description

Add a temporary module to prepopulate nvrf fields per state on save

## Deployment and testing

### Post-deploy

1. enable vote_state_nvrf_fields module

### QA/Test

1. edit Alabama English node and save
2. edit again and check to make sure the "nvrf fields" field is populated


## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
