### PR TITLE
VOTE-2225: Removed unnecessary aria-describedby attribute for registration

### DIFF
--- a/web/themes/custom/votegov/templates/paragraph/paragraph--registration-tool.html.twig
+++ b/web/themes/custom/votegov/templates/paragraph/paragraph--registration-tool.html.twig
@@ -10,7 +10,7 @@
 
 {{ attach_library('votegov/registration_tool') }}
 
-<section{{ attributes.addClass('vote-registration-tool').setAttribute('role', 'region').setAttribute('aria-label', 'Register to vote selector tool' | t).setAttribute('aria-describedby', content.field_form_heading | field_value | render) }}>
+<section{{ attributes.addClass('vote-registration-tool').setAttribute('role', 'region').setAttribute('aria-label', 'Register to vote selector tool' | t) }}>
   {# Hold these title_* placeholders for potential integration #}
   {{ title_prefix }}
   {{ title_suffix }}


### PR DESCRIPTION
## Jira ticket

[VOTE-2225](https://cm-jira.usa.gov/browse/VOTE-2225)

## Description

Removed unnecessary aria-describedby attribute on registration page

## Deployment and testing

### Post-deploy steps

1. run `npm run build` in votegov theme
2. run `lando retune`

### QA/Testing instructions

1. Load up the local site
2. Go to /register
3. Using Inspect-Element verify that there is no aria-describedby attribute in the <section class="vote-registration-tool">

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [] The file changes are relevant to the task objective.
- [] Code is readable and includes appropriate commenting.
- [] Code standards and best practices are followed.
- [] QA/Test steps were successfully completed, if applicable.
- [] Applicable logs are free of errors.
