### PR TITLE
VOTE-2203: Modified mobile margins to 24px

### DIFF
--- a/web/themes/custom/votegov/src/sass/_uswds-settings.scss
+++ b/web/themes/custom/votegov/src/sass/_uswds-settings.scss
@@ -168,6 +168,7 @@ https://designsystem.digital.gov/documentation/settings/
   $theme-column-gap-mobile: 5,
   //$theme-column-gap-desktop: 7,
   $theme-site-margins-width: 10,
+  $theme-site-margins-mobile-width: 3,
   $theme-site-margins-breakpoint: 'tablet',
 
   // Typography settings ---------------------------------------------------------------


### PR DESCRIPTION
## Jira ticket

https://cm-jira.usa.gov/browse/VOTE-2203

## Description

Updated margin to 24px for mobile (per craig's beta design review/audit)

## Deployment and testing

### Post-deploy steps

1. run `npm run build` in votegov theme
2. run `lando retune`

### QA/Testing instructions

1. load up the local site
2. load up the beta.vote.gov site
3. go into mobile-screen mode through Inspect-Element for both sites.
4. verify the local site's margins are 24px and that they are bigger than those of beta.vote.gov

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
