### PR TITLE
VOTE-2370: Add 'No Results Message' field to Registration Tool

### DIFF
--- a/config/sync/core.entity_form_display.paragraph.registration_tool.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.registration_tool.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.paragraph.registration_tool.field_body
     - field.field.paragraph.registration_tool.field_form_heading
     - field.field.paragraph.registration_tool.field_heading
+    - field.field.paragraph.registration_tool.field_no_results_message
     - field.field.paragraph.registration_tool.field_placeholder
     - paragraphs.paragraphs_type.registration_tool
   module:
@@ -34,6 +35,14 @@ content:
   field_heading:
     type: string_textfield
     weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_no_results_message:
+    type: string_textfield
+    weight: 4
     region: content
     settings:
       size: 60

--- a/config/sync/core.entity_view_display.paragraph.registration_tool.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.registration_tool.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.paragraph.registration_tool.field_body
     - field.field.paragraph.registration_tool.field_form_heading
     - field.field.paragraph.registration_tool.field_heading
+    - field.field.paragraph.registration_tool.field_no_results_message
     - field.field.paragraph.registration_tool.field_placeholder
     - paragraphs.paragraphs_type.registration_tool
   module:
@@ -37,6 +38,14 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     weight: 0
+    region: content
+  field_no_results_message:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 3
     region: content
   field_placeholder:
     type: string

--- a/config/sync/field.field.paragraph.registration_tool.field_no_results_message.yml
+++ b/config/sync/field.field.paragraph.registration_tool.field_no_results_message.yml
@@ -1,0 +1,19 @@
+uuid: 0fa55891-9519-46e0-ad9f-2fba31fbb232
+langcode: es
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_no_results_message
+    - paragraphs.paragraphs_type.registration_tool
+id: paragraph.registration_tool.field_no_results_message
+field_name: field_no_results_message
+entity_type: paragraph
+bundle: registration_tool
+label: 'No Results Message'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.storage.paragraph.field_no_results_message.yml
+++ b/config/sync/field.storage.paragraph.field_no_results_message.yml
@@ -1,0 +1,21 @@
+uuid: 41cd1478-0d48-4230-be98-a78cd846b748
+langcode: es
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_no_results_message
+field_name: field_no_results_message
+entity_type: paragraph
+type: string
+settings:
+  max_length: 100
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/themes/custom/votegov/templates/paragraph/paragraph--registration-tool.html.twig
+++ b/web/themes/custom/votegov/templates/paragraph/paragraph--registration-tool.html.twig
@@ -50,7 +50,7 @@
               </li>
             {% endfor %}
             <li id="vote-registration-tool__no-results" hidden>
-              <span tabindex="0" data-key="">{{ "No matching results. Please check spelling." | t }}</span>
+              <span tabindex="0" data-key="">{{ content.field_no_results_message | field_value }}</span>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[VOTE-2370](https://cm-jira.usa.gov/browse/VOTE-2370)

## Description

Adds a field to the registration tool paragraph type to allow admin translation for the no results message. English and Spanish content/translation will need to be added after merging.

## Deployment and testing

### Post-deploy steps

1. Add English content for the field:
"No matching results. Please check spelling."

2. Add English content for the field:
"No hay resultados. Por favor, revise bien la ortografía."

### QA/Testing instructions

1. lando retune
2. Navigate to http://vote-gov.lndo.site/register
3. Edit page
4. Edit State Registration Tool
5. Add string in "No Results Message" field and save
6. Translate field to Spanish
7. Test by typing nonsense into the State Registration Tool :-)

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
