### PR TITLE
VOTE-775: Remove install_profile setting as it is no longer used.

### DIFF
--- a/web/sites/default/settings.cloudgov.php
+++ b/web/sites/default/settings.cloudgov.php
@@ -18,7 +18,6 @@ $s3_proxy_path_cms = getenv('S3_PROXY_PATH_CMS') ?: '/s3/files';
 $settings['tome_static_directory'] = dirname(DRUPAL_ROOT) . '/html';
 $settings['config_sync_directory'] = dirname(DRUPAL_ROOT) . '/config/sync';
 $settings['file_private_path'] = dirname(DRUPAL_ROOT) . '/private';
-$settings['install_profile'] = 'minimal';
 
 $settings['tome_static_path_exclude'] = [
   '/saml', '/saml/acs', '/saml/login', '/saml/logout', '/saml/metadata', '/saml/sls',


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[VOTE-775](https://cm-jira.usa.gov/browse/VOTE-775)

## Description

Remove deprecated setting for install_profile.

## Deployment and testing

### Pre-deploy

n/a

### Post-deploy

1. Locally run `lando retune`

### QA/Test

1. Login as an administrator.
2. Go to admin Status page and confirm that there isn't a warning about "Install profile in settings" listed.

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
