### PR TITLE
VOTE-2201: Hide footer usagov links for non-engish & spanish sites IF not translated

### DIFF
--- a/web/themes/custom/votegov/php-includes/preprocess.inc
+++ b/web/themes/custom/votegov/php-includes/preprocess.inc
@@ -5,6 +5,8 @@
  * Theme preprocess functions.
  */
 
+ use Drupal\block_content\Entity\BlockContent;
+
 /**
  * Implements hook_preprocess().
  */
@@ -23,8 +25,8 @@ function votegov_preprocess(&$variables) {
   $sitename = Drupal::config('system.site')->get('name');
   $variables['sitename'] = $sitename;
 
-  // Block 18 translation flags
-  $block_18 = \Drupal\block_content\Entity\BlockContent::load(18);
+  // set Block 18 translation flags for each language.
+  $block_18 = BlockContent::load(18);
   $languages = Drupal::languageManager()->getLanguages();
   $variables['block_18_translations'] = [];
   foreach ($languages as $langcode => $langauge) {

--- a/web/themes/custom/votegov/php-includes/preprocess.inc
+++ b/web/themes/custom/votegov/php-includes/preprocess.inc
@@ -5,8 +5,6 @@
  * Theme preprocess functions.
  */
 
-use Drupal\block_content\Entity\BlockContent;
-
 /**
  * Implements hook_preprocess().
  */

--- a/web/themes/custom/votegov/php-includes/preprocess.inc
+++ b/web/themes/custom/votegov/php-includes/preprocess.inc
@@ -23,6 +23,14 @@ function votegov_preprocess(&$variables) {
   $sitename = Drupal::config('system.site')->get('name');
   $variables['sitename'] = $sitename;
 
+  // Block 18 translation flags
+  $block_18 = \Drupal\block_content\Entity\BlockContent::load(18);
+  $languages = Drupal::languageManager()->getLanguages();
+  $variables['block_18_translations'] = [];
+  foreach ($languages as $langcode => $langauge) {
+    $variables['block_18_translations'][$langcode] = $block_18->hasTranslation($langcode);
+  }
+
   $block = \Drupal\block_content\Entity\BlockContent::load(18);
   if ($block) {
     $html_content = $block->get('body')->value;

--- a/web/themes/custom/votegov/php-includes/preprocess.inc
+++ b/web/themes/custom/votegov/php-includes/preprocess.inc
@@ -23,6 +23,16 @@ function votegov_preprocess(&$variables) {
   $sitename = Drupal::config('system.site')->get('name');
   $variables['sitename'] = $sitename;
 
+  $block = \Drupal\block_content\Entity\BlockContent::load(18);
+  if ($block) {
+    $html_content = $block->get('body')->value;
+    $dom = new DOMDocument();
+    @$dom->loadHTML($html_content);
+    $a_tag = $dom->getElementsByTagName('li')[0]->getElementsByTagName('a')[0];
+    $text = $a_tag->nodeValue;
+    $variables['footer_links_content'] = $text;
+  }
+
   // Set variable for node object.
   $node = \Drupal::request()->attributes->get('node');
   if (!empty($node)) {

--- a/web/themes/custom/votegov/php-includes/preprocess.inc
+++ b/web/themes/custom/votegov/php-includes/preprocess.inc
@@ -31,16 +31,6 @@ function votegov_preprocess(&$variables) {
     $variables['block_18_translations'][$langcode] = $block_18->hasTranslation($langcode);
   }
 
-  $block = \Drupal\block_content\Entity\BlockContent::load(18);
-  if ($block) {
-    $html_content = $block->get('body')->value;
-    $dom = new DOMDocument();
-    @$dom->loadHTML($html_content);
-    $a_tag = $dom->getElementsByTagName('li')[0]->getElementsByTagName('a')[0];
-    $text = $a_tag->nodeValue;
-    $variables['footer_links_content'] = $text;
-  }
-
   // Set variable for node object.
   $node = \Drupal::request()->attributes->get('node');
   if (!empty($node)) {

--- a/web/themes/custom/votegov/php-includes/preprocess.inc
+++ b/web/themes/custom/votegov/php-includes/preprocess.inc
@@ -5,7 +5,7 @@
  * Theme preprocess functions.
  */
 
- use Drupal\block_content\Entity\BlockContent;
+use Drupal\block_content\Entity\BlockContent;
 
 /**
  * Implements hook_preprocess().
@@ -25,7 +25,7 @@ function votegov_preprocess(&$variables) {
   $sitename = Drupal::config('system.site')->get('name');
   $variables['sitename'] = $sitename;
 
-  // set Block 18 translation flags for each language.
+  // Set block 18 translation flags for each language.
   $block_18 = BlockContent::load(18);
   $languages = Drupal::languageManager()->getLanguages();
   $variables['block_18_translations'] = [];

--- a/web/themes/custom/votegov/php-includes/preprocess.inc
+++ b/web/themes/custom/votegov/php-includes/preprocess.inc
@@ -25,14 +25,6 @@ function votegov_preprocess(&$variables) {
   $sitename = Drupal::config('system.site')->get('name');
   $variables['sitename'] = $sitename;
 
-  // Set block 18 translation flags for each language.
-  $block_18 = BlockContent::load(18);
-  $languages = Drupal::languageManager()->getLanguages();
-  $variables['block_18_translations'] = [];
-  foreach ($languages as $langcode => $langauge) {
-    $variables['block_18_translations'][$langcode] = $block_18->hasTranslation($langcode);
-  }
-
   // Set variable for node object.
   $node = \Drupal::request()->attributes->get('node');
   if (!empty($node)) {

--- a/web/themes/custom/votegov/templates/component/usagov-partner.html.twig
+++ b/web/themes/custom/votegov/templates/component/usagov-partner.html.twig
@@ -1,9 +1,6 @@
 <div class="vote-usagov-partner">
   {# USA.gov Links #}
-  {% set content_cleaned = footer_links_content | render | striptags %}
-  {% set content_original = content_cleaned %}
-  {% set content_translated = content_original | t %}
-  {% if language == 'en' or content_translated != content_original %}
+  {% if block_18_translations[language] %}
     <nav class="vote-usagov-partner__links" aria-label={{ "External election resources" | t }}>
       {# USA.gov election info links #}
       {{ drupal_entity('block_content', '18') }}

--- a/web/themes/custom/votegov/templates/component/usagov-partner.html.twig
+++ b/web/themes/custom/votegov/templates/component/usagov-partner.html.twig
@@ -1,6 +1,7 @@
 <div class="vote-usagov-partner">
   {# USA.gov Links #}
-  {% set content_original = drupal_entity('block_content', '18') | render | striptags %}
+  {% set content_cleaned = footer_links_content | render | striptags %}
+  {% set content_original = content_cleaned %}
   {% set content_translated = content_original | t %}
   {% if language == 'en' or content_translated != content_original %}
     <nav class="vote-usagov-partner__links" aria-label={{ "External election resources" | t }}>

--- a/web/themes/custom/votegov/templates/component/usagov-partner.html.twig
+++ b/web/themes/custom/votegov/templates/component/usagov-partner.html.twig
@@ -1,9 +1,13 @@
 <div class="vote-usagov-partner">
   {# USA.gov Links #}
-  <nav class="vote-usagov-partner__links" aria-label={{ "External election resources" | t }}>
-    {# USA.gov election info links #}
-    {{ drupal_entity('block_content', '18') }}
-  </nav>
+  {% set content_original = drupal_entity('block_content', '18') | render | striptags %}
+  {% set content_translated = content_original | t %}
+  {% if language == 'en' or language == 'es' or content_translated != content_original %}
+    <nav class="vote-usagov-partner__links" aria-label={{ "External election resources" | t }}>
+      {# USA.gov election info links #}
+      {{ drupal_entity('block_content', '18') }}
+    </nav>
+  {% endif %}
 
   {# Row 2 Divider - USA.gov link and email sign-up #}
   <div class="vote-usagov-partner__contact-container">

--- a/web/themes/custom/votegov/templates/component/usagov-partner.html.twig
+++ b/web/themes/custom/votegov/templates/component/usagov-partner.html.twig
@@ -1,9 +1,10 @@
 <div class="vote-usagov-partner">
   {# USA.gov Links #}
-  {% if block_18_translations[language] %}
+  {% set usagov_links_block = drupal_entity('block_content', '18') %}
+  {% if usagov_links_block['#block_content'].langcode.value == language %}
     <nav class="vote-usagov-partner__links" aria-label={{ "External election resources" | t }}>
       {# USA.gov election info links #}
-      {{ drupal_entity('block_content', '18') }}
+      {{ usagov_links_block }}
     </nav>
   {% endif %}
 

--- a/web/themes/custom/votegov/templates/component/usagov-partner.html.twig
+++ b/web/themes/custom/votegov/templates/component/usagov-partner.html.twig
@@ -2,7 +2,7 @@
   {# USA.gov Links #}
   {% set content_original = drupal_entity('block_content', '18') | render | striptags %}
   {% set content_translated = content_original | t %}
-  {% if content_translated != content_original %}
+  {% if language == 'en' or content_translated != content_original %}
     <nav class="vote-usagov-partner__links" aria-label={{ "External election resources" | t }}>
       {# USA.gov election info links #}
       {{ drupal_entity('block_content', '18') }}

--- a/web/themes/custom/votegov/templates/component/usagov-partner.html.twig
+++ b/web/themes/custom/votegov/templates/component/usagov-partner.html.twig
@@ -2,7 +2,7 @@
   {# USA.gov Links #}
   {% set content_original = drupal_entity('block_content', '18') | render | striptags %}
   {% set content_translated = content_original | t %}
-  {% if language == 'en' or language == 'es' or content_translated != content_original %}
+  {% if content_translated != content_original %}
     <nav class="vote-usagov-partner__links" aria-label={{ "External election resources" | t }}>
       {# USA.gov election info links #}
       {{ drupal_entity('block_content', '18') }}


### PR DESCRIPTION
## Jira ticket

[VOTE-2201](https://cm-jira.usa.gov/browse/VOTE-2201)

## Description

Hide footer USAGov election links for non-engish & spanish sites IF not translated.

## Deployment and testing

### Post-deploy steps

1. run `npm run build` in votegov theme
2. run `lando retune`

### QA/Testing instructions

1. Load up the local site.
2. Verify "Learn more about U.S. elections" section is present
3. Go to /es and verify "Learn more about U.S. elections" section is NOT present
5. in `es.po` add id-str-pair for "State and local elections".
6. Run `lando import-translations`
7. Go to /es again and verify "Learn more about U.S. elections" section is now present.

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
