### PR TITLE
VOTE-2520: Increase banner z-index to hide a11y tools

### DIFF
--- a/web/themes/custom/votegov/src/sass/components/a11y-toolbar.scss
+++ b/web/themes/custom/votegov/src/sass/components/a11y-toolbar.scss
@@ -21,7 +21,7 @@
   }
 
   @include at-media-max('tablet') {
-    @include u-bottom('105');
+    @include u-bottom(2.5);
     inset-inline-start: calc(50% - 3.125rem);
   }
 }

--- a/web/themes/custom/votegov/src/sass/uswds-overrides/usa-banner.scss
+++ b/web/themes/custom/votegov/src/sass/uswds-overrides/usa-banner.scss
@@ -6,7 +6,7 @@
   --usa-banner-body-text: #{color('base-darkest')};
   --usa-banner-text: #{color('base-darkest')};
   @include u-position('relative');
-  @include u-z(100);
+  @include u-z(300);
   background-color: $bg-light;
 
   [data-theme="contrast"] & {

--- a/web/themes/custom/votegov/src/sass/uswds-overrides/usa-language-selector.scss
+++ b/web/themes/custom/votegov/src/sass/uswds-overrides/usa-language-selector.scss
@@ -74,6 +74,7 @@
     @include u-height('viewport');
     @include u-width('full');
     @include u-padding(2);
+    @include u-padding-bottom(6);
     @include u-z(500);
     @include vote-fill;
     overflow: auto;


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[VOTE-2520](https://cm-jira.usa.gov/browse/VOTE-2520)

## Description

Adjust stacking order of language selector list so that a11y tools are not overlapping when it is open

### QA/Testing instructions

1. Navigate to any page with more than 2 languages
2. Select language selector to open list
3. Confirm a11y tools do not stack on top of language selector
4. Confirm no regressions with stacking order of other elements

Before
<img width="543" alt="Screenshot 2024-08-02 at 3 09 21 PM" src="https://github.com/user-attachments/assets/12630999-6525-4424-a422-6bf97f869761">

Now
<img width="564" alt="Screenshot 2024-08-02 at 3 10 03 PM" src="https://github.com/user-attachments/assets/1851f547-8210-4669-86bd-b19ac973d9e5">


## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
