### PR TITLE
Vote-1336: Breadcrumb to match page title case

### DIFF
--- a/config/sync/easy_breadcrumb.settings.yml
+++ b/config/sync/easy_breadcrumb.settings.yml
@@ -22,7 +22,7 @@ hide_single_home_item: false
 term_hierarchy: false
 use_site_title: false
 add_structured_data_json_ld: false
-capitalizator_mode: ucwords
+capitalizator_mode: none
 capitalizator_ignored_words:
   - of
   - and
@@ -41,5 +41,5 @@ segment_display_limit: 0
 truncator_mode: false
 truncator_length: 100
 truncator_dots: true
-remove_repeated_segments_text_only: 0
-home_segment_validation_skip: 0
+remove_repeated_segments_text_only: false
+home_segment_validation_skip: false

--- a/web/themes/custom/votegov/templates/navigation/breadcrumb.html.twig
+++ b/web/themes/custom/votegov/templates/navigation/breadcrumb.html.twig
@@ -7,7 +7,6 @@
  * - breadcrumb: Breadcrumb trail items.
  */
 #}
-
 {% if breadcrumb %}
   <nav role="navigation" aria-labelledby="system-breadcrumb" class="usa-breadcrumb">
     <h2 id="system-breadcrumb" class="usa-sr-only visually-hidden">{{ 'Breadcrumb'|t }}</h2>

--- a/web/themes/custom/votegov/templates/navigation/breadcrumb.html.twig
+++ b/web/themes/custom/votegov/templates/navigation/breadcrumb.html.twig
@@ -8,8 +8,6 @@
  */
 #}
 
-{% set title = drupal_title() %}
-
 {% if breadcrumb %}
   <nav role="navigation" aria-labelledby="system-breadcrumb" class="usa-breadcrumb">
     <h2 id="system-breadcrumb" class="usa-sr-only visually-hidden">{{ 'Breadcrumb'|t }}</h2>
@@ -19,7 +17,7 @@
         {% if item.url %}
           <a class="usa-breadcrumb__link" href="{{ item.url }}"><span>{{ item.text }}</span></a>
         {% else %}
-          {{ title }}
+          {{ item.text }}
         {% endif %}
       </li>
     {% endfor %}

--- a/web/themes/custom/votegov/templates/navigation/breadcrumb.html.twig
+++ b/web/themes/custom/votegov/templates/navigation/breadcrumb.html.twig
@@ -7,6 +7,9 @@
  * - breadcrumb: Breadcrumb trail items.
  */
 #}
+
+{% set title = drupal_title() %}
+
 {% if breadcrumb %}
   <nav role="navigation" aria-labelledby="system-breadcrumb" class="usa-breadcrumb">
     <h2 id="system-breadcrumb" class="usa-sr-only visually-hidden">{{ 'Breadcrumb'|t }}</h2>
@@ -16,7 +19,7 @@
         {% if item.url %}
           <a class="usa-breadcrumb__link" href="{{ item.url }}"><span>{{ item.text }}</span></a>
         {% else %}
-          {{ item.text }}
+          {{ title }}
         {% endif %}
       </li>
     {% endfor %}


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[Vote-1336](https://cm-jira.usa.gov/browse/VOTE-1336)

## Description

Updating breadcrumb menu to match the page title... replaced the `item.text` with `Drupal Title` 

<details>
<summary>Before and After</summary>
<br>
Before: 
<br>
<img width="635" alt="Screenshot 2024-05-28 at 12 00 21 PM" src="https://github.com/usagov/vote-gov-drupal/assets/88721460/d03f0bb4-f60b-4c04-9b56-e8c87cfa927f">
<br>
<br>
After: 
<br>
<img width="695" alt="Screenshot 2024-05-28 at 12 00 09 PM" src="https://github.com/usagov/vote-gov-drupal/assets/88721460/f4997a0d-9c6c-4703-a8fc-8cd062b67548">

</details>

## Deployment and testing

### Post-deploy steps

1. run `lando retune`

### QA/Testing instructions

1. log in and visit a voter guide page, verify that breadcrumb is not matching the page title 
2. edit the page title and check that breadcrumb is still matching the page title.  can also visit a state page and update the title case for the state title and should also be reflected in the breadcrumb

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
