### PR TITLE
VOTE-2381: Add 'lang' attribute to language names

### DIFF
--- a/web/themes/custom/votegov/templates/navigation/links--language-block.html.twig
+++ b/web/themes/custom/votegov/templates/navigation/links--language-block.html.twig
@@ -64,7 +64,7 @@
         {%- if item.link -%}
           {# Replace default title with combo of endonym and english versions #}
           {% set link_title %}
-            <span{{ create_attribute().setAttribute('lang', key) }}>
+            <span lang="{{ key }}">
               <strong class="nonvfont">{{ item.link['#title'] }}</strong> {{ item.link['#english'] }}
             </span>
           {% endset %}

--- a/web/themes/custom/votegov/templates/navigation/links--language-block.html.twig
+++ b/web/themes/custom/votegov/templates/navigation/links--language-block.html.twig
@@ -64,7 +64,9 @@
         {%- if item.link -%}
           {# Replace default title with combo of endonym and english versions #}
           {% set link_title %}
-            <strong class="nonvfont">{{ item.link['#title'] }}</strong> {{ item.link['#english'] }}
+            <span{{ create_attribute().setAttribute('lang', key) }}>
+              <strong class="nonvfont">{{ item.link['#title'] }}</strong> {{ item.link['#english'] }}
+            </span>
           {% endset %}
           {# Add class to exclude navajo font from link render #}
           {% set link_options = item.link['#options'] | merge({


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[VOTE-2381](https://cm-jira.usa.gov/browse/VOTE-2381)

## Description

Add correct `lang` attribute to span surrounding name in language switcher. Note that the ticket asks for both lang and xml:lang but we found twig does not support the deprecated xml:lang attribute so it's not being included. This was approved by Ray. source: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes

## Deployment and testing

### QA/Testing instructions

1. lando retune
2. inspect langauge name inside of language switcher list
3. confirm correct attribute for "lang" is wrapping the name (compare to ticket and vote.gov)

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
