### PR TITLE
VOTE-727: change verbosity of backup pipeline output, remove checking…

### DIFF
--- a/scripts/download_backup.sh
+++ b/scripts/download_backup.sh
@@ -70,13 +70,11 @@ RED='\033[0;31m'
 NC='\033[0m'
 
 while getopts 'b:e:s:d:' flag; do
-  case "${flag}" in
+  case ${flag} in
     b) backup_bucket=${OPTARG} ;;
     e) env=${OPTARG} ;;
     s) space=${OPTARG} ;;
-    d) retrieve_date=${OPTARG}
-      [[ $retrieve_date = "latest" || $(${date_command} --date "$retrieve_date" +%s) -ge $(${date_command} --date "15 days ago" +%s) ]] || help && echo -e "\n${RED}Error: Not acceptable -d option.${NC}" && exit 1
-      ;;
+    d) retrieve_date=${OPTARG} ;;
     *) help && exit 1 ;;
   esac
 done


### PR DESCRIPTION
… for retrieval script

<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[VOTE-727](https://cm-jira.usa.gov/browse/VOTE-727)

## Description

Change verbosity for backup pipeline output for more indication of what is failing/succeeding. Remove checking for backup retrieval script -d flag.

## Deployment and testing

### QA/Test

1. Allow scheduled backup to run.
2. Verify output in pipeline for scheduled backup is more but not too much.
3. Verify backup retrieval script can be used for created backup.

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
