### PR TITLE
VOTE-1075 Apply class to override font in lang switcher

### DIFF
--- a/web/themes/custom/votegov/src/sass/base/typography.scss
+++ b/web/themes/custom/votegov/src/sass/base/typography.scss
@@ -111,5 +111,5 @@ main {
 
 .nonvfont,
 .nonvfont * {
-  @include u-font-family('sans')
+  @include u-font-family('sans');
 }

--- a/web/themes/custom/votegov/templates/navigation/links--language-block.html.twig
+++ b/web/themes/custom/votegov/templates/navigation/links--language-block.html.twig
@@ -55,7 +55,7 @@
     {% endfor %}
   {% elseif links|length > 2 %}
     {%- for key, item in links -%}
-      <li class="usa-language__submenu-item" {{ item.attributes.removeAttribute('hreflang') }}
+      <li class="usa-language__submenu-item nonvfont" {{ item.attributes.removeAttribute('hreflang') }}
           data-lang="lang-{{ key }}" data-test="langItem">
         {%- if item.link -%}
           {# Create a custom override for the frontpage links. #}


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket
[VOTE-1075](https://cm-jira.usa.gov/browse/VOTE-1075)

## Description

Exclude the Navajo font from the language switcher dropdown.

## Deployment and testing

### Pre-deploy steps

1. cd into the theme folder and run _npm run build_
2. Run _lando retune_

### QA/Testing instructions

1. Visit a state page and switch to Navajo
2. Expand the language switcher and confirm that the default font is being applied instead of the navajo font

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been included above.
- [ ] No merge conflicts exist with the target branch.
- [ ] Automated tests have passed on this PR.
- [ ] A reviewer has been designated.
- [ ] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
