### PR TITLE
Vote-2194: Fix to breadcrumb style

### DIFF
--- a/web/themes/custom/votegov/src/sass/uswds-overrides/usa-breadcrumb.scss
+++ b/web/themes/custom/votegov/src/sass/uswds-overrides/usa-breadcrumb.scss
@@ -3,16 +3,6 @@
 
 .usa-breadcrumb {
   background-color: transparent;
-
-  // & + * {
-  //   @include u-margin-top(5);
-  
-  //   @include at-media('tablet') {
-  //     @include u-margin-top(10);
-  //   }
-
-  // }
-
 }
 
 .usa-breadcrumb__link {

--- a/web/themes/custom/votegov/src/sass/uswds-overrides/usa-breadcrumb.scss
+++ b/web/themes/custom/votegov/src/sass/uswds-overrides/usa-breadcrumb.scss
@@ -19,4 +19,3 @@
     @include u-margin-top(10);
   }
 }
-

--- a/web/themes/custom/votegov/src/sass/uswds-overrides/usa-breadcrumb.scss
+++ b/web/themes/custom/votegov/src/sass/uswds-overrides/usa-breadcrumb.scss
@@ -3,6 +3,16 @@
 
 .usa-breadcrumb {
   background-color: transparent;
+
+  // & + * {
+  //   @include u-margin-top(5);
+  
+  //   @include at-media('tablet') {
+  //     @include u-margin-top(10);
+  //   }
+
+  // }
+
 }
 
 .usa-breadcrumb__link {
@@ -12,10 +22,11 @@
 }
 
 // targeting the div wrapping the breadcrumb block and add margin top to the following element
-.system-breadcrumb-block + * {
+.block.system-breadcrumb-block + * {
   @include u-margin-top(5);
 
   @include at-media('tablet') {
     @include u-margin-top(10);
   }
 }
+


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[Vote-2194](https://cm-jira.usa.gov/browse/VOTE-2194)

## Description

The breadcrumb style that was added last sprint was not getting applied to the voter guide... i update the class name to be more specific in the targeting 

## Deployment and testing

### Post-deploy steps

1. run `lando retune` and cd into the `votegov` theme

### QA/Testing instructions

1. visit a voterguide and inspect the hero and check that the header is getting a margin top of 80px/5rem applied

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
