### PR TITLE
Vote-1028: Fixing space issue on register to vote page

### DIFF
--- a/web/themes/custom/votegov/src/sass/components/basics-block.scss
+++ b/web/themes/custom/votegov/src/sass/components/basics-block.scss
@@ -26,7 +26,7 @@
 
 .basics-block--container {
   .node--landing & {
-    @include at-media('tablet') {
+    @include at-media('desktop') {
       @include grid-col(7);
       @include grid-offset(1);
     }


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[Vote-1028](https://cm-jira.usa.gov/browse/VOTE-1028)

## Description

Updating media breakpoint for column layout to be enforced at desktop and not tablet to help address the spacing issue on the register to vote page. 

<details>
<summary>Before and After images</summary>
<br>
Left Image -> after - Right Image -> before 

![Screenshot 2024-04-23 at 10 21 04 AM](https://github.com/usagov/vote-gov-drupal/assets/88721460/8268c404-50ec-4b88-b317-4e78f34d0b37)
</details>


## Deployment and testing

### Post-deploy

1. Run `lando retune` cd into `votegov` directory and run `npm run build`

### QA/Test

1. Visit `/register` and adjust the screen size and ensure that the spacing on the content does not get reduced like in the before image

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
