### PR TITLE
VOTE-2534: Update upkeep script to download current static files before running tome

### DIFF
--- a/scripts/upkeep
+++ b/scripts/upkeep
@@ -26,12 +26,15 @@ export ssg_endpoint="https://ssg-${environment}.vote.gov"
 [ "${environment}" = "prod" ] && export ssg_endpoint="https://vote.gov"
 export ssg_sitemap_endpoint=ssg_endpoint
 
-cd ${html_path}
 echo "**************************************************"
 echo "Copying current static files from '${bucket_name}'..."
 echo "**************************************************"
-aws s3 sync s3://${bucket} . --delete --no-verify-ssl 2>/dev/null
-echo "Copy current static files from '${bucket_name}'...completed!"
+if [ "$(ls -A $html_path)" ]; then
+  echo "Static html directory is not empty. Syncing aborted."
+else
+  aws s3 sync s3://${bucket} ${html_path} --delete --no-verify-ssl 2>/dev/null
+  echo "Copying current static files from '${bucket_name}'...completed!"
+fi
 echo ""
 
 cd ${app_path}

--- a/scripts/upkeep
+++ b/scripts/upkeep
@@ -26,6 +26,14 @@ export ssg_endpoint="https://ssg-${environment}.vote.gov"
 [ "${environment}" = "prod" ] && export ssg_endpoint="https://vote.gov"
 export ssg_sitemap_endpoint=ssg_endpoint
 
+cd ${html_path}
+echo "**************************************************"
+echo "Copying current static files from '${bucket_name}'..."
+echo "**************************************************"
+aws s3 sync s3://${bucket} . --delete --no-verify-ssl 2>/dev/null
+echo "Copy current static files from '${bucket_name}'...completed!"
+echo ""
+
 cd ${app_path}
 echo "**************************************************"
 echo "Running 'drush cron' in '${environment}'..."


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[VOTE-2534](https://cm-jira.usa.gov/browse/VOTE-2534)

## Description

Download static files from current static site before running tome generation during deployment. Prevent tome from having to generate every file that is missing from the static export directory.

## Deployment and testing

### Post-deploy steps

1. n/a

### QA/Testing instructions

1. Once merged, review the completed executed time for post-deploy-upkeep pipeline step and determine if it is less than previous times.
2. Additionally, you do a manual test in the environment by removing the html directory and then run the scripts/upkeep script.
3. Confirm that the files from the static site are downloaded to the html directory before tome is executed.
4. Confirm that the number of files that are generated are less that the total found paths 2000+.

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
