### PR TITLE
Vote- 2234 high contrast breadcrumb

### DIFF
--- a/web/themes/custom/votegov/src/sass/mixins/mixins.scss
+++ b/web/themes/custom/votegov/src/sass/mixins/mixins.scss
@@ -158,16 +158,23 @@
 
 @mixin vote-link-dark {
   @include u-text('underline');
-  color: $base-white;
+  --vote-link--color: #{$base-white};
+  --vote-link-hover--color: #{$ac-cool-light};
+  color: var(--vote-link--color);
+
+  [data-theme="contrast"] & {
+    --vote-link--color: #{$base-white};
+    --vote-link-hover--color: #{$link-high-contrast-hover-blue};
+  }
 
   &:visited {
-    color: $base-white;
+    color: var(--vote-link--color);
   }
 
   @include hover {
     @include u-text('underline');
     background-color: transparent;
-    color: $ac-cool-light;
+    color: var(--vote-link-hover--color);
   }
 }
 

--- a/web/themes/custom/votegov/src/sass/mixins/mixins.scss
+++ b/web/themes/custom/votegov/src/sass/mixins/mixins.scss
@@ -164,7 +164,7 @@
 
   [data-theme="contrast"] & {
     --vote-link--color: #{$base-white};
-    --vote-link-hover--color: #{$link-high-contrast-hover-blue};
+    --vote-link-hover--color: #{$btn-secondary-bg-high-contrast-hover};
   }
 
   &:visited {

--- a/web/themes/custom/votegov/src/sass/uswds-overrides/usa-breadcrumb.scss
+++ b/web/themes/custom/votegov/src/sass/uswds-overrides/usa-breadcrumb.scss
@@ -6,9 +6,7 @@
 }
 
 .usa-breadcrumb__link {
-  .page-masthead & {
-    @include vote-link-dark;
-  }
+  @include vote-link-dark;
 }
 
 // targeting the div wrapping the breadcrumb block and add margin top to the following element

--- a/web/themes/custom/votegov/src/sass/uswds-overrides/usa-identifier.scss
+++ b/web/themes/custom/votegov/src/sass/uswds-overrides/usa-identifier.scss
@@ -5,14 +5,10 @@
 .usa-identifier {
   // Default to USWDS colors
   --usa-identifier-bg: #{color('base-darkest')};
-  --usa-identifier-link: #{color('base-light')};
-  --usa-identifier-link-hover: #{color('base-lighter')};
   background-color: var(--usa-identifier-bg);
 
   [data-theme="contrast"] & {
     --usa-identifier-bg: #{$bg-high-contrast};
-    --usa-identifier-link: #{$base-white};
-    --usa-identifier-link-hover: #{$link-high-contrast-hover-blue};
   }
 }
 
@@ -20,14 +16,6 @@
 .usa-identifier__required-link.usa-link,
 .usa-identifier__identity-disclaimer a,
 .usa-identifier__container a {
-  color: var(--usa-identifier-link);
-
-  &:visited {
-    color: var(--usa-identifier-link);
-  }
-
-  @include hover {
-    color: var(--usa-identifier-link-hover);
-  }
+  @include vote-link-dark;
 }
 


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

https://cm-jira.usa.gov/browse/VOTE-2234

## Description

1. Change the vote-dark-link mixin to have a yellow hover state for high contrast
2. Correctly apply the mixin to the breadcrumb

## Deployment and testing

### Post-deploy steps

1. re-build the theme
2. lando retune

### QA/Testing instructions

1. Visit [the register to vote page](http://vote-gov.lndo.site/register) and confirm the high contrast style is being applied correctly to the breadcrumb
2. Repeat on the [Guide to voting](http://vote-gov.lndo.site/guide-to-voting) page breadcrumb

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
