### PR TITLE
VOTE-2199: Fix logo focus outline

### DIFF
--- a/web/themes/custom/votegov/src/sass/uswds-overrides/usa-header.scss
+++ b/web/themes/custom/votegov/src/sass/uswds-overrides/usa-header.scss
@@ -13,7 +13,7 @@
     }
 
     a {
-      display: inline-block;
+      @include u-display('inline-block')
     }
   }
 }

--- a/web/themes/custom/votegov/src/sass/uswds-overrides/usa-header.scss
+++ b/web/themes/custom/votegov/src/sass/uswds-overrides/usa-header.scss
@@ -11,6 +11,10 @@
     @include at-media('tablet-lg') {
       width: 12.5rem;
     }
+
+    a {
+      display: inline-block;
+    }
   }
 }
 


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[VOTE-2199](https://cm-jira.usa.gov/browse/VOTE-2199)

## Description

This fixes the issue on safari where the focus state outline box around the logo was not positioned correctly by adding inline-block rule to the wrapping <a> element.

## Deployment and testing

### QA/Testing instructions

1. lando retune
2. npm run build
3. Using safari browser 
4. test the focus outline position by selecting the logo in the header

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
