### PR TITLE
VOTE-2443 Replace spanish usa.gov links in the footer

### DIFF
--- a/web/themes/custom/votegov/templates/component/usa-identifier.html.twig
+++ b/web/themes/custom/votegov/templates/component/usa-identifier.html.twig
@@ -34,8 +34,13 @@
     <div class="usa-identifier__container">
       <p>
         {% set usagov_link = "Visit USA.gov" | t %}
+        {% if language != "es" %}
+          {% set usagov_url = "https://www.usa.gov/" %}
+        {% else %}
+          {% set usagov_url = "https://www.usa.gov/es" %}
+        {% endif %}
         {{'Looking for U.S. government information and services? @link.' | t({
-          '@link': {'#markup': " <a href=\"https://www.usa.gov/\" class=\"usa-link\">#{usagov_link}</a>"} | render
+          '@link': {'#markup': " <a href=#{usagov_url} class=\"usa-link\">#{usagov_link}</a>"} | render
         }) }}
       </p>
     </div>

--- a/web/themes/custom/votegov/templates/component/usa-identifier.html.twig
+++ b/web/themes/custom/votegov/templates/component/usa-identifier.html.twig
@@ -34,10 +34,10 @@
     <div class="usa-identifier__container">
       <p>
         {% set usagov_link = "Visit USA.gov" | t %}
-        {% if language != "es" %}
-          {% set usagov_url = "https://www.usa.gov/" %}
-        {% else %}
+        {% if language == "es" %}
           {% set usagov_url = "https://www.usa.gov/es" %}
+        {% else %}
+          {% set usagov_url = "https://www.usa.gov" %}
         {% endif %}
         {{'Looking for U.S. government information and services? @link.' | t({
           '@link': {'#markup': " <a href=#{usagov_url} class=\"usa-link\">#{usagov_link}</a>"} | render

--- a/web/themes/custom/votegov/templates/component/usagov-partner.html.twig
+++ b/web/themes/custom/votegov/templates/component/usagov-partner.html.twig
@@ -13,10 +13,10 @@
     <div class="vote-usagov-partner__contact">
       <div class="vote-usagov-partner__logo">
         {# USA.gov link #}
-        {% if language != "es" %}
-          {% set usagov_url = "https://www.usa.gov/" %}
-        {% else %}
+        {% if language == "es" %}
           {% set usagov_url = "https://www.usa.gov/es" %}
+        {% else %}
+          {% set usagov_url = "https://www.usa.gov" %}
         {% endif %}
         <a href={{ usagov_url }} extlinkjs-ignore>
           <img

--- a/web/themes/custom/votegov/templates/component/usagov-partner.html.twig
+++ b/web/themes/custom/votegov/templates/component/usagov-partner.html.twig
@@ -13,7 +13,12 @@
     <div class="vote-usagov-partner__contact">
       <div class="vote-usagov-partner__logo">
         {# USA.gov link #}
-        <a href="https://www.usa.gov/" extlinkjs-ignore>
+        {% if language != "es" %}
+          {% set usagov_url = "https://www.usa.gov/" %}
+        {% else %}
+          {% set usagov_url = "https://www.usa.gov/es" %}
+        {% endif %}
+        <a href={{ usagov_url }} extlinkjs-ignore>
           <img
             src="{{ theme_path }}/img/usagov-logo.svg"
             alt="{{ "USA.gov logo" | t }}"


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

https://cm-jira.usa.gov/browse/VOTE-2443

## Description

Direct hardcoded usa.gov links in the footer to the Spanish site when the translation is set to Spanish.

## Deployment and testing

### Post-deploy steps

1. lando retune

### QA/Testing instructions

1. Visit the homepage, and switch to Spanish. Confirm the usa.gov logo and the Visit usa.gov link goes to their Spanish site.
2. Switch to English, confirm the links still direct to the English site.

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been included above.
- [ ] No merge conflicts exist with the target branch.
- [ ] Automated tests have passed on this PR.
- [ ] A reviewer has been designated.
- [ ] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
