### PR TITLE
VOTE-886: Flush image files after downsync restore

### DIFF
--- a/scripts/pipeline/downsync-restore.sh
+++ b/scripts/pipeline/downsync-restore.sh
@@ -57,7 +57,7 @@ echo "Cleaning up old connections..."
 ## Clean up.
 rm -rf restore.txt ~/.mysql backup_${BACKUP_ENV}.sql
 
-echo "Running 'drush cr' on '${BACKUP_ENV}' database..."
+echo "Running 'drush cr' on '${RESTORE_ENV}' database..."
 source $(pwd $(dirname $0))/scripts/pipeline/cloud-gov-remote-command.sh "${project}-drupal-${RESTORE_ENV}" "drush cr"
 
 # Upload media files.
@@ -79,8 +79,11 @@ echo "Uploading media files..."
   export AWS_DEFAULT_REGION=$(echo "${s3_credentials}" | jq -r '.credentials.region')
   export AWS_SECRET_ACCESS_KEY=$(echo "${s3_credentials}" | jq -r '.credentials.secret_access_key')
 
-  # Sync files to restore env, deleting those not found from backup env.
+  # Sync files to restore env, deleting those not found in backup env.
   aws s3 sync --no-verify-ssl --delete ${backup_media}/ s3://${bucket}/${backup_media} 2>/dev/null
 
   cf delete-service-key "${service}" "${service_key}" -f
 } >/dev/null 2>&1
+
+echo "Running 'drush image-flush --all' on '${RESTORE_ENV}'..."
+source $(pwd $(dirname $0))/scripts/pipeline/cloud-gov-remote-command.sh "${project}-drupal-${RESTORE_ENV}" "drush image-flush --all"


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[VOTE-886](https://cm-jira.usa.gov/browse/VOTE-886)

## Description

Flush images after downsync restore.

## Deployment and testing

### QA/Testing instructions

1. Allow deploy to complete.
2. List backup and restore media storage bucket contents.
3. Trigger downsync pipeline.
4. Verify images are flushed and regenerated on restore env.

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
