### PR TITLE
VOTE-2328: Move #main-content id to fix andi tab order

### DIFF
--- a/web/themes/custom/votegov/templates/layout/page--node--landing.html.twig
+++ b/web/themes/custom/votegov/templates/layout/page--node--landing.html.twig
@@ -1,9 +1,8 @@
 {% extends "page.html.twig" %}
 
 {% block main %}
-  <main role="main" id="main">
-    {# link is in html.html.twig #}
-    <a id="main-content" tabindex="-1"></a>
+  <main role="main" id="main-content">
+
     {{ page.content }}
   </main>
 {% endblock %}

--- a/web/themes/custom/votegov/templates/layout/page--node--voter-guide.html.twig
+++ b/web/themes/custom/votegov/templates/layout/page--node--voter-guide.html.twig
@@ -2,8 +2,7 @@
 {% set title = drupal_title() %}
 
 {% block main %}
-  <main role="main" id="main">
-    <a id="main-content" tabindex="-1"></a>
+  <main role="main" id="main-content">
     <section class="vote-hero vote-hero--dark">
       <div class="vote-hero__container">
         <div class="vote-hero__callout">

--- a/web/themes/custom/votegov/templates/layout/page.html.twig
+++ b/web/themes/custom/votegov/templates/layout/page.html.twig
@@ -97,9 +97,7 @@
 
 {% block main %}
   {% if page.sidebar %}
-    <section class="grid-container content-container">
-      {# link is in html.html.twig #}
-      <a id="main-content" tabindex="-1"></a>
+    <section id="main-content" class="grid-container content-container">
       <div class="page-masthead {{ node_image ? "page-masthead--image-offset" }}">
         {# Breadcrumbs component. #}
         {{ drupal_entity('block', 'votegov_breadcrumbs') }}
@@ -117,9 +115,7 @@
       </div>
     </section>
   {% else %}
-    <main role="main" id="main" class="grid-container content-container">
-      {# link is in html.html.twig #}
-      <a id="main-content" tabindex="-1"></a>
+    <main role="main" id="main-content" class="grid-container content-container">
       <div class="page-masthead {{ node_image ? "page-masthead--image-offset" }}">
         {# Breadcrumbs component. #}
         {{ drupal_entity('block', 'votegov_breadcrumbs') }}


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

[VOTE-2328](https://cm-jira.usa.gov/browse/VOTE-2328)

Insert a link to the Jira ticket (e.g VOTE-XXX).

## Description

ANDI screen reader was generating an extra 'X' where the skip nav link element was to flag where it was removed from tab order. To fix, #main-content id has been to the container of the main content in each instance.

## Deployment and testing

### QA/Testing instructions

1. lando retune
2. Using ANDI, turn on tab order
<img width="387" alt="Screenshot 2024-07-11 at 7 35 28 PM" src="https://github.com/user-attachments/assets/bf636b6a-714d-4928-a195-3bd1dd893ecc">
3. Confirm skip navigation works the same as expected
4. Confirm the "X" span isn't being added under the main nav
<img width="513" alt="Screenshot 2024-07-11 at 7 36 31 PM" src="https://github.com/user-attachments/assets/4684a74a-abc2-4804-b0ac-552f70e9c5c4">


## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
