### PR TITLE
VOTE-1337 add translation alert with sitemap fallback

### DIFF
--- a/config/sync/block.block.votegov_htmlsitemap.yml
+++ b/config/sync/block.block.votegov_htmlsitemap.yml
@@ -23,5 +23,5 @@ settings:
   depth: 3
   expand_all_items: true
   only_translated_labels: 0
-  only_translated_content: 0
+  only_translated_content: 1
 visibility: {  }

--- a/config/sync/block.block.votegov_mainnavigation.yml
+++ b/config/sync/block.block.votegov_mainnavigation.yml
@@ -23,5 +23,5 @@ settings:
   depth: 2
   expand_all_items: true
   only_translated_labels: 0
-  only_translated_content: 0
+  only_translated_content: 1
 visibility: {  }

--- a/config/sync/field.field.block_content.sitewide_alert.field_publish.yml
+++ b/config/sync/field.field.block_content.sitewide_alert.field_publish.yml
@@ -12,7 +12,7 @@ bundle: sitewide_alert
 label: Publish
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value:
   -
     value: 0

--- a/web/themes/custom/votegov/templates/component/translation-alert.html.twig
+++ b/web/themes/custom/votegov/templates/component/translation-alert.html.twig
@@ -1,8 +1,0 @@
-{% set alert_translation %}
-  <p>Welcome to the new design of vote.gov! We are continuing to translate new and revised pages. View
-    <a href="/{{ language }}/legacy">pages available in {{ languagename }}.</a></p>
-{% endset %}
-{% include '@uswds_templates/usa-site-alert.html.twig' with {
-  'alert_type': 'info',
-  'text': alert_translation
-} %}

--- a/web/themes/custom/votegov/templates/component/translation-alert.html.twig
+++ b/web/themes/custom/votegov/templates/component/translation-alert.html.twig
@@ -1,0 +1,8 @@
+{% set alert_translation %}
+  <p>Welcome to the new design of vote.gov! We are continuing to translate new and revised pages. In the meantime, you can still view the
+    <a href="/{{ language }}/legacy">original pages in {{ languagename }}</a>.</p>
+{% endset %}
+{% include '@uswds_templates/usa-site-alert.html.twig' with {
+  'alert_type': 'info',
+  'text': alert_translation
+} %}

--- a/web/themes/custom/votegov/templates/component/translation-alert.html.twig
+++ b/web/themes/custom/votegov/templates/component/translation-alert.html.twig
@@ -1,6 +1,6 @@
 {% set alert_translation %}
-  <p>Welcome to the new design of vote.gov! We are continuing to translate new and revised pages. In the meantime, you can still view the
-    <a href="/{{ language }}/legacy">original pages in {{ languagename }}</a>.</p>
+  <p>Welcome to the new design of vote.gov! We are continuing to translate new and revised pages. View
+    <a href="/{{ language }}/legacy">pages available in {{ languagename }}.</a></p>
 {% endset %}
 {% include '@uswds_templates/usa-site-alert.html.twig' with {
   'alert_type': 'info',

--- a/web/themes/custom/votegov/templates/embedded-content/ec-placeholder--sitemap-menu.html.twig
+++ b/web/themes/custom/votegov/templates/embedded-content/ec-placeholder--sitemap-menu.html.twig
@@ -1,3 +1,7 @@
+{% set htmlsitemap = drupal_entity('block', 'votegov_htmlsitemap') | render %}
+{% set legacy_link %}
+  <li class="usa-list usa-list--unstyled"><a href="{{ path('entity.node.canonical', { 'node': 63 }) }}">{{ drupal_field('title', 'node', 63) }}</a></li>
+{% endset %}
 <nav class="vote-sitemap vote-sitemap--menu">
-  {{ drupal_entity('block', 'votegov_htmlsitemap') }}
+  {{ htmlsitemap | default(legacy_link) }}
 </nav>

--- a/web/themes/custom/votegov/templates/layout/page.html.twig
+++ b/web/themes/custom/votegov/templates/layout/page.html.twig
@@ -53,6 +53,12 @@
 {# Government banner component #}
   {{ drupal_entity('block_content', '1') }}
 
+{# If the current page has been marked as outdated and it's the front page #}
+{% if is_front and node.content_translation_outdated.value == 1 %}
+  {# Display a translation alert with a link to the legacy homepage #}
+  {% include '@votegov/component/translation-alert.html.twig' %}
+{% endif %}
+
 {# Sitewide alert component #}
   {{ drupal_view('sitewide_alert', 'block_1') }}
 

--- a/web/themes/custom/votegov/templates/layout/page.html.twig
+++ b/web/themes/custom/votegov/templates/layout/page.html.twig
@@ -56,7 +56,14 @@
 {# If the current page has been marked as outdated and it's the front page #}
 {% if is_front and node.content_translation_outdated.value == 1 %}
   {# Display a translation alert with a link to the legacy homepage #}
-  {% include '@votegov/component/translation-alert.html.twig' %}
+  {% set alert_translation %}
+    <p>Welcome to the new vote.gov! We're continuing to add more languages to the site.
+      <a href="/{{ language }}/legacy">Find information about registering to vote in {{ languagename }}.</a></p>
+  {% endset %}
+  {% include '@uswds_templates/usa-site-alert.html.twig' with {
+    'alert_type': 'info',
+    'text': alert_translation
+  } %}
 {% endif %}
 
 {# Sitewide alert component #}


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

https://cm-jira.usa.gov/browse/VOTE-1337
https://cm-jira.usa.gov/browse/VOTE-1159

## Description

Add functionality for a site alert on the homepage for translations that are not ready.

## Deployment and testing

### Post-deploy steps

1. run `lando retune`
2. Publish this node in english and spanish http://vote-gov.lndo.site/node/63/edit with `/legacy` as the url
4. Add and publish spanish translation of the new Homepage http://vote-gov.lndo.site/node/91/translations with `/votegov` as the url
5. Edit http://vote-gov.lndo.site/node/91/edit and select "mark all other translations as outdated" in the translations accordion in the sidebar
3. Visit http://vote-gov.lndo.site/es and confirm the site alert shows with a link to the legacy homepage
4. Click on the link and make sure it goes to http://vote-gov.lndo.site/es/legacy

### QA/Testing instructions

1. Insert steps to test and confirm the result meets the "definition of done".

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.