### PR TITLE
VOTE-1064 basics block dynamic headings

### DIFF
--- a/web/themes/custom/votegov/templates/taxonomy/taxonomy-term--basics-modules.html.twig
+++ b/web/themes/custom/votegov/templates/taxonomy/taxonomy-term--basics-modules.html.twig
@@ -10,7 +10,8 @@
   {% set attributes = attributes.setAttribute('id', anchor) %}
 {% endif %}
 
-{% set heading_level = term._referringItem.parent.parent.entity.field_heading.value ? '3' : '2' %}
+{% set paragraph_parent = drupal_entity('paragraph', '30', 'default') %}
+{% set heading_level = paragraph_parent['#paragraph'].field_heading.value ? '3' : '2' %}
 
 {% block content %}
   <h{{heading_level}} class="heading--red-underline">{{ content.field_heading | field_value }}</h{{heading_level}}>

--- a/web/themes/custom/votegov/templates/taxonomy/taxonomy-term--basics-modules.html.twig
+++ b/web/themes/custom/votegov/templates/taxonomy/taxonomy-term--basics-modules.html.twig
@@ -10,7 +10,8 @@
   {% set attributes = attributes.setAttribute('id', anchor) %}
 {% endif %}
 
-{% set paragraph_parent = drupal_entity('paragraph', '30', 'default') %}
+{% set id = term._referringItem.parent.parent.entity.id.value %}
+{% set paragraph_parent = drupal_entity('paragraph', id , 'default') %}
 {% set heading_level = paragraph_parent['#paragraph'].field_heading.value ? '3' : '2' %}
 
 {% block content %}

--- a/web/themes/custom/votegov/templates/taxonomy/taxonomy-term--basics-modules.html.twig
+++ b/web/themes/custom/votegov/templates/taxonomy/taxonomy-term--basics-modules.html.twig
@@ -12,9 +12,9 @@
 
 {% set id = term._referringItem.parent.parent.entity.id.value %}
 {% set paragraph_parent = drupal_entity('paragraph', id , 'default') %}
-{% set heading_level = paragraph_parent['#paragraph'].field_heading.value ? '3' : '2' %}
+{% set heading_level = paragraph_parent['#paragraph'].field_heading.value ? 'h3' : 'h2' %}
 
 {% block content %}
-  <h{{heading_level}} class="heading--red-underline">{{ content.field_heading | field_value }}</h{{heading_level}}>
+  <{{heading_level | default('h2')}} class="heading--red-underline">{{ content.field_heading | field_value }}</{{heading_level}}>
   {{ content.field_content | field_value }}
 {% endblock %}

--- a/web/themes/custom/votegov/templates/taxonomy/taxonomy-term--basics-modules.html.twig
+++ b/web/themes/custom/votegov/templates/taxonomy/taxonomy-term--basics-modules.html.twig
@@ -4,8 +4,8 @@
  * Default theme implementation to display a taxonomy term: Basics Modules.
  */
 #}
-{% set heading_level = '2' %}
 {% extends '@bixaluswds/taxonomy/taxonomy-term.html.twig' %}
+{% set heading_level = term._referringItem.parent.parent.entity.field_heading.value ? '3' : '2' %}
 
 {% block content %}
   <h{{heading_level}} class="heading--red-underline">{{ content.field_heading | field_value }}</h{{heading_level}}>

--- a/web/themes/custom/votegov/templates/taxonomy/taxonomy-term--basics-modules.html.twig
+++ b/web/themes/custom/votegov/templates/taxonomy/taxonomy-term--basics-modules.html.twig
@@ -10,6 +10,8 @@
   {% set attributes = attributes.setAttribute('id', anchor) %}
 {% endif %}
 
+{% set heading_level = term._referringItem.parent.parent.entity.field_heading.value ? '3' : '2' %}
+
 {% block content %}
   <h{{heading_level}} class="heading--red-underline">{{ content.field_heading | field_value }}</h{{heading_level}}>
   {{ content.field_content | field_value }}

--- a/web/themes/custom/votegov/templates/taxonomy/taxonomy-term--basics-modules.html.twig
+++ b/web/themes/custom/votegov/templates/taxonomy/taxonomy-term--basics-modules.html.twig
@@ -10,8 +10,11 @@
   {% set attributes = attributes.setAttribute('id', anchor) %}
 {% endif %}
 
+{# Gather the id of the parent paragraph #}
 {% set id = term._referringItem.parent.parent.entity.id.value %}
+{# Load the parent paragraph object #}
 {% set paragraph_parent = drupal_entity('paragraph', id , 'default') %}
+{# Set the heading level based on the value of the header in the parent paragraph #}
 {% set heading_level = paragraph_parent['#paragraph'].field_heading.value ? 'h3' : 'h2' %}
 
 {% block content %}

--- a/web/themes/custom/votegov/templates/taxonomy/taxonomy-term--basics-modules.html.twig
+++ b/web/themes/custom/votegov/templates/taxonomy/taxonomy-term--basics-modules.html.twig
@@ -4,10 +4,10 @@
  * Default theme implementation to display a taxonomy term: Basics Modules.
  */
 #}
-
+{% set heading_level = '2' %}
 {% extends '@bixaluswds/taxonomy/taxonomy-term.html.twig' %}
 
 {% block content %}
-  <h3 class="heading--red-underline">{{ content.field_heading | field_value }}</h3>
+  <h{{heading_level}} class="heading--red-underline">{{ content.field_heading | field_value }}</h{{heading_level}}>
   {{ content.field_content | field_value }}
 {% endblock %}


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

https://cm-jira.usa.gov/browse/VOTE-1064

## Description

In the basics modules taxonomy, change the heading levels dynamically based on whether the basics block heading is set.

## Deployment and testing

### Pre-deploy

1. lando retune

### QA/Test

1. Sign into the CMS locally
2. Go to http://vote-gov.lndo.site/register and edit the basics block to have a heading.
3. Confirm the Basics Block heading is h2 and the module subheadings are h3.
4. Remove the Basics Block heading
5. Confirm the module subheadings have changed to h2
6. Repeat steps 2-5 for Spanish. You might have to create the new translation if it doesn't exist yet.

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
