### PR TITLE
VOTE-2101 Add content version field to nodes and taxonomy edit forms

### DIFF
--- a/config/sync/core.entity_form_display.node.landing.default.yml
+++ b/config/sync/core.entity_form_display.node.landing.default.yml
@@ -4,14 +4,34 @@ status: true
 dependencies:
   config:
     - field.field.node.landing.body
+    - field.field.node.landing.field_content_version
     - field.field.node.landing.field_metatags
     - field.field.node.landing.field_paragraph_components
     - node.type.landing
   module:
     - content_moderation
+    - field_group
     - metatag
     - paragraphs
     - path
+third_party_settings:
+  field_group:
+    group_version_tracking:
+      children:
+        - field_content_version
+      label: 'Version tracking'
+      region: content
+      parent_name: ''
+      weight: 11
+      format_type: details_sidebar
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        open: true
+        description: ''
+        required_fields: true
+        weight: 0
 id: node.landing.default
 targetEntityType: node
 bundle: landing
@@ -22,6 +42,14 @@ content:
     weight: 2
     region: content
     settings: {  }
+    third_party_settings: {  }
+  field_content_version:
+    type: string_textfield
+    weight: 10
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   field_metatags:
     type: metatag_firehose

--- a/config/sync/core.entity_form_display.node.nvrf_page.default.yml
+++ b/config/sync/core.entity_form_display.node.nvrf_page.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.nvrf_page.body
+    - field.field.node.nvrf_page.field_content_version
     - field.field.node.nvrf_page.field_display_title
     - field.field.node.nvrf_page.field_general_instructions
     - field.field.node.nvrf_page.field_omb_number
@@ -11,8 +12,27 @@ dependencies:
     - workflows.workflow.publishing_content
   module:
     - content_moderation
+    - field_group
     - path
     - text
+third_party_settings:
+  field_group:
+    group_version_tracking:
+      children:
+        - field_content_version
+      label: 'Version tracking'
+      region: content
+      parent_name: ''
+      weight: 13
+      format_type: details_sidebar
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        open: true
+        description: ''
+        required_fields: true
+        weight: 0
 id: node.nvrf_page.default
 targetEntityType: node
 bundle: nvrf_page
@@ -33,6 +53,14 @@ content:
     weight: 3
     region: content
     settings: {  }
+    third_party_settings: {  }
+  field_content_version:
+    type: string_textfield
+    weight: 12
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   field_display_title:
     type: string_textfield

--- a/config/sync/core.entity_form_display.node.page.default.yml
+++ b/config/sync/core.entity_form_display.node.page.default.yml
@@ -5,16 +5,36 @@ dependencies:
   config:
     - field.field.node.page.body
     - field.field.node.page.field_body
+    - field.field.node.page.field_content_version
     - field.field.node.page.field_media
     - field.field.node.page.field_metatags
     - node.type.page
     - workflows.workflow.publishing_content
   module:
     - content_moderation
+    - field_group
     - media_library
     - metatag
     - path
     - text
+third_party_settings:
+  field_group:
+    group_content_version:
+      children:
+        - field_content_version
+      label: 'Version tracking'
+      region: content
+      parent_name: ''
+      weight: 11
+      format_type: details_sidebar
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        open: true
+        description: ''
+        required_fields: true
+        weight: 0
 id: node.page.default
 targetEntityType: node
 bundle: page
@@ -35,6 +55,14 @@ content:
       summary_rows: 3
       placeholder: ''
       show_summary: false
+    third_party_settings: {  }
+  field_content_version:
+    type: string_textfield
+    weight: 12
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   field_media:
     type: media_library_widget

--- a/config/sync/core.entity_form_display.node.state_territory.default.yml
+++ b/config/sync/core.entity_form_display.node.state_territory.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.state_territory.field_accepts_nvrf
     - field.field.node.state_territory.field_address_location_inst
     - field.field.node.state_territory.field_confirm_registration_link
