### PR TITLE
VOTE-2411 Fix typo in overseas voter card

### DIFF
--- a/web/modules/custom/vote_utility/translations/es.po
+++ b/web/modules/custom/vote_utility/translations/es.po
@@ -321,5 +321,5 @@ msgstr "Votar como miembro del servicio militar"
 msgid "Learn more from the Federal Voting Assistance Program."
 msgstr "Obtenga más información del Programa Federal de Asistencia para Votar (sigla en inglés)."
 
-msgid "Voting as a U.S. citizenfrom outside the U.S."
+msgid "Voting as a U.S. citizen from outside the U.S."
 msgstr "Votar como ciudadano en el extrajero"

--- a/web/themes/custom/votegov/templates/component/feature-cards.html.twig
+++ b/web/themes/custom/votegov/templates/component/feature-cards.html.twig
@@ -42,7 +42,7 @@
           </div>
           <div class="vote-feature-card__content">
             <h3 class="usa-card__heading">
-              <span>{{"Voting as a U.S. citizenfrom outside the U.S." | t }}</span>
+              <span>{{"Voting as a U.S. citizen from outside the U.S." | t }}</span>
             </h3>
             <div class="usa-card__body">
               {{ "Learn more from the Federal Voting Assistance Program." | t }}


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

https://cm-jira.usa.gov/browse/VOTE-2411

## Description

Fix the typo found in the overseas voter card

## Deployment and testing

### Post-deploy steps

1. In the root folder of the repo, **lando retune**
2. cd into web/themes/custom/votegov, **npm run build**

### QA/Testing instructions

1. Visit the homepage in English, and confirm the overseas voter card has the typo (space between "citizen and "from")
![image](https://github.com/user-attachments/assets/1db85d69-4177-4651-ba34-23ccd5dfdc37)

2. Select Spanish from the language dropdown, and confirm the overseas voter card translates
![image](https://github.com/user-attachments/assets/e3a9ba0e-9317-4101-8d24-fee54d8e8088)


## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
