### PR TITLE
VOTE-2191 align registration tool horizontally on desktop

### DIFF
--- a/web/themes/custom/votegov/src/sass/components/registration-tool.scss
+++ b/web/themes/custom/votegov/src/sass/components/registration-tool.scss
@@ -5,13 +5,15 @@
 .vote-registration-tool {
   --registration-tool--bg: #{$base-dark};
   --registration-tool__input--text: #{$base-dark};
-  @include vote-block-padding-y--narrow;
+  @include u-padding-top(5);
+  @include u-padding-bottom(6);
   background-color: var(--registration-tool--bg);
   color: $base-white;
 
   @include at-media('tablet-lg') {
     background: var(--registration-tool--bg) url('../../img/hero-map.webp') no-repeat center center;
     background-size: cover;
+    @include u-padding-bottom(10);
   }
 
   [data-theme="contrast"] & {
@@ -27,19 +29,18 @@
 
 .vote-registration-tool__container {
   @include grid-container;
-}
 
-.vote-registration-tool__content {
   @include at-media('tablet-lg') {
     @include grid-row;
+    @include u-flex('align-center');
+    @include u-flex('justify');
 
-    .vote-registration-tool__text {
+    .vote-registration-tool__content {
       @include grid-col(6);
     }
 
     .vote-registration-tool__form {
       @include grid-col(5);
-      margin-inline-start: calc(100% / 12);
     }
   }
 

--- a/web/themes/custom/votegov/templates/paragraph/paragraph--registration-tool.html.twig
+++ b/web/themes/custom/votegov/templates/paragraph/paragraph--registration-tool.html.twig
@@ -15,11 +15,11 @@
   {{ title_prefix }}
   {{ title_suffix }}
   <div class="vote-registration-tool__container">
-    {{ drupal_entity('block', 'votegov_breadcrumbs') }}
-    <h1 class="vote-registration-tool__heading">
-      {{ content.field_heading | field_value }}
-    </h1>
     <div class="vote-registration-tool__content">
+      {{ drupal_entity('block', 'votegov_breadcrumbs') }}
+      <h1 class="vote-registration-tool__heading">
+        {{ content.field_heading | field_value }}
+      </h1>
       <div class="vote-registration-tool__text">
         {% if content.field_body | render %}
           {{ content.field_body | field_value }}
@@ -27,35 +27,35 @@
           <p>{{ content.field_form_heading | field_value }}</p>
         {% endif %}
       </div>
-      <form id="vote-registration-tool__form" class="vote-registration-tool__form">
-        <label class="{{ not content.field_body | render ? 'usa-sr-only' }} vote-registration-tool__label"
-               for="vote-registration-tool__input">
-          {{ content.field_form_heading | field_value }}
-        </label>
-        <input type="text" class="vote-registration-tool__input usa-input maxw-none"
-               id="vote-registration-tool__input" autocomplete="off"
-               placeholder="{{ content.field_placeholder | field_value }}" data-test="stateInput"
-               aria-autocomplete="list" aria-expanded="true" aria-controls="vote-registration-tool__results">
-        <div class="vote-registration-tool__list-container">
-          <div id="vote-registration-tool__results" class="vote-registration-tool__nav" role="listbox"
-               aria-label="{{ 'States and territories list' | t }}">
-            <ul class="vote-registration-tool__list" data-test="stateList">
-              {% set results = drupal_view_result('state_territory', 'block') %}
-              {% for result in results %}
-                {% set nodeID = result._entity.id() %}
-                {% set node_path = path('entity.node.canonical', {'node': nodeID}) %}
-                {% set node_key = result._entity.field_state_abbreviation.value %}
-                <li role="option">
-                  <a data-key="{{ node_key }}" href="{{ node_path }}">{{ result.node_field_data_title }}</a>
-                </li>
-              {% endfor %}
-              <li id="vote-registration-tool__no-results" hidden>
-                <span tabindex="0" data-key="">{{ "No matching results. Please check spelling." | t }}</span>
-              </li>
-            </ul>
-          </div>
-        </div>
-      </form>
     </div>
+    <form id="vote-registration-tool__form" class="vote-registration-tool__form">
+      <label class="{{ not content.field_body | render ? 'usa-sr-only' }} vote-registration-tool__label"
+             for="vote-registration-tool__input">
+        {{ content.field_form_heading | field_value }}
+      </label>
+      <input type="text" class="vote-registration-tool__input usa-input maxw-none"
+             id="vote-registration-tool__input" autocomplete="off"
+             placeholder="{{ content.field_placeholder | field_value }}" data-test="stateInput"
+             aria-autocomplete="list" aria-expanded="true" aria-controls="vote-registration-tool__results">
+      <div class="vote-registration-tool__list-container">
+        <div id="vote-registration-tool__results" class="vote-registration-tool__nav" role="listbox"
+             aria-label="{{ 'States and territories list' | t }}">
+          <ul class="vote-registration-tool__list" data-test="stateList">
+            {% set results = drupal_view_result('state_territory', 'block') %}
+            {% for result in results %}
+              {% set nodeID = result._entity.id() %}
+              {% set node_path = path('entity.node.canonical', {'node': nodeID}) %}
+              {% set node_key = result._entity.field_state_abbreviation.value %}
+              <li role="option">
+                <a data-key="{{ node_key }}" href="{{ node_path }}">{{ result.node_field_data_title }}</a>
+              </li>
+            {% endfor %}
+            <li id="vote-registration-tool__no-results" hidden>
+              <span tabindex="0" data-key="">{{ "No matching results. Please check spelling." | t }}</span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </form>
   </div>
 </section>


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

https://cm-jira.usa.gov/browse/VOTE-2191

## Description

Horizontally center the regisration tool columns on desktop and above

## Deployment and testing

### Post-deploy steps

1. run `npm run build` in votegov theme
2. run `lando drush cr`

### QA/Testing instructions

1. visit http://vote-gov.lndo.site/register make sure the two columns are horizontally center aligned
2. test in arabic and confirm it works in RTL

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