+    - field.field.node.state_territory.field_content_version
     - field.field.node.state_territory.field_election_homepage_link
     - field.field.node.state_territory.field_g_in_person_deadline
     - field.field.node.state_territory.field_g_mail_postmarked_deadline
@@ -105,7 +106,7 @@ third_party_settings:
       label: Tabs
       region: content
       parent_name: ''
-      weight: 2
+      weight: 1
       format_type: tabs
       format_settings:
         classes: ''
@@ -196,6 +197,22 @@ third_party_settings:
         formatter: closed
         description: ''
         required_fields: true
+    group_version_tracking:
+      children:
+        - field_content_version
+      label: 'Version tracking'
+      region: content
+      parent_name: ''
+      weight: 10
+      format_type: details_sidebar
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        open: true
+        description: ''
+        required_fields: true
+        weight: 0
 id: node.state_territory.default
 targetEntityType: node
 bundle: state_territory
@@ -203,7 +220,7 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 4
+    weight: 3
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -232,6 +249,14 @@ content:
     settings:
       placeholder_url: ''
       placeholder_title: ''
+    third_party_settings: {  }
+  field_content_version:
+    type: string_textfield
+    weight: 11
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   field_election_homepage_link:
     type: link_default
@@ -356,7 +381,7 @@ content:
     third_party_settings: {  }
   field_metatags:
     type: metatag_firehose
-    weight: 9
+    weight: 8
     region: content
     settings:
       sidebar: true
@@ -509,26 +534,26 @@ content:
     third_party_settings: {  }
   field_updated_date:
     type: datetime_default
-    weight: 10
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
   langcode:
     type: language_select
-    weight: 8
+    weight: 7
     region: content
     settings:
       include_locked: true
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 6
+    weight: 5
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 7
+    weight: 6
     region: content
     settings:
       display_label: true
@@ -543,7 +568,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 3
+    weight: 2
     region: content
     settings:
       match_operator: CONTAINS
@@ -552,7 +577,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   url_redirects:
-    weight: 5
+    weight: 4
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.node.voter_guide.default.yml
+++ b/config/sync/core.entity_form_display.node.voter_guide.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.voter_guide.body
     - field.field.node.voter_guide.field_basics_block
+    - field.field.node.voter_guide.field_content_version
     - field.field.node.voter_guide.field_icon
     - field.field.node.voter_guide.field_media
     - field.field.node.voter_guide.field_metatags
@@ -13,11 +14,30 @@ dependencies:
     - workflows.workflow.publishing_content
   module:
     - content_moderation
+    - field_group
     - media_library
     - metatag
     - paragraphs
     - path
     - text
+third_party_settings:
+  field_group:
+    group_version_tracking:
+      children:
+        - field_content_version
+      label: 'Version tracking'
+      region: content
+      parent_name: ''
+      weight: 15
+      format_type: details_sidebar
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        open: true
+        description: ''
+        required_fields: true
+        weight: 0
 id: node.voter_guide.default
 targetEntityType: node
 bundle: voter_guide
@@ -58,6 +78,14 @@ content:
         collapse_edit_all: collapse_edit_all
         duplicate: '0'
     third_party_settings: {  }
+  field_content_version:
+    type: string_textfield
+    weight: 13
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   field_icon:
     type: media_library_widget
     weight: 5
@@ -97,7 +125,7 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 13
+    weight: 14
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.taxonomy_term.basics_modules.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.basics_modules.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.taxonomy_term.basics_modules.field_anchor_id
     - field.field.taxonomy_term.basics_modules.field_content
+    - field.field.taxonomy_term.basics_modules.field_content_version
     - field.field.taxonomy_term.basics_modules.field_heading
     - taxonomy.vocabulary.basics_modules
   module:
@@ -30,6 +31,14 @@ content:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
+  field_content_version:
+    type: string_textfield
+    weight: 4
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   field_heading:
     type: string_textfield
     weight: 1
@@ -40,7 +49,7 @@ content:
     third_party_settings: {  }
   langcode:
     type: language_select
-    weight: 4
+    weight: 5
     region: content
     settings:
       include_locked: true
