### PR TITLE
Vote-2127: Removed USWDS External Link Notification

### DIFF
--- a/web/themes/custom/votegov/src/sass/_uswds-settings.scss
+++ b/web/themes/custom/votegov/src/sass/_uswds-settings.scss
@@ -146,7 +146,7 @@ https://designsystem.digital.gov/documentation/settings/
   $theme-in-page-nav-margin-top: 0,
   // -- Input
   // -- Link
-  // turning off USWDS sting to let users know of an external link in favor or project settings
+  // turning off USWDS sting to let users know of an external link in favor of project settings
     $theme-external-link-sr-label-tab-new: " ",
   // -- Modal
   // -- Navigation

--- a/web/themes/custom/votegov/src/sass/_uswds-settings.scss
+++ b/web/themes/custom/votegov/src/sass/_uswds-settings.scss
@@ -146,6 +146,8 @@ https://designsystem.digital.gov/documentation/settings/
   $theme-in-page-nav-margin-top: 0,
   // -- Input
   // -- Link
+  // turning off USWDS sting to let users know of an external link in favor or project settings
+    $theme-external-link-sr-label-tab-new: " ",
   // -- Modal
   // -- Navigation
   $theme-header-min-width: 'tablet-lg',


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[Vote-2127](https://cm-jira.usa.gov/browse/VOTE-2127)

## Description

Removing the default voice over notification coming from USWDS to let the user know they are on an external link.  Since we have added custom strings that will be translated this will no longer be needed. 

## Deployment and testing

### Post-deploy steps

1. cd into the `votegov` theme and run a npm run dev and wait for build to complete 

### QA/Testing instructions

1. Visit home page and turn on voiceover (for mac can use command+f5) and use the tab button to navigate to an external link
2. The expected behavior is you should not hear "external link" at the start of the command but only the custom message we have applied. 
3. To verify that this is targeting the right setting visit `web/themes/custom/votegov/src/sass/_uswds-settings.scss` and update the setting by adding `This is a test` after a rebuild you should now hear this at the start of the link. 

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
