### PR TITLE
VOTE-2265 Remove 'default' option from hero background color field

### DIFF
--- a/config/sync/field.field.paragraph.hero.field_background_color.yml
+++ b/config/sync/field.field.paragraph.hero.field_background_color.yml
@@ -17,7 +17,7 @@ required: true
 translatable: false
 default_value:
   -
-    value: predefined_color_list_from_color_palette
+    value: dark
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/config/sync/field.storage.paragraph.field_background_color.yml
+++ b/config/sync/field.storage.paragraph.field_background_color.yml
@@ -12,9 +12,6 @@ type: list_string
 settings:
   allowed_values:
     -
-      value: predefined_color_list_from_color_palette
-      label: Default
-    -
       value: dark
       label: Dark
     -


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

https://cm-jira.usa.gov/browse/VOTE-2265

## Description

Remove default option from background color field on hero paragraph

## Deployment and testing

### Post-deploy steps

1. run `lando retune`

### QA/Testing instructions

1. Visit http://vote-gov.lndo.site/node/79/edit and edit the hero component
2. Confirm that there are only 2 options: dark and homepage

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
