### PR TITLE
VOTE-2330 Update voter guide listing view to only display results fro…

### DIFF
--- a/config/sync/views.view.voter_guides.yml
+++ b/config/sync/views.view.voter_guides.yml
@@ -171,6 +171,48 @@ display:
           plugin_id: bundle
           value:
             voter_guide: voter_guide
+        langcode:
+          id: langcode
+          table: node_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: langcode
+          plugin_id: language
+          operator: in
+          value:
+            '***LANGUAGE_language_interface***': '***LANGUAGE_language_interface***'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       style:
         type: default
         options:


### PR DESCRIPTION
…m the current language

<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

https://cm-jira.usa.gov/browse/VOTE-2330

## Description

Update voter guide listing view on voter guide pages to only show results from the current language.

## Deployment and testing

### Post-deploy steps

1. run `lando retune`

### QA/Testing instructions

1. visit http://vote-gov.lndo.site/node/82/translations and add a spanish translation of this voter guide
2. visit http://vote-gov.lndo.site/node/83/translations and add a spnaish translation of this voter guide
3. visit http://vote-gov.lndo.site/guide-to-voting/new-united-states-citizen and confirm Spanish voter guides are not displaying in the listing
4. visit http://vote-gov.lndo.site/es/guide-to-voting/new-united-states-citizen and confirm that only the Spanish voter guide displaying in the listing

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
