### PR TITLE
VOTE-383: Add sandbox attribute to gtm iframe embed snippet.

### DIFF
--- a/web/themes/custom/vote_gov/templates/layout/html.html.twig
+++ b/web/themes/custom/vote_gov/templates/layout/html.html.twig
@@ -57,7 +57,7 @@
 {% if not logged_in %}
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TDRBDKS"
-                  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+                  sandbox height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
 {% endif %}
 {#


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[VOTE-383](https://cm-jira.usa.gov/browse/VOTE-383)

## Description

Resolve security scan issue with iframe embed for Google Tag Manager.

## Deployment and testing

### Pre-deploy

N/A

### Post-deploy

N/A

### QA/Test

1. Locally, run `lando retune`
2. Load the site, inspect the source code, and confirm that the <iframe> tag for googletagmanager includes a 'sandbox' attribute.

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
