### PR TITLE
Vote-2233: adding contrast styles to touchpoints form

### DIFF
--- a/web/themes/custom/votegov/src/sass/components/touchpoints.scss
+++ b/web/themes/custom/votegov/src/sass/components/touchpoints.scss
@@ -1,4 +1,6 @@
 @use "uswds-core" as *;
+@use "variables" as *;
+@use "mixins" as *;
 
 .touchpoints-form-wrapper {
   h2.fba-modal-title {
@@ -20,5 +22,18 @@
     @include u-right(3);
     border-bottom-right-radius: 0;
     border-bottom-left-radius: 0;
+  }
+}
+
+// Targeting the submit button on embedded form
+.fba-modal-dialog .usa-form .usa-button {
+  --usa-button-bg: #{$base-primary};
+  --usa-button--outline: #{color('blue-40v')};
+  background-color: var(--usa-button-bg);
+  outline-color: var(--usa-button--outline);
+
+  [data-theme="contrast"] & {
+    --usa-button-bg: #{$btn-bg-high-contrast};
+    outline-color: var(--usa-button--outline);
   }
 }


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[Vote-2233](https://cm-jira.usa.gov/browse/VOTE-2333)

## Description

Adding high contrast styles to the embedded touch points form on accessibility page.  Also updating the base style to match the site theme as well. 

## Deployment and testing

### Post-deploy steps

1. run `lando retune` and then cd into the `votegov` theme and run `npm run build`

### QA/Testing instructions

1. visit accessibility page and toggle on the high contrast mode and verify that styles are being added.  
2. also check that hover and base styles match others on the site as well. 

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
