### PR TITLE
VOTE-946 add background color option to hero for landing pages

### DIFF
--- a/config/sync/field.field.paragraph.hero.field_background_color.yml
+++ b/config/sync/field.field.paragraph.hero.field_background_color.yml
@@ -13,9 +13,11 @@ entity_type: paragraph
 bundle: hero
 label: 'Background Color'
 description: ''
-required: false
+required: true
 translatable: false
-default_value: {  }
+default_value:
+  -
+    value: predefined_color_list_from_color_palette
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/config/sync/field.storage.paragraph.field_background_color.yml
+++ b/config/sync/field.storage.paragraph.field_background_color.yml
@@ -13,7 +13,10 @@ settings:
   allowed_values:
     -
       value: predefined_color_list_from_color_palette
-      label: 'Background color'
+      label: Default
+    -
+      value: dark
+      label: Dark
   allowed_values_function: ''
 module: options
 locked: false

--- a/web/themes/custom/votegov/templates/paragraph/paragraph--hero.html.twig
+++ b/web/themes/custom/votegov/templates/paragraph/paragraph--hero.html.twig
@@ -4,8 +4,12 @@
  * Default theme implementation to display a paragraph: Basics Block.
  */
 #}
+{% set classes = [
+  'vote-hero',
+  'vote-hero--' ~ content.field_background_color | field_value | render
+] %}
 
-<section class="vote-hero">
+<section{{ attributes.addClass(classes) }}>
   <div class="vote-hero__container">
     {% if content.field_media | render %}
       <div class="vote-hero__image">


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[VOTE-946](https://cm-jira.usa.gov/browse/VOTE-946)

## Description

Add background color options for hero component.

## Deployment and testing

### Post-deploy steps

1. run `lando retune`

### QA/Testing instructions

1. visit http://vote-gov.lndo.site/your-vote-safe
2. edit the page and select background color in the hero as "dark"
3. view the page and see that the style of the hero has changed to the alternative version

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
