### PR TITLE
VOTE-961 allow class attr on h2 in basic_html format

### DIFF
--- a/config/sync/editor.editor.basic_html.yml
+++ b/config/sync/editor.editor.basic_html.yml
@@ -51,7 +51,7 @@ settings:
     ckeditor5_sourceEditing:
       allowed_tags:
         - '<div id class data-allow-multiple>'
-        - '<h2 id>'
+        - '<h2 id class>'
         - '<h3 class>'
         - '<button type class aria-expanded aria-controls>'
         - '<ul class>'

--- a/config/sync/filter.format.basic_html.yml
+++ b/config/sync/filter.format.basic_html.yml
@@ -27,7 +27,7 @@ filters:
     status: true
     weight: -10
     settings:
-      allowed_html: '<br> <p class="usa-intro text-align-left text-align-center text-align-right"> <h2 id class="text-align-left text-align-center text-align-right"> <h3 class> <h4 class="text-align-left text-align-center text-align-right"> <h5 class="text-align-left text-align-center text-align-right"> <h6 class="text-align-left text-align-center text-align-right"> <a class href aria-label title target="_blank" rel> <div id class data-allow-multiple> <button type class aria-expanded aria-controls> <strong> <em> <u> <ul class> <ol> <li class> <hr> <img src alt height width> <drupal-media data-entity-type data-entity-uuid alt data-align> <embedded-content data-plugin-config data-plugin-id>'
+      allowed_html: '<br> <p class="usa-intro text-align-left text-align-center text-align-right"> <h2 id class> <h3 class> <h4 class="text-align-left text-align-center text-align-right"> <h5 class="text-align-left text-align-center text-align-right"> <h6 class="text-align-left text-align-center text-align-right"> <a class href aria-label title target="_blank" rel> <div id class data-allow-multiple> <button type class aria-expanded aria-controls> <strong> <em> <u> <ul class> <ol> <li class> <hr> <img src alt height width> <drupal-media data-entity-type data-entity-uuid alt data-align> <embedded-content data-plugin-config data-plugin-id>'
       filter_html_help: true
       filter_html_nofollow: false
   media_embed:


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

https://cm-jira.usa.gov/browse/VOTE-961

## Description

Allow class on h2s in WYSIWYG when using basic html format

## Deployment and testing

### Post-deploy

1. run `lando retune`

### QA/Test

1. visit http://vote-gov.lndo.site/node/3/edit and edit the source of wysiwyg to add a class on an h2 tag of `heading--red-underline`
2. save and view the page and make sure it has a red underline style.

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
