### PR TITLE
VOTE-2319 Change date format for election day to long date

### DIFF
--- a/web/themes/custom/votegov/templates/node/node--state-territory.html.twig
+++ b/web/themes/custom/votegov/templates/node/node--state-territory.html.twig
@@ -22,7 +22,7 @@
 {% set of_state_name = node.field_of_state_name.value | default("@state_name") | t({ "@state_name": state_name}) %}
 {% set state_abrev = content.field_state_abbreviation | field_value | render %}
 {% set in_english = "(in English)" | t %}
-{% set election_date = "11/05/2024"  | date('U') | format_date('revision_date') | replace(t_numbers[language].numbers | default([])) %}
+{% set election_date = "11/05/2024"  | date('U') | format_date('long_date') | replace(t_numbers[language].numbers | default([])) %}
 {% set election_link_text = 'Find state and local election dates.' | t %}
 {% if language != "en" %}
   {% set election_link_text = election_link_text ~ ' ' ~ in_english %}


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

https://cm-jira.usa.gov/browse/VOTE-2391

## Description

Change the format of the election date to match format of the registration deadlines. 
Single digits are expressed as "5", not "05".

## Deployment and testing

### Post-deploy steps

1. lando retune

### QA/Testing instructions

1. Visit http://vote-gov.lndo.site/register/colorado and confirm the election day format is changed to match the rest rest of the dates.
![image](https://github.com/user-attachments/assets/c69647cd-aadb-4487-94fc-78978f6219bb)
2. Switch to Spanish, and confirm the dates match the Spanish format and translation.
![image](https://github.com/user-attachments/assets/c76e1491-4a0d-4ab3-8809-37bbf3a108ce)

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
