### PR TITLE
VOTE-755 update content manager permissions to include access to admi…

### DIFF
--- a/config/sync/user.role.content_manager.yml
+++ b/config/sync/user.role.content_manager.yml
@@ -21,6 +21,7 @@ dependencies:
     - node.type.page
     - node.type.state_territory
     - node.type.voter_guide
+    - taxonomy.vocabulary.basics_modules
     - taxonomy.vocabulary.nvrf_field
     - workflows.workflow.publishing_content
   module:
@@ -41,6 +42,7 @@ label: 'Content Manager'
 weight: 3
 is_admin: null
 permissions:
+  - 'access administration pages'
   - 'access block library'
   - 'access content overview'
   - 'access files overview'
@@ -62,6 +64,7 @@ permissions:
   - 'create remote_video media'
   - 'create sitewide_alert block content'
   - 'create state_territory content'
+  - 'create terms in basics_modules'
   - 'create terms in nvrf_field'
   - 'create voter_guide content'
   - 'delete all revisions'
@@ -93,6 +96,7 @@ permissions:
   - 'delete own voter_guide content'
   - 'delete page revisions'
   - 'delete state_territory revisions'
+  - 'delete terms in basics_modules'
   - 'delete terms in nvrf_field'
   - 'delete voter_guide revisions'
   - 'edit any audio media'
@@ -122,6 +126,7 @@ permissions:
   - 'edit own remote_video media'
   - 'edit own state_territory content'
   - 'edit own voter_guide content'
+  - 'edit terms in basics_modules'
   - 'edit terms in nvrf_field'
   - 'mark as hidden in editoria11y'
   - 'revert all revisions'


### PR DESCRIPTION
…nstrative pages and new taxonomy vocab

<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

https://cm-jira.usa.gov/browse/VOTE-755

## Description

Add permissions for Content Manager to access admin pages and new taxonomy vocab

## Deployment and testing

### Post-deploy

1. `lando retune`

### QA/Test

1. Create a new account user/pass with a Content Manager role
2. Go to http://vote-gov.lndo.site/user/login and log in as that account
3. Check the admin toolbar to confirm that you can access the Structure > Taxonomy page and click to go
4. Add a new term under the Basics Modules vocabulary and confirm you can save

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
