### PR TITLE
BUGFIX: remove 'of' from alias ignore settings

### DIFF
--- a/config/sync/pathauto.settings.yml
+++ b/config/sync/pathauto.settings.yml
@@ -42,7 +42,7 @@ max_component_length: 100
 transliterate: true
 reduce_ascii: false
 case: true
-ignore_words: 'a, an, as, at, before, but, by, for, from, is, in, into, like, of, off, on, onto, per, since, than, the, this, that, to, up, via, with'
+ignore_words: 'a, an, as, at, before, but, by, for, from, is, in, into, like, off, on, onto, per, since, than, the, this, that, to, up, via, with'
 update_action: 2
 safe_tokens:
   - alias


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

https://cm-jira.usa.gov/browse/VOTE-2491

## Description

Allow 'of' in auto generated aliases

## Deployment and testing

### Post-deploy steps

1. run `lando retune`

### QA/Testing instructions

1. Create a new basic page with the title 'Title of page' and make sure the checkbox for auto generating the alias is checked. Then save.
2. Confirm that the alias reads `/title-of-page`

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
