### PR TITLE
VOTE-2065: configure basic HTML wysiwyg to not allow image alignment

### DIFF
--- a/config/sync/filter.format.basic_html.yml
+++ b/config/sync/filter.format.basic_html.yml
@@ -15,19 +15,13 @@ filters:
     status: true
     weight: 100
     settings: {  }
-  filter_align:
-    id: filter_align
-    provider: filter
-    status: true
-    weight: 0
-    settings: {  }
   filter_html:
     id: filter_html
     provider: filter
     status: true
     weight: -10
     settings:
-      allowed_html: '<br> <p class="usa-intro text-align-left text-align-center text-align-right"> <h2 id class> <h3 class> <h4 class="text-align-left text-align-center text-align-right"> <h5 class="text-align-left text-align-center text-align-right"> <h6 class="text-align-left text-align-center text-align-right"> <a class href aria-label title target="_blank" rel> <div id class data-allow-multiple> <button type class aria-expanded aria-controls> <strong> <em> <u> <ul class> <ol> <li class> <hr> <img src alt height width> <drupal-media data-entity-type data-entity-uuid alt data-align> <embedded-content data-plugin-config data-plugin-id>'
+      allowed_html: '<br> <p class="usa-intro text-align-left text-align-center text-align-right"> <h2 id class> <h3 class> <h4 class="text-align-left text-align-center text-align-right"> <h5 class="text-align-left text-align-center text-align-right"> <h6 class="text-align-left text-align-center text-align-right"> <a class href aria-label title target="_blank" rel> <div id class data-allow-multiple> <button type class aria-expanded aria-controls> <img src alt height width> <strong> <em> <u> <ul class> <ol> <li class> <hr> <drupal-media data-entity-type data-entity-uuid alt> <embedded-content data-plugin-config data-plugin-id>'
       filter_html_help: true
       filter_html_nofollow: false
   media_embed:


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[Insert a link to the Jira ticket (e.g VOTE-XXX).](https://cm-jira.usa.gov/browse/VOTE-2065)

## Description

Reconfigures the text editor for basic HTML wysiwig to not allow image alignment option.

## Deployment and testing

### QA/Testing instructions

1. lando retune
2. lando drush cim
3. edit a page
4. add an image inside the wysiwyg
5. hover over image while in wysiwyg and confirm no alignment buttons are available

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
