### PR TITLE
VOTE-2418: Resolve issue with taxonomy page loading

### DIFF
--- a/web/themes/custom/votegov/templates/taxonomy/taxonomy-term--basics-modules.html.twig
+++ b/web/themes/custom/votegov/templates/taxonomy/taxonomy-term--basics-modules.html.twig
@@ -15,10 +15,13 @@
 
 {# Gather the id of the parent paragraph #}
 {% set id = term._referringItem.parent.parent.entity.id.value %}
-{# Load the parent paragraph object #}
-{% set paragraph_parent = drupal_entity('paragraph', id , 'default') %}
-{# Set the heading level based on the value of the header in the parent paragraph #}
-{% set heading_level = paragraph_parent['#paragraph'].field_heading.value ? 'h3' : 'h2' %}
+{% set heading_level = 'h2' %}
+{% if id %}
+  {# Load the parent paragraph object #}
+  {% set paragraph_parent = drupal_entity('paragraph', id , 'default') %}
+  {# Set the heading level based on the value of the header in the parent paragraph #}
+  {% set heading_level = paragraph_parent['#paragraph'].field_heading.value ? 'h3' : 'h2' %}
+{% endif %}
 
 {% block content %}
   <{{heading_level | default('h2')}} {{ heading_level != 'h3' ? 'class="vote-heading--red-underline"' }}>{{ content.field_heading | field_value }}</{{heading_level}}>


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[VOTE-2418](https://cm-jira.usa.gov/browse/VOTE-2418)

## Description

Fix bug with Basic Modules taxonomy term page. Add default handling of header tag when the term is not loaded from a parenting paragraph.

## Deployment and testing

### Post-deploy steps

1. Run `lando retune`

### QA/Testing instructions

1. Go to the taxonomy admin page for Basic Modules and view the list of terms.
2. Click on any term to view its page.
3. Confirm that the page loads and no error is displayed.
4. Confirm that the headings are shown as H2's.
5. Goto /guide-to-voting and locate a Basic Modules block (ie. taxonomy/52 which is Voting In Person).
6. Confirm that the heading for (ie Voting In Person) is shown as H3.

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been included above.
- [ ] No merge conflicts exist with the target branch.
- [ ] Automated tests have passed on this PR.
- [ ] A reviewer has been designated.
- [ ] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
