### PR TITLE
VOTE-2247 Remove translator access to edit block content

### DIFF
--- a/config/sync/user.role.content_translator.yml
+++ b/config/sync/user.role.content_translator.yml
@@ -8,10 +8,8 @@ dependencies:
     - node.type.landing
     - node.type.page
     - node.type.voter_guide
-    - taxonomy.vocabulary.basics_modules
     - workflows.workflow.publishing_content
   module:
-    - block_content
     - ckeditor5_embedded_content
     - content_moderation
     - content_translation
@@ -31,8 +29,6 @@ permissions:
   - 'edit own landing content'
   - 'edit own page content'
   - 'edit own voter_guide content'
-  - 'translate basics_modules taxonomy_term'
-  - 'translate block_content'
   - 'translate landing node'
   - 'translate page node'
   - 'translate paragraph'

--- a/config/sync/views.view.global_blocks.yml
+++ b/config/sync/views.view.global_blocks.yml
@@ -7,7 +7,6 @@ dependencies:
     - block_content.type.government_banner
     - block_content.type.registration_form_selector
     - block_content.type.search
-    - user.role.authenticated
   module:
     - block_content
     - user
@@ -370,10 +369,9 @@ display:
           sort_asc_label: Asc
           sort_desc_label: Desc
       access:
-        type: role
+        type: perm
         options:
-          role:
-            authenticated: authenticated
+          perm: 'access block library'
       cache:
         type: tag
         options: {  }
@@ -726,7 +724,7 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-        - user.roles
+        - user.permissions
       tags: {  }
   page_1:
     id: page_1
@@ -752,5 +750,5 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-        - user.roles
+        - user.permissions
       tags: {  }

--- a/config/sync/views.view.site_alerts.yml
+++ b/config/sync/views.view.site_alerts.yml
@@ -6,7 +6,6 @@ dependencies:
     - block_content.type.inline_alert
     - block_content.type.sitewide_alert
     - field.storage.block_content.field_publish
-    - user.role.authenticated
   module:
     - block_content
     - user
@@ -377,10 +376,9 @@ display:
           sort_asc_label: Asc
           sort_desc_label: Desc
       access:
-        type: role
+        type: perm
         options:
-          role:
-            authenticated: authenticated
+          perm: 'access block library'
       cache:
         type: tag
         options: {  }
@@ -685,7 +683,7 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-        - user.roles
+        - user.permissions
       tags:
         - 'config:field.storage.block_content.field_publish'
   page_1:
@@ -712,6 +710,6 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-        - user.roles
+        - user.permissions
       tags:
         - 'config:field.storage.block_content.field_publish'

--- a/web/modules/custom/vote_utility/inc/form_alter.inc
+++ b/web/modules/custom/vote_utility/inc/form_alter.inc
@@ -21,3 +21,16 @@ function vote_utility_form_node_state_territory_edit_form_alter(&$form, FormStat
     $form['field_override_registration_link']['#access'] = FALSE;
   }
 }
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function vote_utility_form_user_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  // Check if the user has the "content_translator" role.
+  if (\Drupal::currentUser()->hasRole('content_translator')) {
+    // Disable access to alter user profile settings.
+    $form['language']['#disabled'] = TRUE;
+    $form['account']['#disabled'] = TRUE;
+    $form['actions']['#access'] = FALSE;
+  }
+}


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

https://cm-jira.usa.gov/browse/VOTE-2243
https://cm-jira.usa.gov/browse/VOTE-2247

## Description

Remove translator access to edit blocks.
Remove translator access to edit user profile.

## Deployment and testing

### Post-deploy steps

1. run `lando retune`

### QA/Testing instructions

1. Login and create a new test user with the role of content translator
2. Logout and login in as the content translator user
3. visit http://vote-gov.lndo.site/admin/content and confirm you only see the "content" tab and no "block" related tabs are available.
4. try to edit your user profile by click on your username in the admin toolbar and clicking on "edit profile" and make sure the fields are disabled.

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
