### PR TITLE
Vote-1141: Remove preview funtion for voter guide

### DIFF
--- a/config/sync/node.type.voter_guide.yml
+++ b/config/sync/node.type.voter_guide.yml
@@ -22,10 +22,14 @@ third_party_settings:
       status: false
       settings:
         age: 1
+    only_drafts:
+      status: false
+      settings:
+        age: 0
 name: 'Voter Guide'
 type: voter_guide
 description: ''
 help: ''
-new_revision: false
-preview_mode: 1
+new_revision: true
+preview_mode: 0
 display_submitted: false


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[Vote-1141](https://cm-jira.usa.gov/browse/VOTE-1141)

## Description

Removing the preview function from the voter guide.  This function is not consistent in its use and can cause more issues then help. 

## Deployment and testing

### Post-deploy steps

1. run `lando retune`

### QA/Testing instructions

1. log into the site and navigate to a voter guide and open the edit view... scroll to the bottom and verify that the `preview` option is no longer next to the save button

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
