### PR TITLE
Adding a sleep command to wait to rerun any failed test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,7 @@ jobs:
       - run:
           name: "Cypress - frontend tests - rerun"
           command: |
+            sleep 120
             echo "I am the result of frontend tests failed job"
             cd testing
             npm install
@@ -77,6 +78,7 @@ jobs:
       - run:
           name: "Cypress - axe tests - rerun"
           command: |
+            sleep 120
             echo "I am the result of axe tests failed job"
             cd testing
             npm install


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[Vote-2421](https://cm-jira.usa.gov/browse/VOTE-2421)

## Description

Adding a delay to the rerun tests if the first one fails... the goal is to help address any issues with a upkeep command and the site not building 

## Deployment and testing

### Post-deploy steps

n/a

### QA/Testing instructions

1. verify that the sleep command is added to the rerun steps

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
