### PR TITLE
VOTE-1339 Remove devel, field_ui and views_ui from global permissions…

### DIFF
--- a/config/local/config_split.patch.user.role.site_builder.yml
+++ b/config/local/config_split.patch.user.role.site_builder.yml
@@ -1,8 +1,10 @@
 adding:
   dependencies:
     module:
+      - devel
       - disable_language
   permissions:
+    - 'access devel information'
     - 'create content in disabled language'
     - 'view disabled languages'
 removing: {  }

--- a/config/sync/user.role.site_builder.yml
+++ b/config/sync/user.role.site_builder.yml
@@ -38,11 +38,9 @@ dependencies:
     - content_moderation
     - content_translation
     - crop
-    - devel
     - easy_breadcrumb
     - editoria11y
     - entity_reference_revisions
-    - field_ui
     - file
     - file_delete
     - filter
@@ -67,7 +65,6 @@ dependencies:
     - tome_static
     - toolbar
     - update
-    - views_ui
     - workflows
 id: site_builder
 label: 'Site Builder'
@@ -78,7 +75,6 @@ permissions:
   - 'access block library'
   - 'access content'
   - 'access content overview'
-  - 'access devel information'
   - 'access files overview'
   - 'access media overview'
   - 'access site in maintenance mode'


### PR DESCRIPTION
… on site builder role

<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

https://cm-jira.usa.gov/browse/VOTE-1339

## Description

Resolves the config import issue with the site builder role

## Deployment and testing

### Post-deploy steps

1. update settings.local setting to `$config['config_split.config_split.non_production']['status'] = TRUE;`
2. run lando retune

### QA/Testing instructions

1. Make sure the configuration imports successfully without error

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
