### PR TITLE
Vote-2124: Make image alt text optional

### DIFF
--- a/config/sync/field.field.media.image.field_media_image.yml
+++ b/config/sync/field.field.media.image.field_media_image.yml
@@ -33,7 +33,7 @@ settings:
   max_resolution: ''
   min_resolution: ''
   alt_field: true
-  alt_field_required: true
+  alt_field_required: false
   title_field: false
   title_field_required: false
   default_image:


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[Vote-2124](https://cm-jira.usa.gov/browse/VOTE-2124)

## Description

Updating the alt text to be optional and no longer required 

## Deployment and testing

### Post-deploy steps

1. run `lando retune`

### QA/Testing instructions

1. log in as an admin and update the homepage hero by adding an image and verify that the alt text filed is no longer required.

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
