### PR TITLE
VOTE-226: Language selector - high contrast

### DIFF
--- a/web/themes/custom/votegov/src/sass/uswds-overrides/usa-language-selector.scss
+++ b/web/themes/custom/votegov/src/sass/uswds-overrides/usa-language-selector.scss
@@ -47,11 +47,17 @@
 }
 
 .usa-language__submenu {
+  --usa-language--submenu-bg: #{$base-dark};
+
+  [data-theme="contrast"] & {
+    --usa-language--submenu-bg: #{$btn-bg-high-contrast};
+  }
+
   @include u-padding(2.5);
   @include u-width('auto');
   @include u-radius('sm');
   @include u-text('no-wrap');
-  background-color: $base-dark;
+  background-color: var(--usa-language--submenu-bg);
 
   .usa-language__primary-item:last-of-type & {
     @include u-right('auto');
@@ -89,9 +95,15 @@
 
 
 .usa-button.usa-language__link {
-  &[aria-expanded="true"]{
+  --usa-language--link-bg: #{$base-dark};
+
+  [data-theme="contrast"] & {
+    --usa-language--link-bg: #{$btn-bg-high-contrast};
+  }
+
+  &[aria-expanded="true"] {
     @include u-radius-bottom(0);
-    background-color: $base-dark;
+    background-color: var(--usa-language--link-bg);
   }
 }
 


### PR DESCRIPTION
## Jira ticket

[VOTE-2261](https://cm-jira.usa.gov/browse/VOTE-2261)

## Description

Adds high contrast variables for the language selector button and dropdown

## Deployment and testing

### QA/Testing instructions

1. lando retune
2. npm run build
3. Visit a page that has 3 translations so the dropdown renders
4. Toggle the language selector and confirm no style regressions
5. Toggle high contrast mode on
6. Toggle the language selector and high contrast confirm styles

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
