### PR TITLE
VOTE-2375 Enable translation on double deck card component

### DIFF
--- a/config/sync/field.field.paragraph.double_deck_card.field_body.yml
+++ b/config/sync/field.field.paragraph.double_deck_card.field_body.yml
@@ -15,7 +15,7 @@ bundle: double_deck_card
 label: 'State list'
 description: ''
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/config/sync/field.field.paragraph.double_deck_card.field_body_secondary.yml
+++ b/config/sync/field.field.paragraph.double_deck_card.field_body_secondary.yml
@@ -17,7 +17,7 @@ bundle: double_deck_card
 label: 'Guidance Text'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/config/sync/field.field.paragraph.double_deck_card.field_heading.yml
+++ b/config/sync/field.field.paragraph.double_deck_card.field_heading.yml
@@ -12,7 +12,7 @@ bundle: double_deck_card
 label: Heading
 description: ''
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/config/sync/language.content_settings.paragraph.double_deck_card.yml
+++ b/config/sync/language.content_settings.paragraph.double_deck_card.yml
@@ -1,0 +1,18 @@
+uuid: 903c83fd-4c80-4ead-952d-9466fb24fcb6
+langcode: es
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.double_deck_card
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '1'
+id: paragraph.double_deck_card
+target_entity_type_id: paragraph
+target_bundle: double_deck_card
+default_langcode: site_default
+language_alterable: false


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

https://cm-jira.usa.gov/browse/VOTE-2375

## Description

Enable translation on double deck card component

## Deployment and testing

### Post-deploy steps

1. run `lando retune`

### QA/Testing instructions

1. visit http://vote-gov.lndo.site/guide-to-voting/after-felony-conviction
2. Edit the page and add a double deck card in english and publish
3. Create a new translation of the page for spanish
4. Edit the double deck card content and publish
5. Confirm that you can save without error and that the spanish content shows on the spanish page and the english content on the english page

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been included above.
- [ ] No merge conflicts exist with the target branch.
- [ ] Automated tests have passed on this PR.
- [ ] A reviewer has been designated.
- [ ] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
