### PR TITLE
VOTE-1122: Reduce unused Javascript

### DIFF
--- a/web/themes/custom/votegov/templates/layout/html.html.twig
+++ b/web/themes/custom/votegov/templates/layout/html.html.twig
@@ -74,12 +74,14 @@
     </script>
     {% if not logged_in %}
       <!-- Google Tag Manager -->
+      <!--
       <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push(
           {'gtm.start': new Date().getTime(),event:'gtm.js'}
         );var f=d.getElementsByTagName(s)[0],
           j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','GTM-5BKF7S7X');</script>
+      -->
       <!-- End Google Tag Manager -->
     {% endif %}
 </head>


### PR DESCRIPTION
## Jira ticket

[VOTE-1122](https://cm-jira.usa.gov/browse/VOTE-1122)

## Description

Commenting out the "Google Tag Manager," which is detected as a source of unused Javascript by Lighthouse:
![image](https://github.com/user-attachments/assets/b6e4755b-f3ad-409e-9af6-44ed11d653e0)

After commenting out this section of code, "Reduce unused Javascript" no longer appears as an action item in the lighthouse mobile performance report.

## Deployment and testing

### QA/Testing instructions

1. Run a lighthouse performance test for mobile using the Chrome Dev tools, and confirm that "Reduce unused Javascript" is no longer listed as an issue.
2. Confirm that the site still loads and works correctly (the Google Tag Manager is used for site analytics, so commenting it out should not impact functionality)

## Checklist for the Developer

- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
