### PR TITLE
Feature/vote 1338 upkeep script update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ jobs:
             source ./scripts/pipeline/deb-cf-install.sh
       - run:
           name: "Run Drush Cron and Generate Static Site"
+          no_output_timeout: 30m
           command: |
             source ./scripts/pipeline/exports.sh ${CIRCLE_BRANCH}
             source ./scripts/pipeline/cloud-gov-login.sh
@@ -142,6 +143,7 @@ jobs:
             source ./scripts/pipeline/deb-cf-install.sh
       - run:
           name: "Post Deploy Upkeep"
+          no_output_timeout: 30m
           command: |
             source ./scripts/pipeline/exports.sh ${CIRCLE_BRANCH}
             source ./scripts/pipeline/cloud-gov-login.sh

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -71,6 +71,7 @@ module:
   token: 0
   tome_base: 0
   tome_static: 0
+  tome_static_super_cache: 0
   toolbar: 0
   translatable_menu_link_uri: 0
   twig_field_value: 0

--- a/scripts/upkeep
+++ b/scripts/upkeep
@@ -34,8 +34,8 @@ echo ""
 echo "**************************************************"
 echo "Running 'drush tome:static' in '${environment}'..."
 echo "**************************************************"
-drush tome:static --uri=${ssg_endpoint} --process-count=2 --retry-count=0 -y
-drush tome:static-export-path '/sitemap.xml,/sitemap_generator/default/sitemap.xsl' --uri=${ssg_endpoint} --process-count=2 --retry-count=0 -y
+drush tome:static --uri=${ssg_endpoint} --path-count=1 --retry-count=0 -y
+drush tome:static-export-path '/sitemap.xml,/sitemap_generator/default/sitemap.xsl' --uri=${ssg_endpoint} --retry-count=0 -y
 echo "'drush tome:static' task...completed!"
 echo ""
 

--- a/scripts/upkeep
+++ b/scripts/upkeep
@@ -36,6 +36,7 @@ echo "Running 'drush tome:static' in '${environment}'..."
 echo "**************************************************"
 drush tome:static --uri=${ssg_endpoint} --path-count=1 --retry-count=0 -y
 drush tome:static-export-path '/sitemap.xml,/sitemap_generator/default/sitemap.xsl' --uri=${ssg_endpoint} --retry-count=0 -y
+drush cr
 echo "'drush tome:static' task...completed!"
 echo ""
 


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[VOTE-1338](https://cm-jira.usa.gov/browse/VOTE-1338)

## Description

Update tome script to process one path at a time to avoid disappearing sidebar menu which is set to render child menu items. Enable tome's cache to improve generation performance, especially given that we will process one path at a time.

## Deployment and testing

### Post-deploy steps

n/a

### QA/Testing instructions

1. Locally, import latest DB backup from production
2. Run `lando retune`
3. Run `lando drush tome:static --path-count=1` to generate the local static site one path at a time. (this is reflected in the updated script)
4. Visit the pages under 'Guide to Voting' and confirm that the left sidebar navigation appears and that the css-based active state is applied to the correct menu link.
5. Testing on cloud environments, once the pipeline is executed for the upkeep script, repeat step 4 above.

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