@@ -55,13 +64,13 @@ content:
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 6
+    weight: 7
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   translation:
-    weight: 5
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.taxonomy_term.nvrf_field.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.nvrf_field.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.taxonomy_term.nvrf_field.field_content_version
     - field.field.taxonomy_term.nvrf_field.field_display_label
     - field.field.taxonomy_term.nvrf_field.field_error_message
     - field.field.taxonomy_term.nvrf_field.field_help_text
@@ -72,6 +73,14 @@ targetEntityType: taxonomy_term
 bundle: nvrf_field
 mode: default
 content:
+  field_content_version:
+    type: string_textfield
+    weight: 4
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   field_display_label:
     type: string_textfield
     weight: 1

--- a/config/sync/core.entity_view_display.node.landing.default.yml
+++ b/config/sync/core.entity_view_display.node.landing.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.landing.body
+    - field.field.node.landing.field_content_version
     - field.field.node.landing.field_metatags
     - field.field.node.landing.field_paragraph_components
     - node.type.landing
@@ -28,6 +29,14 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 3
+    region: content
+  field_content_version:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 8
     region: content
   field_metatags:
     type: metatag_empty_formatter

--- a/config/sync/core.entity_view_display.node.landing.full.yml
+++ b/config/sync/core.entity_view_display.node.landing.full.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.full
     - field.field.node.landing.body
+    - field.field.node.landing.field_content_version
     - field.field.node.landing.field_metatags
     - field.field.node.landing.field_paragraph_components
     - node.type.landing
@@ -32,6 +33,7 @@ content:
     region: content
 hidden:
   body: true
+  field_content_version: true
   field_metatags: true
   langcode: true
   links: true

--- a/config/sync/core.entity_view_display.node.landing.teaser.yml
+++ b/config/sync/core.entity_view_display.node.landing.teaser.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.landing.body
+    - field.field.node.landing.field_content_version
     - field.field.node.landing.field_metatags
     - field.field.node.landing.field_paragraph_components
     - node.type.landing
@@ -27,6 +28,7 @@ content:
     region: content
 hidden:
   body: true
+  field_content_version: true
   field_metatags: true
   field_paragraph_components: true
   langcode: true

--- a/config/sync/core.entity_view_display.node.nvrf_page.default.yml
+++ b/config/sync/core.entity_view_display.node.nvrf_page.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.nvrf_page.body
+    - field.field.node.nvrf_page.field_content_version
     - field.field.node.nvrf_page.field_display_title
     - field.field.node.nvrf_page.field_general_instructions
     - field.field.node.nvrf_page.field_omb_number
@@ -27,6 +28,14 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: -20
+    region: content
+  field_content_version:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 8
     region: content
   field_display_title:
     type: string

--- a/config/sync/core.entity_view_display.node.nvrf_page.teaser.yml
+++ b/config/sync/core.entity_view_display.node.nvrf_page.teaser.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.nvrf_page.body
+    - field.field.node.nvrf_page.field_content_version
     - field.field.node.nvrf_page.field_display_title
     - field.field.node.nvrf_page.field_general_instructions
     - field.field.node.nvrf_page.field_omb_number
@@ -28,6 +29,7 @@ content:
     region: content
 hidden:
   body: true
+  field_content_version: true
   field_display_title: true
   field_general_instructions: true
   field_omb_number: true

--- a/config/sync/core.entity_view_display.node.page.default.yml
+++ b/config/sync/core.entity_view_display.node.page.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.page.body
     - field.field.node.page.field_body
+    - field.field.node.page.field_content_version
     - field.field.node.page.field_media
     - field.field.node.page.field_metatags
     - node.type.page
@@ -35,6 +36,14 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 7
+    region: content
+  field_content_version:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 8
     region: content
   field_media:
     type: entity_reference_entity_view

--- a/config/sync/core.entity_view_display.node.page.full.yml
+++ b/config/sync/core.entity_view_display.node.page.full.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.full
     - field.field.node.page.body
     - field.field.node.page.field_body
