### PR TITLE
Vote-2228: Adding aria-current to main menu items

### DIFF
--- a/web/themes/custom/votegov/templates/navigation/menu--main--votegov-mainnavigation.html.twig
+++ b/web/themes/custom/votegov/templates/navigation/menu--main--votegov-mainnavigation.html.twig
@@ -49,7 +49,7 @@ We call a macro which calls itself to render the full tree.
       <ul class="usa-nav__primary usa-accordion" data-test="mobileNav">
         {% for item in items %}
           {% set aria_id = aria_id ~ loop.index | clean_id %}
-          <li class="usa-nav__primary-item" aria-current="{{ item.in_active_trail ? 'page' : 'false' }}">
+          <li class="usa-nav__primary-item">
             {% if item.below %}
               <button
                 type="button"
@@ -84,9 +84,10 @@ We call a macro which calls itself to render the full tree.
               {% else %}
                 {% set link_classes = [
                   'usa-nav__link',
-                  item.in_active_trail ? 'usa-current'
+                  item.in_active_trail ? 'usa-current',
                 ] %}
-                {{ link(item.title, item.url, {'class': link_classes}) }}
+                {% set link_attributes = item.in_active_trail? {'aria-current': 'page'} : {} %}
+                {{ link(item.title, item.url, {'class': link_classes} | merge(link_attributes)) }}
               {% endif %}
             {% endif %}
           </li>
@@ -97,7 +98,8 @@ We call a macro which calls itself to render the full tree.
         {% for item in items %}
           <li class="usa-nav__submenu-item">
             {% if item.url.routeName != '<nolink>' %}
-              {{ link(item.title, item.url) }}
+                {% set link_attributes = item.in_active_trail? {'aria-current': 'page'} : {} %}
+              {{ link(item.title, item.url, link_attributes) }}
             {% else %}
               <span>{{ item.title }}</span>
             {% endif %}

--- a/web/themes/custom/votegov/templates/navigation/menu--main--votegov-mainnavigation.html.twig
+++ b/web/themes/custom/votegov/templates/navigation/menu--main--votegov-mainnavigation.html.twig
@@ -49,7 +49,7 @@ We call a macro which calls itself to render the full tree.
       <ul class="usa-nav__primary usa-accordion" data-test="mobileNav">
         {% for item in items %}
           {% set aria_id = aria_id ~ loop.index | clean_id %}
-          <li class="usa-nav__primary-item">
+          <li class="usa-nav__primary-item" aria-current="{{ item.in_active_trail ? 'page' : 'false' }}">
             {% if item.below %}
               <button
                 type="button"

--- a/web/themes/custom/votegov/templates/navigation/menu--main--votegov-mainnavigation.html.twig
+++ b/web/themes/custom/votegov/templates/navigation/menu--main--votegov-mainnavigation.html.twig
@@ -70,7 +70,10 @@ We call a macro which calls itself to render the full tree.
                   'usa-nav__link--parent',
                   item.in_active_trail ? 'usa-current'
                 ] %}
-                <li class="usa-nav__submenu-item">{{ link(item.title, item.url, {'class': link_classes}) }}</li>
+                <li class="usa-nav__submenu-item">
+                  {% set link_attributes = item.in_active_trail ? {'aria-current': 'page'} : {} %}
+                  {{ link(item.title, item.url, {'class': link_classes} | merge(link_attributes)) }}
+                </li>
                 {{ menus.menu_links(item.below, attributes, menu_level + 1, aria_id) }}
 
             {% else %}
@@ -86,7 +89,7 @@ We call a macro which calls itself to render the full tree.
                   'usa-nav__link',
                   item.in_active_trail ? 'usa-current'
                 ] %}
-                {% set link_attributes = item.in_active_trail? {'aria-current': 'page'} : {} %}
+                {% set link_attributes = item.in_active_trail ? {'aria-current': 'page'} : {} %}
                 {{ link(item.title, item.url, {'class': link_classes} | merge(link_attributes)) }}
               {% endif %}
             {% endif %}
@@ -98,7 +101,7 @@ We call a macro which calls itself to render the full tree.
         {% for item in items %}
           <li class="usa-nav__submenu-item">
             {% if item.url.routeName != '<nolink>' %}
-                {% set link_attributes = item.in_active_trail? {'aria-current': 'page'} : {} %}
+              {% set link_attributes = item.in_active_trail ? {'aria-current': 'page'} : {} %}
               {{ link(item.title, item.url, link_attributes) }}
             {% else %}
               <span>{{ item.title }}</span>

--- a/web/themes/custom/votegov/templates/navigation/menu--main--votegov-mainnavigation.html.twig
+++ b/web/themes/custom/votegov/templates/navigation/menu--main--votegov-mainnavigation.html.twig
@@ -84,7 +84,7 @@ We call a macro which calls itself to render the full tree.
               {% else %}
                 {% set link_classes = [
                   'usa-nav__link',
-                  item.in_active_trail ? 'usa-current',
+                  item.in_active_trail ? 'usa-current'
                 ] %}
                 {% set link_attributes = item.in_active_trail? {'aria-current': 'page'} : {} %}
                 {{ link(item.title, item.url, {'class': link_classes} | merge(link_attributes)) }}


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[Vote-2228](https://cm-jira.usa.gov/browse/VOTE-2228)

## Description

Adding function for `arira-current` on the main nav links.  This set up function for the active page to have the current=page and all others to be set to false. 

See [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current) to see more info on this

## Deployment and testing

### Post-deploy steps

1. run `lando retune`

### QA/Testing instructions

1. Inspect the main nav and check that when you click on the page that you see `aria-current="page"` while on the active page 

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
