### PR TITLE
VOTE-2012 Update storage location for oembed thumbnails

### DIFF
--- a/config/sync/media.type.remote_video.yml
+++ b/config/sync/media.type.remote_video.yml
@@ -1,7 +1,12 @@
 uuid: fab91431-1247-4d3e-9803-2305c59d7647
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - crop
+third_party_settings:
+  crop:
+    image_field: null
 id: remote_video
 label: 'Remote Video'
 description: ''
@@ -10,7 +15,7 @@ queue_thumbnail_downloads: false
 new_revision: false
 source_configuration:
   source_field: field_media_oembed_video
-  thumbnails_directory: 'public://oembed_thumbnails/media/video/[media:name]'
+  thumbnails_directory: 'public://media/video/oembed_thumbnails/'
   providers:
     - YouTube
 field_map: {  }


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

https://cm-jira.usa.gov/browse/VOTE-2012

## Description

Update storage location for oembed thumbnails to be inside the `/media/video` directory

## Deployment and testing

### Post-deploy steps

1. run `lando retune`

### QA/Testing instructions

1. log into the site and visit http://vote-gov.lndo.site/media/add/remote_video
2. Add a new remote video, save and confirm that the thumbnail is generated on the listing page http://vote-gov.lndo.site/admin/content/media

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