+    - field.field.node.page.field_content_version
     - field.field.node.page.field_media
     - field.field.node.page.field_metatags
     - node.type.page
@@ -40,6 +41,7 @@ content:
     region: content
 hidden:
   body: true
+  field_content_version: true
   field_metatags: true
   langcode: true
   links: true

--- a/config/sync/core.entity_view_display.node.page.teaser.yml
+++ b/config/sync/core.entity_view_display.node.page.teaser.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.page.body
     - field.field.node.page.field_body
+    - field.field.node.page.field_content_version
     - field.field.node.page.field_media
     - field.field.node.page.field_metatags
     - node.type.page
@@ -29,6 +30,7 @@ content:
 hidden:
   body: true
   field_body: true
+  field_content_version: true
   field_media: true
   field_metatags: true
   langcode: true

--- a/config/sync/core.entity_view_display.node.state_territory.default.yml
+++ b/config/sync/core.entity_view_display.node.state_territory.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.state_territory.field_accepts_nvrf
     - field.field.node.state_territory.field_address_location_inst
     - field.field.node.state_territory.field_confirm_registration_link
+    - field.field.node.state_territory.field_content_version
     - field.field.node.state_territory.field_election_homepage_link
     - field.field.node.state_territory.field_g_in_person_deadline
     - field.field.node.state_territory.field_g_mail_postmarked_deadline
@@ -87,6 +88,14 @@ content:
       target: ''
     third_party_settings: {  }
     weight: 16
+    region: content
+  field_content_version:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 8
     region: content
   field_election_homepage_link:
     type: link

--- a/config/sync/core.entity_view_display.node.state_territory.full.yml
+++ b/config/sync/core.entity_view_display.node.state_territory.full.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.state_territory.field_accepts_nvrf
     - field.field.node.state_territory.field_address_location_inst
     - field.field.node.state_territory.field_confirm_registration_link
+    - field.field.node.state_territory.field_content_version
     - field.field.node.state_territory.field_election_homepage_link
     - field.field.node.state_territory.field_g_in_person_deadline
     - field.field.node.state_territory.field_g_mail_postmarked_deadline
@@ -320,6 +321,7 @@ content:
 hidden:
   body: true
   field_address_location_inst: true
+  field_content_version: true
   field_identification_inst: true
   field_mail_registration_link: true
   field_mailing_address_inst: true

--- a/config/sync/core.entity_view_display.node.state_territory.teaser.yml
+++ b/config/sync/core.entity_view_display.node.state_territory.teaser.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.state_territory.field_accepts_nvrf
     - field.field.node.state_territory.field_address_location_inst
     - field.field.node.state_territory.field_confirm_registration_link
+    - field.field.node.state_territory.field_content_version
     - field.field.node.state_territory.field_election_homepage_link
     - field.field.node.state_territory.field_g_in_person_deadline
     - field.field.node.state_territory.field_g_mail_postmarked_deadline
@@ -64,6 +65,7 @@ hidden:
   field_accepts_nvrf: true
   field_address_location_inst: true
   field_confirm_registration_link: true
+  field_content_version: true
   field_election_homepage_link: true
   field_g_in_person_deadline: true
   field_g_mail_postmarked_deadline: true

--- a/config/sync/core.entity_view_display.node.voter_guide.default.yml
+++ b/config/sync/core.entity_view_display.node.voter_guide.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.voter_guide.body
     - field.field.node.voter_guide.field_basics_block
+    - field.field.node.voter_guide.field_content_version
     - field.field.node.voter_guide.field_icon
     - field.field.node.voter_guide.field_media
     - field.field.node.voter_guide.field_metatags
@@ -40,6 +41,14 @@ content:
       link: ''
     third_party_settings: {  }
     weight: 4
+    region: content
+  field_content_version:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 8
     region: content
   field_icon:
     type: entity_reference_entity_view

--- a/config/sync/core.entity_view_display.node.voter_guide.full.yml
+++ b/config/sync/core.entity_view_display.node.voter_guide.full.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.full
     - field.field.node.voter_guide.body
     - field.field.node.voter_guide.field_basics_block
