### PR TITLE
VOTE-2371: Add Spanish Aria Labels

### DIFF
--- a/web/modules/custom/vote_utility/translations/es.po
+++ b/web/modules/custom/vote_utility/translations/es.po
@@ -169,6 +169,15 @@ msgstr "Ir al contenido principal"
 msgid "(in English)"
 msgstr "(en inglés)"
 
+msgid "Register to vote selector tool"
+msgtr "Herramienta selector para registrarse para votar"
+
+msgid "Select your state or territory"
+msgstr "Seleccione su estado o territorio"
+
+msgid "States and territories tion list"
+msgtr "Lista de sugerencias de estados y territorios"
+
 #banner
 msgid "Official government website"
 msgstr "Sitio web oficial del gobierno"

--- a/web/modules/custom/vote_utility/translations/es.po
+++ b/web/modules/custom/vote_utility/translations/es.po
@@ -170,13 +170,13 @@ msgid "(in English)"
 msgstr "(en inglés)"
 
 msgid "Register to vote selector tool"
-msgtr "Herramienta selector para registrarse para votar"
+msgstr "Herramienta selector para registrarse para votar"
 
 msgid "Select your state or territory"
 msgstr "Seleccione su estado o territorio"
 
-msgid "States and territories tion list"
-msgtr "Lista de sugerencias de estados y territorios"
+msgid "States and territories list"
+msgstr "Lista de sugerencias de estados y territorios"
 
 #banner
 msgid "Official government website"


### PR DESCRIPTION
## Jira ticket

[VOTE-2371](https://cm-jira.usa.gov/browse/VOTE-2371)

## Description

Added three aria-label translations for the Spanish version of the "Register to vote" page. Two of the translations appear on the page, as seen below:
![image](https://github.com/user-attachments/assets/dec1b862-b122-4a94-806b-7c0785131f93)
For one of the translations ("Select your state or territory" --> "Seleccione su estado o territorio") there is no English aria-label that says "Select your state or territory," so it does not appear on the page.

## Deployment and testing

### Post-deploy steps

1. Run `lando retune` after pulling to ensure that the translations are updated.

### QA/Testing instructions

1. Load the home page of the site, and switch to Spanish using the language selector
2. Navigate to the Register to vote page using the button on the home page
3. Using Chrome dev tools or WAVE, ensure that the first two translated aria-labels appear as expected on the vote-registration-tool <section> element and the list of state/territory names.

## Checklist for the Developer

- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
