### PR TITLE
VOTE-2015: Set production url for sitemap.xml and update upkeep scrip…

### DIFF
--- a/config/production/config_split.patch.simple_sitemap.settings.yml
+++ b/config/production/config_split.patch.simple_sitemap.settings.yml
@@ -1,0 +1,4 @@
+adding:
+  base_url: 'https://vote.gov'
+removing:
+  base_url: ''

--- a/config/sync/config_split.config_split.production.yml
+++ b/config/sync/config_split.config_split.production.yml
@@ -22,4 +22,5 @@ complete_list:
   - views.view.samlauth_map
 partial_list:
   - core.extension
+  - simple_sitemap.settings
   - system.performance

--- a/scripts/upkeep
+++ b/scripts/upkeep
@@ -23,6 +23,9 @@ export bucket_endpoint=$(echo $VCAP_SERVICES | jq -r '.s3[] | select(.name | str
 export ssg_endpoint="https://ssg-${environment}.vote.gov"
 [ "${environment}" = "prod" ] && export ssg_endpoint="https://beta.vote.gov"
 
+export ssg_sitemap_endpoint=ssg_endpoint
+[ "${environment}" = "prod" ] && export ssg_sitemap_endpoint="https://vote.gov"
+
 cd ${app_path}
 echo "**************************************************"
 echo "Running 'drush cron' in '${environment}'..."
@@ -35,7 +38,7 @@ echo "**************************************************"
 echo "Running 'drush tome:static' in '${environment}'..."
 echo "**************************************************"
 drush tome:static --uri=${ssg_endpoint} --path-count=1 --retry-count=0 -y
-drush tome:static-export-path '/sitemap.xml,/sitemap_generator/default/sitemap.xsl' --uri=${ssg_endpoint} --retry-count=0 -y
+drush tome:static-export-path '/sitemap.xml,/sitemap_generator/default/sitemap.xsl' --uri=${ssg_sitemap_endpoint} --retry-count=0 -y
 drush cr
 echo "'drush tome:static' task...completed!"
 echo ""


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[VOTE-2015](https://cm-jira.usa.gov/browse/VOTE-2015)

## Description

Set urls within sitemap.xml to begin with https://vote.gov for production environment.

## Deployment and testing

### Post-deploy steps

1. Update your setting.local.php file to set config split environment to production
`$config['config_split.config_split.production']['status'] = TRUE;`
2. Locally run `lando retune`

### QA/Testing instructions

1. Visit /sitemap.xml and confirm the urls begin with https://vote.gov/
2. Run `lando drush tome:static-export-path 'sitemap.xml'`
3. Locate the sitemap.xml within the `{project_root}/html/` directory
4. Confirm the urls begin with https://vote.gov/
5. Update your setting.local.php file to set config split environment to non_production 
`$config['config_split.config_split.non_production']['status'] = TRUE;`
6. Run `lando drush cim`
7. Visit /sitemap.xml and confirm the urls do not begin with https://vote.gov
8. Update your setting.local.php file to set config split environment to local
`$config['config_split.config_split.local']['status'] = TRUE;`
9. Repeat Steps 6-7

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
