### PR TITLE
VOTE-2040: Legacy site alert block content

### DIFF
--- a/web/themes/custom/votegov/templates/layout/page.html.twig
+++ b/web/themes/custom/votegov/templates/layout/page.html.twig
@@ -57,15 +57,7 @@
 
 {# If the current page has been marked as outdated and it's the front page #}
 {% if is_front and node.content_translation_outdated.value == 1 %}
-  {# Display a translation alert with a link to the legacy homepage #}
-  {% set alert_translation %}
-    <p>Welcome to the new vote.gov! We're continuing to add more languages to the site.
-      <a href="/{{ language }}/legacy">Find information about registering to vote in {{ languagename }}.</a></p>
-  {% endset %}
-  {% include '@uswds_templates/usa-site-alert.html.twig' with {
-    'alert_type': 'info',
-    'text': alert_translation
-  } %}
+  {{ drupal_entity('block_content', '20') }}
 {% endif %}
 
 {# Sitewide alert component #}


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[VOTE-2040](https://cm-jira.usa.gov/browse/VOTE-2040)

## Description

Replaces hard coded alert component for legacy site link with a content block. The block has been created on production where ID is 20. Translations being added on production.

## Deployment and testing

### Post deploy
1. Test again with translations and block id that are on production

### QA/Testing instructions

1. Create site alert block (this should have id 20 but if not update line 60 of page.html.twig to match your environment)
2. Confirm block shows on pages where translation is marked as outdated
3. Add translations for block and confirm it translates

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [ ] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
