### PR TITLE
VOTE-2200: Add Portuguese config file

### DIFF
--- a/config/sync/language/pt/language.entity.pt.yml
+++ b/config/sync/language/pt/language.entity.pt.yml
@@ -1,0 +1,1 @@
+label: Português


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[VOTE-2200](https://cm-jira.usa.gov/browse/VOTE-2200)

## Description

Adds missing Portuguese config file to fix language selector dropdown selection.

## Deployment and testing

### QA/Testing instructions

1. lando retune
2. make sure configuration is imported
3. Check that both names for Portuguese appear in language selector dropdown, matching the current Vote.gov site.

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
