### PR TITLE
Vote-2229: Adding aria-label="secondary" to footer nav

### DIFF
--- a/web/themes/custom/votegov/templates/layout/page.html.twig
+++ b/web/themes/custom/votegov/templates/layout/page.html.twig
@@ -135,7 +135,7 @@
   {% endif %}
 {% endblock %}
 
-<footer class="usa-footer">
+<footer aria-label="{{ 'Secondary' | t }}" class="usa-footer">
   {% include '@votegov/component/usagov-partner.html.twig' %}
   {% include '@votegov/component/eacgov-partner.html.twig' %}
   {% include '@votegov/component/usa-identifier.html.twig' %}


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[Vote-2229](https://cm-jira.usa.gov/browse/VOTE-2229)

## Description

Adding `aria-label="secondary"` to the footer element to address issues brought up by the USA.gov team

see [W3 Documentation](https://www.w3.org/TR/WCAG20-TECHS/H97.html) for reference.  This update will match the same mark up for the aria-label found in the [main nav](https://github.com/usagov/vote-gov-drupal/blob/8c90441196b07d38c6f1ad23559ffd5d7c59e57c/web/themes/custom/votegov/templates/navigation/menu--main--votegov-mainnavigation.html.twig#L30)

## Deployment and testing

### Post-deploy steps

1. run `lando retune`

### QA/Testing instructions

1. inspect the footer and check that `aria-label="Secondary"` is present

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
