### PR TITLE
Vote-2235: Fixes for Axe Tests

### DIFF
--- a/web/themes/custom/votegov/templates/layout/page--node--voter-guide.html.twig
+++ b/web/themes/custom/votegov/templates/layout/page--node--voter-guide.html.twig
@@ -39,7 +39,7 @@
       </div>
     </div>
   </main>
-  <div role="region" aria-labelledby="{{ 'Know your voting rights' | t }}">
+  <div role="region" aria-label="{{ 'Know your voting rights' | t }}">
   {# Voter guide listing #}
   {{ drupal_view('voter_guides', 'embed_1') }}
   </div>

--- a/web/themes/custom/votegov/templates/layout/page--node--voter-guide.html.twig
+++ b/web/themes/custom/votegov/templates/layout/page--node--voter-guide.html.twig
@@ -39,7 +39,7 @@
       </div>
     </div>
   </main>
-  <div role="region" aria-labelledby="voter-guide-cards">
+  <div role="region" aria-labelledby="{{ 'Know your voting rights' | t }}">
   {# Voter guide listing #}
   {{ drupal_view('voter_guides', 'embed_1') }}
   </div>

--- a/web/themes/custom/votegov/templates/layout/page--node--voter-guide.html.twig
+++ b/web/themes/custom/votegov/templates/layout/page--node--voter-guide.html.twig
@@ -35,6 +35,8 @@
       </div>
     </div>
   </main>
+  <div role="region" aria-labelledby="voter-guide-cards">
   {# Voter guide listing #}
   {{ drupal_view('voter_guides', 'embed_1') }}
+  </div>
 {% endblock %}

--- a/web/themes/custom/votegov/templates/media/image.html.twig
+++ b/web/themes/custom/votegov/templates/media/image.html.twig
@@ -1,0 +1,13 @@
+{#
+/**
+ * @file
+ * setting conditional that if alt text is not set to add `role="presentation"` to address accessability
+ */
+#}
+
+
+{% if attributes.alt %}
+  <img{{ attributes }} />
+{% else %}
+  <img{{ attributes.setAttribute('role', 'presentation') }}/>
+{% endif %}

--- a/web/themes/custom/votegov/templates/paragraph/paragraph--hero.html.twig
+++ b/web/themes/custom/votegov/templates/paragraph/paragraph--hero.html.twig
@@ -12,6 +12,8 @@
 {# Caching the data in content object #}
 {% set savedCache = content | render %}
 
+{# add if statement - if alt is set of alt = alt else null alt = alt="" #}
+
 <section{{ attributes.addClass(classes) }}>
   {# Hold these title_* placeholders for potential integration #}
   {{ title_prefix }}
@@ -32,6 +34,7 @@
         'secondary': true
       } %}
     </div>
+    {{ dd(content.field.media[0]['#media'].field_media_image.alt) }}
     {% if content.field_media | render %}
     {% if image.attributes.alt %}
     <div class="vote-hero__image">
@@ -40,9 +43,10 @@
     {% else %}
     
     <div class="vote-hero__image">
-      {{ content.field_media | field_value }}
+      {{ content.field_media | field_value }} 
     </div>
     {% endif %}
   {% endif %}
+
   </div>
 </section>

--- a/web/themes/custom/votegov/templates/paragraph/paragraph--hero.html.twig
+++ b/web/themes/custom/votegov/templates/paragraph/paragraph--hero.html.twig
@@ -33,9 +33,16 @@
       } %}
     </div>
     {% if content.field_media | render %}
+    {% if image.attributes.alt %}
     <div class="vote-hero__image">
       {{ content.field_media | field_value }}
     </div>
+    {% else %}
+    
+    <div class="vote-hero__image">
+      {{ content.field_media | field_value }}
+    </div>
+    {% endif %}
   {% endif %}
   </div>
 </section>

--- a/web/themes/custom/votegov/templates/paragraph/paragraph--hero.html.twig
+++ b/web/themes/custom/votegov/templates/paragraph/paragraph--hero.html.twig
@@ -9,10 +9,16 @@
   'vote-hero--' ~ content.field_background_color | field_value | render
 ] %}
 
+{% set alt_text = content.field_media[0]['#item'].alt %}
+
 {# Caching the data in content object #}
 {% set savedCache = content | render %}
 
 {# add if statement - if alt is set of alt = alt else null alt = alt="" #}
+
+{# {% if item.alt %}
+  {{ item.alt|t }} -> {{ 'New alt text'|t }}
+{% endif %} #}
 
 <section{{ attributes.addClass(classes) }}>
   {# Hold these title_* placeholders for potential integration #}
@@ -34,16 +40,18 @@
         'secondary': true
       } %}
     </div>
-    {{ dd(content.field.media[0]['#media'].field_media_image.alt) }}
+    {# {{ dd(content.field_media[0]['#item'].alt) }} #}
+
     {% if content.field_media | render %}
-    {% if image.attributes.alt %}
+    {# {{ dd(alt_text) }} #}
+    {% if alt_text is not empty %}
     <div class="vote-hero__image">
       {{ content.field_media | field_value }}
     </div>
     {% else %}
-    
     <div class="vote-hero__image">
-      {{ content.field_media | field_value }} 
+      {{ content.field_media | {{ add_alt_text(content.field_media, 'Your alt text here') | field_value }} }}
+    
     </div>
     {% endif %}
   {% endif %}

--- a/web/themes/custom/votegov/templates/paragraph/paragraph--hero.html.twig
+++ b/web/themes/custom/votegov/templates/paragraph/paragraph--hero.html.twig
@@ -9,16 +9,8 @@
   'vote-hero--' ~ content.field_background_color | field_value | render
 ] %}
 
-{% set alt_text = content.field_media[0]['#item'].alt %}
-
 {# Caching the data in content object #}
 {% set savedCache = content | render %}
-
-{# add if statement - if alt is set of alt = alt else null alt = alt="" #}
-
-{# {% if item.alt %}
-  {{ item.alt|t }} -> {{ 'New alt text'|t }}
-{% endif %} #}
 
 <section{{ attributes.addClass(classes) }}>
   {# Hold these title_* placeholders for potential integration #}
@@ -45,21 +37,10 @@
         } %}
       </div>
     </div>
-    {# {{ dd(content.field_media[0]['#item'].alt) }} #}
-
     {% if content.field_media | render %}
-    {# {{ dd(alt_text) }} #}
-    {% if alt_text is not empty %}
     <div class="vote-hero__image">
       {{ content.field_media | field_value }}
     </div>
-    {% else %}
-    <div class="vote-hero__image">
-      {{ content.field_media | {{ add_alt_text(content.field_media, 'Your alt text here') | field_value }} }}
-    
-    </div>
-    {% endif %}
   {% endif %}
-
   </div>
 </section>


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[Vote-2235](https://cm-jira.usa.gov/browse/VOTE-2235)

## Description

Addressing 2 fails that were happening in the Cypress Axe tests 

- Image needing alt text:  Now that we are setting alt text on an image as optional this will set up a conditional to check that if alt text is present render the image if not add the attribute of `role="presentation"` to allow the component to pass. [See documentation for more info](https://dequeuniversity.com/rules/axe/4.9/image-alt?application=axeAPI) 
- content needed a wrapper: With the new Voter guide cards it was living outside of main and needed to have a landmark element. [See documentation for more info](https://dequeuniversity.com/rules/axe/4.9/region?application=axeAPI)  

## Deployment and testing

### Post-deploy steps

1. run `lando retune`
2. cd into `votegov` theme and run `npm run build`

### QA/Testing instructions

1. log in as a super user and upload an image and do not add any alt text.  Inspect the image and check to see if the attribute of `role="presentation"`and then add an image with alt text and check that the role is removed and the alt text is being added.
2. cd into `testing` and run `npm run cy:open` and select the Axe test and check that all tests outside of the register to vote are passing (this is getting addressed in another ticket)

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
