### PR TITLE
VOTE-2105: Temporary CSS adjustment to in-page nav

### DIFF
--- a/web/themes/custom/votegov/src/sass/uswds-overrides/usa-in-page-nav.scss
+++ b/web/themes/custom/votegov/src/sass/uswds-overrides/usa-in-page-nav.scss
@@ -22,15 +22,14 @@
     }
 
     &.usa-current {
-      // @include vote-link-bg($color: $base-dark);
-      @include vote-link-bg; // temporarily using default color
+      @include vote-link-bg; // add back ($color: $base-dark) when USWDS fix is made
 
-      // section indicator (left of current section heading)
+      // turning off styling until USWDS fix is made
       &:after {
-        @include u-left(0);
-        inset-inline-start: 0;
-        background-color: $base-dark;
-        visibility: hidden; // temporarily hiding section indicator
+        display: none; // temporarily hiding section indicator
+        // @include u-left(0);
+        // inset-inline-start: 0;
+        // background-color: $base-dark;
       }
     }
   }

--- a/web/themes/custom/votegov/src/sass/uswds-overrides/usa-in-page-nav.scss
+++ b/web/themes/custom/votegov/src/sass/uswds-overrides/usa-in-page-nav.scss
@@ -22,12 +22,15 @@
     }
 
     &.usa-current {
-      @include vote-link-bg($color: $base-dark);
+      // @include vote-link-bg($color: $base-dark);
+      @include vote-link-bg; // temporarily using default color
 
+      // section indicator (left of current section heading)
       &:after {
         @include u-left(0);
         inset-inline-start: 0;
         background-color: $base-dark;
+        visibility: hidden; // temporarily hiding section indicator
       }
     }
   }

--- a/web/themes/custom/votegov/templates/layout/page--node--voter-guide.html.twig
+++ b/web/themes/custom/votegov/templates/layout/page--node--voter-guide.html.twig
@@ -30,9 +30,9 @@
         data-main-content-selector=".usa-in-page-nav-container"
         data-title-text="On this page"
         data-title-heading-level="h2"
-        data-scroll-offset="0"
-        data-root-margin="0px 0px -800px 0px"
-        data-threshold="0"
+        data-scroll-offset="-600"
+        data-root-margin="48px 0px -90% 0px"
+        data-threshold="1"
       ></aside>
       <div class="vote-page-content vote-page-content--alt">
         {{ page.content }}


### PR DESCRIPTION
## Jira ticket

[VOTE-2105](https://cm-jira.usa.gov/browse/VOTE-2105)

## Description

When clicking the name of a section on the USWDS in-page nav component, the "current section" indicator does not move to the correct section. This temporary adjustment hides the current section indicator by removing the text color adjustment and left indicator bar, until the bug can be resolved with USWDS (issue [here](https://github.com/uswds/uswds/issues/5953)).

Before (darker color and left indicator show which section is currently on-screen):
![image](https://github.com/usagov/vote-gov-drupal/assets/78001945/bb92c8b5-f07b-43b2-b643-2da44cb83978)

After change (no visual indication of current section):
![image](https://github.com/usagov/vote-gov-drupal/assets/78001945/da0eaffc-84d0-4cc9-a5d4-0e655bc17fc9)

## Deployment and testing

### Post-deploy steps

Navigate to `web/themes/custom/votegov`, and run `npm run dev`
In the root directory, run `lando retune`

### QA/Testing instructions

1. Navigate to a page where the in-page nav appears -- for example, Guide to Voting > Voting as a college student
2. Make sure that the in-page nav appears on the right side of the page
3. Scroll through the different sections of the page, making sure that there are no visual changes to the in-page nav (ie. changes that would indicate which section of the page is currently on-screen)
4. Interact with the in-page nav by clicking a section name to ensure that it still works as expected (ie. scrolls so that the given section is on-screen)

## Checklist for the Developer

- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
