### PR TITLE
VOTE-801 remove duplicate subtitle displaying on voter guide detail page

### DIFF
--- a/config/sync/core.entity_view_display.node.voter_guide.full.yml
+++ b/config/sync/core.entity_view_display.node.voter_guide.full.yml
@@ -22,12 +22,7 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 2
-    region: content
-  content_moderation_control:
-    settings: {  }
-    third_party_settings: {  }
-    weight: -20
+    weight: 0
     region: content
   field_basics_block:
     type: entity_reference_revisions_entity_view
@@ -36,16 +31,11 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 3
-    region: content
-  field_subtitle:
-    type: text_default
-    label: hidden
-    settings: {  }
-    third_party_settings: {  }
     weight: 1
     region: content
 hidden:
+  content_moderation_control: true
+  field_subtitle: true
   langcode: true
   links: true
   published_at: true


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

https://cm-jira.usa.gov/browse/VOTE-801

## Description

remove duplicate subtitle displaying on voter guide detail page

## Deployment and testing

### Post-deploy

1. run `lando retune`

### QA/Test

NOTE: make sure you have the latest DB imported
1. visit http://vote-gov.lndo.site/node/add/voter_guide and create a new voter guide with a subtitle field
2. Confirm that when you view the page the subtitle isn't showing twice.

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
