### PR TITLE
Vote-1137: Fix spacing for UL on basics block

### DIFF
--- a/web/themes/custom/votegov/src/sass/components/basics-block.scss
+++ b/web/themes/custom/votegov/src/sass/components/basics-block.scss
@@ -76,6 +76,10 @@
     @include u-margin-top(5);
   }
 
+  ul {
+    @include u-margin-y(2);
+  }
+
   @include at-media('tablet') {
     @include u-padding(4);
   }


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[Vote-1137](https://cm-jira.usa.gov/browse/VOTE-1137)

## Description

Adjusting the margin on `ul` elements to reduce extra space within basics blocks. 
Before there was the wildcard selector that was getting anything with the the `basics-block--content`, and this was causing the extra space.  By targeting the `ul` elments and making the margins equal on top and bottom will reduce the space.

<details>
<summary>Before and After Images</summary>
<br>
Before:
<br>
<img width="852" alt="Screenshot 2024-05-06 at 11 40 08 AM" src="https://github.com/usagov/vote-gov-drupal/assets/88721460/731fccf3-d93c-40fa-a70c-b89f79726c9a">
<br>
<br>
After:
<br>
<img width="764" alt="Screenshot 2024-05-06 at 11 41 14 AM" src="https://github.com/usagov/vote-gov-drupal/assets/88721460/a01dc18c-6cc7-44ca-b3a8-426eb73a85f3">
</details>

## Deployment and testing

### Post-deploy steps

1. cd into `votegov` theme and run `npm run build`

### QA/Testing instructions

1. log into site and visit the voter guid for `new us citizens` scroll down to the block that is titled `Support for new citizens` and check that the `ul` has 16px margin. 
2. also spot check other voter guide with basics blocks for any visual regressions 

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
