### PR TITLE
VOTE-2380: Only allow 'image' as embedded option in WYSIWYG

### DIFF
--- a/config/sync/core.entity_view_display.media.image.scaled.yml
+++ b/config/sync/core.entity_view_display.media.image.scaled.yml
@@ -1,0 +1,46 @@
+uuid: 626b9a83-0f93-4953-97a8-ca30a42cf88f
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.scaled
+    - field.field.media.image.field_caption
+    - field.field.media.image.field_media_image
+    - image.style.scaled_lg
+    - media.type.image
+  module:
+    - svg_image
+    - text
+id: media.image.scaled
+targetEntityType: media
+bundle: image
+mode: scaled
+content:
+  field_caption:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_media_image:
+    type: image
+    label: visually_hidden
+    settings:
+      image_link: ''
+      image_style: scaled_lg
+      image_loading:
+        attribute: lazy
+      svg_attributes:
+        width: null
+        height: null
+      svg_render_as_image: true
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  created: true
+  langcode: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/config/sync/core.entity_view_mode.media.scaled.yml
+++ b/config/sync/core.entity_view_mode.media.scaled.yml
@@ -1,0 +1,11 @@
+uuid: 71e28add-26ea-4400-9cde-70baf155c1df
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.scaled
+label: Scaled
+description: ''
+targetEntityType: media
+cache: true

--- a/config/sync/filter.format.basic_html.yml
+++ b/config/sync/filter.format.basic_html.yml
@@ -2,6 +2,8 @@ uuid: 7541554d-e57b-4314-953a-24e11f9082c4
 langcode: en
 status: true
 dependencies:
+  config:
+    - core.entity_view_mode.media.scaled
   module:
     - ckeditor5_embedded_content
     - media
@@ -30,8 +32,8 @@ filters:
     status: true
     weight: 100
     settings:
-      default_view_mode: default
+      default_view_mode: scaled
       allowed_view_modes:
-        default: default
+        scaled: scaled
       allowed_media_types:
         image: image

--- a/config/sync/filter.format.basic_html.yml
+++ b/config/sync/filter.format.basic_html.yml
@@ -33,4 +33,5 @@ filters:
       default_view_mode: default
       allowed_view_modes:
         default: default
-      allowed_media_types: {  }
+      allowed_media_types:
+        image: image


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[VOTE-2341](https://cm-jira.usa.gov/browse/VOTE-2341)

## Description

Remove the ability to embed audio, document, icon and video from the wysiwyg. Only image is available.

## Deployment and testing

### QA/Testing instructions

1. Pull up any wysiwyg editor and confirm only image media type is available to embed

Before
<img width="1177" alt="Screenshot 2024-08-02 at 2 31 52 PM" src="https://github.com/user-attachments/assets/d6a9a1f1-9e68-4f88-b352-fc4383fdafb3">

Now
<img width="1153" alt="Screenshot 2024-08-02 at 2 32 47 PM" src="https://github.com/user-attachments/assets/176fca56-7b06-4982-ad37-0037ae4acec8">

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
