### PR TITLE
Vote-1008: Adding override to alert component

### DIFF
--- a/web/themes/custom/votegov/src/sass/uswds-overrides/_index.scss
+++ b/web/themes/custom/votegov/src/sass/uswds-overrides/_index.scss
@@ -17,3 +17,4 @@
 @forward "usa-sidenav";
 @forward "usa-nav";
 @forward "usa-contact-identifier";
+@forward "usa-alert.scss"

--- a/web/themes/custom/votegov/src/sass/uswds-overrides/_index.scss
+++ b/web/themes/custom/votegov/src/sass/uswds-overrides/_index.scss
@@ -17,4 +17,4 @@
 @forward "usa-sidenav";
 @forward "usa-nav";
 @forward "usa-contact-identifier";
-@forward "usa-alert.scss"
+@forward "usa-alert"

--- a/web/themes/custom/votegov/src/sass/uswds-overrides/usa-alert.scss
+++ b/web/themes/custom/votegov/src/sass/uswds-overrides/usa-alert.scss
@@ -2,22 +2,12 @@
 @use "variables" as *;
 @use "mixins" as *;
 
-// styling for inline alerts
-.usa-alert .usa-alert__body {
+.usa-alert .usa-alert__body, .usa-site-alert .usa-alert .usa-alert__body {
   @include u-padding-y(2);
   @include u-padding-x(8);
 
   &:before {
-  left: 1.5rem;
+    left: 1.5rem;
   }
-  }
+}
 
-// styling for site wide alerts
-.usa-site-alert .usa-alert .usa-alert__body {
-  @include u-padding-y(2);
-  @include u-padding-x(8);
-
-  &:before {
-  left: 1.5rem;
-  }
-  }

--- a/web/themes/custom/votegov/src/sass/uswds-overrides/usa-alert.scss
+++ b/web/themes/custom/votegov/src/sass/uswds-overrides/usa-alert.scss
@@ -2,7 +2,7 @@
 @use "variables" as *;
 @use "mixins" as *;
 
-.usa-alert--warning .usa-alert__body {
+.usa-alert .usa-alert__body {
   @include u-padding-x(8);
 
   &:before {

--- a/web/themes/custom/votegov/src/sass/uswds-overrides/usa-alert.scss
+++ b/web/themes/custom/votegov/src/sass/uswds-overrides/usa-alert.scss
@@ -1,0 +1,11 @@
+@use "uswds-core" as *;
+@use "variables" as *;
+@use "mixins" as *;
+
+.usa-alert--warning .usa-alert__body {
+  @include u-padding-x(8);
+
+  &:before {
+    left: 1.5rem;
+  }
+}

--- a/web/themes/custom/votegov/src/sass/uswds-overrides/usa-alert.scss
+++ b/web/themes/custom/votegov/src/sass/uswds-overrides/usa-alert.scss
@@ -3,9 +3,10 @@
 @use "mixins" as *;
 
 .usa-alert .usa-alert__body {
-  @include u-padding-x(8);
-
+  @include u-padding(2);
+  padding-left: 4rem;
+  
   &:before {
-    left: 1.5rem;
+  left: 1.5rem;
   }
-}
+  }

--- a/web/themes/custom/votegov/src/sass/uswds-overrides/usa-alert.scss
+++ b/web/themes/custom/votegov/src/sass/uswds-overrides/usa-alert.scss
@@ -2,10 +2,21 @@
 @use "variables" as *;
 @use "mixins" as *;
 
+// styling for inline alerts
 .usa-alert .usa-alert__body {
-  @include u-padding(2);
-  padding-left: 4rem;
-  
+  @include u-padding-y(2);
+  @include u-padding-x(8);
+
+  &:before {
+  left: 1.5rem;
+  }
+  }
+
+// styling for site wide alerts
+.usa-site-alert .usa-alert .usa-alert__body {
+  @include u-padding-y(2);
+  @include u-padding-x(8);
+
   &:before {
   left: 1.5rem;
   }


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[Vote-1008](https://cm-jira.usa.gov/browse/VOTE-1008)

## Description

There seems to be an override style within the uswds package that was causing the extra padding.  I have added a local override to match the same styles as what is expected from the USWDS component page. 

I have also added override to the sitewide alert and class both overrides will live in the same file.

## Deployment and testing

### Pre-deploy

`lando retune`

### Post-deploy

n/a

### QA/Test

1. Pull down the branch and cd into the `votegov` theme 
2. Run `npm run build`
3. Visit `/user/login` and verify that the alert matches the [alert commponent](https://designsystem.digital.gov/components/alert/) on the uswds page
4. Can also visit `/admin/content/block/12?destination=/admin/content/block` and open the source code and adjust the `--warning` flag for `--info` and `--success` to verify that fix is constant across alerts 
5. Inspect and compare the log-in and site-wide alert to the USWDS component... should have a 64 padding on left/right and 16 padding on top/bottom

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
