### PR TITLE
VOTE-1101 Add configurable anchor id to basics modules

### DIFF
--- a/config/sync/core.entity_form_display.taxonomy_term.basics_modules.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.basics_modules.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.taxonomy_term.basics_modules.field_anchor_id
     - field.field.taxonomy_term.basics_modules.field_content
     - field.field.taxonomy_term.basics_modules.field_heading
     - taxonomy.vocabulary.basics_modules
@@ -13,6 +14,14 @@ targetEntityType: taxonomy_term
 bundle: basics_modules
 mode: default
 content:
+  field_anchor_id:
+    type: string_textfield
+    weight: 3
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   field_content:
     type: text_textarea
     weight: 2
@@ -31,7 +40,7 @@ content:
     third_party_settings: {  }
   langcode:
     type: language_select
-    weight: 3
+    weight: 4
     region: content
     settings:
       include_locked: true
@@ -46,13 +55,13 @@ content:
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 5
+    weight: 6
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   translation:
-    weight: 4
+    weight: 5
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_view_display.taxonomy_term.basics_modules.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.basics_modules.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.taxonomy_term.basics_modules.field_anchor_id
     - field.field.taxonomy_term.basics_modules.field_content
     - field.field.taxonomy_term.basics_modules.field_heading
     - taxonomy.vocabulary.basics_modules
@@ -13,6 +14,14 @@ targetEntityType: taxonomy_term
 bundle: basics_modules
 mode: default
 content:
+  field_anchor_id:
+    type: string
+    label: visually_hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 2
+    region: content
   field_content:
     type: text_default
     label: hidden

--- a/config/sync/field.field.taxonomy_term.basics_modules.field_anchor_id.yml
+++ b/config/sync/field.field.taxonomy_term.basics_modules.field_anchor_id.yml
@@ -1,0 +1,19 @@
+uuid: 29fe3187-9a13-4e80-b19a-04edba369e94
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_anchor_id
+    - taxonomy.vocabulary.basics_modules
+id: taxonomy_term.basics_modules.field_anchor_id
+field_name: field_anchor_id
+entity_type: taxonomy_term
+bundle: basics_modules
+label: 'Anchor ID'
+description: 'Use only letters and dashes. Example: example-name'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.storage.taxonomy_term.field_anchor_id.yml
+++ b/config/sync/field.storage.taxonomy_term.field_anchor_id.yml
@@ -1,0 +1,21 @@
+uuid: 84d1a581-59d6-4fff-8629-30ea5122a0f8
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_anchor_id
+field_name: field_anchor_id
+entity_type: taxonomy_term
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/themes/custom/votegov/templates/taxonomy/taxonomy-term--basics-modules.html.twig
+++ b/web/themes/custom/votegov/templates/taxonomy/taxonomy-term--basics-modules.html.twig
@@ -6,6 +6,10 @@
 #}
 
 {% extends '@bixaluswds/taxonomy/taxonomy-term.html.twig' %}
+{% set anchor = content.field_anchor_id | field_value | render | clean_class %}
+{% if anchor %}
+  {% set attributes = attributes.setAttribute('id', anchor) %}
+{% endif %}
 
 {% block content %}
   <h3 class="heading--red-underline">{{ content.field_heading | field_value }}</h3>


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

https://cm-jira.usa.gov/browse/VOTE-1101

## Description

Add configurable anchor id to the basics modules

## Deployment and testing

### Post-deploy

1. run `lando retune`

### QA/Test

1. Log into your local environment and visit http://vote-gov.lndo.site/taxonomy/term/50/edit?destination=/admin/structure/taxonomy/manage/basics_modules/overview
2. Add an anchor id of `registration-options` and save
3. Visit http://vote-gov.lndo.site/register#registration-options and make sure you are scrolled to that module on the page

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been included above.
- [ ] No merge conflicts exist with the target branch.
- [ ] Automated tests have passed on this PR.
- [ ] A reviewer has been designated.
- [ ] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