+    - field.field.node.voter_guide.field_content_version
     - field.field.node.voter_guide.field_icon
     - field.field.node.voter_guide.field_media
     - field.field.node.voter_guide.field_metatags
@@ -38,6 +39,7 @@ content:
     region: content
 hidden:
   content_moderation_control: true
+  field_content_version: true
   field_icon: true
   field_media: true
   field_metatags: true

--- a/config/sync/core.entity_view_display.node.voter_guide.teaser.yml
+++ b/config/sync/core.entity_view_display.node.voter_guide.teaser.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.voter_guide.body
     - field.field.node.voter_guide.field_basics_block
+    - field.field.node.voter_guide.field_content_version
     - field.field.node.voter_guide.field_icon
     - field.field.node.voter_guide.field_media
     - field.field.node.voter_guide.field_metatags
@@ -39,6 +40,7 @@ content:
 hidden:
   content_moderation_control: true
   field_basics_block: true
+  field_content_version: true
   field_media: true
   field_metatags: true
   field_subtitle: true

--- a/config/sync/core.entity_view_display.taxonomy_term.basics_modules.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.basics_modules.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.taxonomy_term.basics_modules.field_anchor_id
     - field.field.taxonomy_term.basics_modules.field_content
+    - field.field.taxonomy_term.basics_modules.field_content_version
     - field.field.taxonomy_term.basics_modules.field_heading
     - taxonomy.vocabulary.basics_modules
   module:
@@ -28,6 +29,14 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 1
+    region: content
+  field_content_version:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 3
     region: content
   field_heading:
     type: string

--- a/config/sync/core.entity_view_display.taxonomy_term.nvrf_field.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.nvrf_field.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.taxonomy_term.nvrf_field.field_content_version
     - field.field.taxonomy_term.nvrf_field.field_display_label
     - field.field.taxonomy_term.nvrf_field.field_error_message
     - field.field.taxonomy_term.nvrf_field.field_help_text
@@ -26,6 +27,14 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 0
+    region: content
+  field_content_version:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 3
     region: content
   field_display_label:
     type: string

