### PR TITLE
Vote-1036: Update to email button

### DIFF
--- a/web/themes/custom/votegov/templates/block/block-content--email-signup.html.twig
+++ b/web/themes/custom/votegov/templates/block/block-content--email-signup.html.twig
@@ -6,9 +6,9 @@
   <label class="usa-label" for="email" id="emailsub">
     {{ content.field_email_field_label | field_value }}
   </label>
-  <form class="usa-form" action="{{ content.field_link | field_value }}" method="get">
+  <form class="usa-form" target="_blank" action="{{ content.field_link | field_value }}" method="get">
     <input id="email" name="email" type="email" class="usa-input max-width-input" data-test="email-signup"/>
-    <button class="usa-button max-width-input" id="user-submit" type="submit">
+    <button class="usa-button max-width-input usa-link--external" id="user-submit" type="submit">
       {{ content.field_signup_button_label | field_value }}
     </button>
   </form>

--- a/web/themes/custom/votegov/templates/block/block-content--email-signup.html.twig
+++ b/web/themes/custom/votegov/templates/block/block-content--email-signup.html.twig
@@ -8,7 +8,7 @@
   </label>
   <form class="usa-form" target="_blank" action="{{ content.field_link | field_value }}" method="get">
     <input id="email" name="email" type="email" class="usa-input max-width-input" data-test="email-signup"/>
-    <button class="usa-button max-width-input usa-link--external" id="user-submit" type="submit">
+    <button class="usa-button max-width-input" id="user-submit" type="submit">
       {{ content.field_signup_button_label | field_value }}
     </button>
   </form>


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[Vote-1036](https://cm-jira.usa.gov/browse/VOTE-1036)

## Description

Adding `target="_blank"` to the form to open sign up page in a new tab

## Deployment and testing

### Pre-deploy

n/a

### Post-deploy

n/a

### QA/Test

1. run `lando retune`
2. visit local and scroll to the usa.gov email sign up field... enter an email and hit signup and verify that you are taken to a new page and email that was entered is present as well

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
