### PR TITLE
Vote-2349: Add "On this page" transltion for spanish

### DIFF
--- a/web/modules/custom/vote_utility/translations/es.po
+++ b/web/modules/custom/vote_utility/translations/es.po
@@ -19,6 +19,10 @@ msgstr "Seleccione el idioma"
 msgid "Home"
 msgstr "Página principal"
 
+#in-page nav
+msgid "On this page"
+msgstr "En esta página"
+
 #main
 msgid "@sitename in language"
 msgstr "@sitename en Español"

--- a/web/themes/custom/votegov/templates/layout/page--node--voter-guide.html.twig
+++ b/web/themes/custom/votegov/templates/layout/page--node--voter-guide.html.twig
@@ -28,7 +28,7 @@
       <aside
         class="usa-in-page-nav"
         data-main-content-selector=".usa-in-page-nav-container"
-        data-title-text="On this page"
+        data-title-text="{{ 'On this page' | t }}"
         data-title-heading-level="h2"
         data-scroll-offset="-600"
         data-root-margin="48px 0px -90% 0px"


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[Vote-2349](https://cm-jira.usa.gov/browse/VOTE-2349)

## Description

Adding the Spanish translation for "On this page" for the in-page nav. 

![Screenshot 2024-07-11 at 9 52 31 AM](https://github.com/usagov/vote-gov-drupal/assets/88721460/0ad6079f-9afd-45f6-a628-c99eababf9a3)


## Deployment and testing

### Post-deploy steps

1. run `lando retune`

### QA/Testing instructions

1. log in as an admin locally and visit `http://vote-gov.lndo.site/node/82/translations` and add a spanish translation (just save the page no need to worry about other text). 
2. verify that `On this page` has been translated. 

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
