### PR TITLE
VOTE-2184: add timestamps between steps of the downsync and backup scripts

### DIFF
--- a/scripts/pipeline/downsync-backup.sh
+++ b/scripts/pipeline/downsync-backup.sh
@@ -17,6 +17,8 @@ wait_for_tunnel() {
   done
 }
 
+date
+
 ## Create a tunnel through the application to pull the database.
 echo "Creating tunnel to database..."
 if [[ ${BACKUP_ENV} = "prod" ]]; then
@@ -26,6 +28,8 @@ fi
 cf connect-to-service --no-client ${project}-drupal-${BACKUP_ENV} ${project}-mysql-${BACKUP_ENV} > backup.txt &
 
 wait_for_tunnel
+
+date
 
 ## Create variables and credential file for MySQL login.
 echo "Backing up '${BACKUP_ENV}' database..."
@@ -97,6 +101,8 @@ echo "Backing up '${BACKUP_ENV}' database..."
 
 } >/dev/null 2>&1
 
+date
+
 ## Kill the backgrounded SSH tunnel.
 echo "Cleaning up old connections..."
 {
@@ -108,6 +114,8 @@ if [ ${BACKUP_ENV} = "prod" ]; then
   cf disable-ssh ${project}-drupal-${BACKUP_ENV}
 fi
 rm -rf backup.txt ~/.mysql
+
+date
 
 # Download media files.
 backup_media="cms/public/media"
@@ -134,3 +142,5 @@ echo "Downloading media files..."
 
   cf delete-service-key "${service}" "${service_key}" -f
 } >/dev/null 2>&1
+
+date

--- a/scripts/pipeline/downsync-restore.sh
+++ b/scripts/pipeline/downsync-restore.sh
@@ -17,11 +17,15 @@ wait_for_tunnel() {
   done
 }
 
+date
+
 ## Create a tunnel through the application to restore the database.
 echo "Creating tunnel to database..."
 cf connect-to-service --no-client ${project}-drupal-${RESTORE_ENV} ${project}-mysql-${RESTORE_ENV} > restore.txt &
 
 wait_for_tunnel
+
+date
 
 ## Create variables and credential file for MySQL login.
 echo "Restoring '${BACKUP_ENV}' database to '${RESTORE_ENV}'..."
@@ -48,6 +52,8 @@ echo "Restoring '${BACKUP_ENV}' database to '${RESTORE_ENV}'..."
 
 } >/dev/null 2>&1
 
+date
+
 ## Kill the backgrounded SSH tunnel.
 echo "Cleaning up old connections..."
 {
@@ -57,8 +63,12 @@ echo "Cleaning up old connections..."
 ## Clean up.
 rm -rf restore.txt ~/.mysql backup_${BACKUP_ENV}.sql
 
+date
+
 echo "Running 'drush cr' on '${RESTORE_ENV}' database..."
 source $(pwd $(dirname $0))/scripts/pipeline/cloud-gov-remote-command.sh "${project}-drupal-${RESTORE_ENV}" "drush cr"
+
+date
 
 # Upload media files.
 backup_media="cms/public/media"
@@ -85,5 +95,9 @@ echo "Uploading media files..."
   cf delete-service-key "${service}" "${service_key}" -f
 } >/dev/null 2>&1
 
+date
+
 echo "Running 'drush image-flush --all' on '${RESTORE_ENV}'..."
 source $(pwd $(dirname $0))/scripts/pipeline/cloud-gov-remote-command.sh "${project}-drupal-${RESTORE_ENV}" "drush image-flush --all"
+
+date

--- a/scripts/pipeline/scheduled_backup.sh
+++ b/scripts/pipeline/scheduled_backup.sh
@@ -15,6 +15,8 @@ rm -rf scheduled_backup/
 mkdir -p scheduled_backup
 cd scheduled_backup
 
+date
+
 echo "Downloading media files..."
 {
   cf target -s "${cf_space}"
@@ -39,6 +41,8 @@ echo "Downloading media files..."
 
   cf delete-service-key "${service}" "${service_key}" -f
 } >/dev/null 2>&1
+
+date
 
 echo "Downloading static files..."
 {
@@ -65,6 +69,8 @@ echo "Downloading static files..."
   cf delete-service-key "${service}" "${service_key}" -f
 } >/dev/null 2>&1
 
+date
+
 echo "Downloading terraform state..."
 {
   cf target -s "${backup_space}"
@@ -89,6 +95,8 @@ echo "Downloading terraform state..."
 
   cf delete-service-key "${service}" "${service_key}" -f
 } >/dev/null 2>&1
+
+date
 
 echo "Saving to backup bucket..."
 {
@@ -134,3 +142,5 @@ echo "Saving to backup bucket..."
 
   cf delete-service-key "${service}" "${service_key}" -f >/dev/null 2>&1
 }
+
+date


### PR DESCRIPTION


## Jira ticket

[VOTE-2184](https://cm-jira.usa.gov/browse/VOTE-2184)

## Description

Add timestamps between steps of the two downsync and one backup scripts

## Deployment and testing

### QA/Testing instructions

1. After merged, look at the pipeline runs for scheduled backups and run a downsync.
2. Ensure timestamps are output to the pipeline.

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