--- a/config/sync/field.field.node.landing.field_content_version.yml
+++ b/config/sync/field.field.node.landing.field_content_version.yml
@@ -1,0 +1,19 @@
+uuid: 5708b076-8ae8-4ceb-a538-e08121166207
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_content_version
+    - node.type.landing
+id: node.landing.field_content_version
+field_name: field_content_version
+entity_type: node
+bundle: landing
+label: 'Content Version'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.node.nvrf_page.field_content_version.yml
+++ b/config/sync/field.field.node.nvrf_page.field_content_version.yml
@@ -1,0 +1,19 @@
+uuid: 04c20672-4bf1-4630-831b-5ebf930ef083
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_content_version
+    - node.type.nvrf_page
+id: node.nvrf_page.field_content_version
+field_name: field_content_version
+entity_type: node
+bundle: nvrf_page
+label: 'Content Version'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.node.page.field_content_version.yml
+++ b/config/sync/field.field.node.page.field_content_version.yml
@@ -1,0 +1,19 @@
+uuid: 1a1e59ac-0dea-4d94-91ca-237dd92b7362
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_content_version
+    - node.type.page
+id: node.page.field_content_version
+field_name: field_content_version
+entity_type: node
+bundle: page
+label: 'Content Version'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.node.state_territory.field_content_version.yml
+++ b/config/sync/field.field.node.state_territory.field_content_version.yml
@@ -1,0 +1,19 @@
+uuid: f4ef6d75-aeaf-489f-8512-61e356c90ff3
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_content_version
+    - node.type.state_territory
+id: node.state_territory.field_content_version
+field_name: field_content_version
+entity_type: node
+bundle: state_territory
+label: 'Content Version'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.node.voter_guide.field_content_version.yml
+++ b/config/sync/field.field.node.voter_guide.field_content_version.yml
@@ -1,0 +1,19 @@
+uuid: 075c6881-ae45-4aca-bb59-ce28762dc847
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_content_version
+    - node.type.voter_guide
+id: node.voter_guide.field_content_version
+field_name: field_content_version
+entity_type: node
+bundle: voter_guide
+label: 'Content Version'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.taxonomy_term.basics_modules.field_content_version.yml
+++ b/config/sync/field.field.taxonomy_term.basics_modules.field_content_version.yml
@@ -1,0 +1,19 @@
+uuid: 68b847ce-a8ac-43a1-a5fe-33dab0474672
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_content_version
+    - taxonomy.vocabulary.basics_modules
+id: taxonomy_term.basics_modules.field_content_version
+field_name: field_content_version
+entity_type: taxonomy_term
+bundle: basics_modules
+label: 'Content version'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.taxonomy_term.nvrf_field.field_content_version.yml
+++ b/config/sync/field.field.taxonomy_term.nvrf_field.field_content_version.yml
@@ -1,0 +1,19 @@
+uuid: 841d7e60-5e47-4c7c-bf0c-b07ef29fb5af
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_content_version
+    - taxonomy.vocabulary.nvrf_field
+id: taxonomy_term.nvrf_field.field_content_version
+field_name: field_content_version
+entity_type: taxonomy_term
+bundle: nvrf_field
+label: 'Content version'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.storage.node.field_content_version.yml
+++ b/config/sync/field.storage.node.field_content_version.yml
@@ -1,0 +1,21 @@
+uuid: e21a4add-df53-4029-9013-54a12aadc46c
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_content_version
+field_name: field_content_version
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.taxonomy_term.field_content_version.yml
+++ b/config/sync/field.storage.taxonomy_term.field_content_version.yml
@@ -1,0 +1,21 @@
+uuid: eae23485-4287-4a1b-a6f5-32c850f4bc2b
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_content_version
+field_name: field_content_version
+entity_type: taxonomy_term
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/vote_utility/inc/form_alter.inc
+++ b/web/modules/custom/vote_utility/inc/form_alter.inc
@@ -8,6 +8,21 @@
 use Drupal\Core\Form\FormStateInterface;
 
 /**
+ * Implements hook_form_alter().
+ */
+function vote_utility_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  if (isset($form['field_content_version'])) {
+    $current_user = \Drupal::service('current_user');
+    $roles = $current_user->getRoles();
+
+    if (in_array('content_editor', $roles)) {
+      // Hide content version field from content editors.
+      $form['field_content_version']['#access'] = FALSE;
+    }
+  }
+}
+
+/**
  * Implements hook_form_FORM_ID_alter().
  */
 function vote_utility_form_node_state_territory_edit_form_alter(&$form, FormStateInterface $form_state, $form_id) {


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

https://cm-jira.usa.gov/browse/VOTE-2101

## Description

Add new content version field to node and taxonomy edit forms. Field is hidden for content_editor role.

## Deployment and testing

### Post-deploy steps

1. `lando retune`

### QA/Testing instructions

1. visit http://vote-gov.lndo.site/node/add/page and confirm the Content version field displays in the sidebar.
2. visit http://vote-gov.lndo.site/node/add/landing and confirm the Content version field displays in the sidebar.
3. visit http://vote-gov.lndo.site/node/add/nvrf_page and confirm the Content version field displays in the sidebar.
4. visit http://vote-gov.lndo.site/node/add/state_territory and confirm the Content version field displays in the sidebar.
5. visit http://vote-gov.lndo.site/node/add/voter_guide and confirm the Content version field displays in the sidebar.
6. visit http://vote-gov.lndo.site/admin/structure/taxonomy/manage/basics_modules/add and confirm the Content version field displays.
7. visit http://vote-gov.lndo.site/admin/structure/taxonomy/manage/nvrf_field/add and confirm the Content version field displays.
8. Log in with the user with the role of content editor
9. visit http://vote-gov.lndo.site/node/add/page and confirm you can't see the Content version field.

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
