### PR TITLE
VOTE-2518: Excluded navajo font from language selection

### DIFF
--- a/web/themes/custom/votegov/src/sass/uswds-overrides/usa-language-selector.scss
+++ b/web/themes/custom/votegov/src/sass/uswds-overrides/usa-language-selector.scss
@@ -97,10 +97,6 @@
 .usa-language__submenu-item {
   @include u-padding(1);
   @include u-border(0);
-
-  * {
-    font-family: "Source Sans Pro Web", "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif !important;
-  }
 }
 
 

--- a/web/themes/custom/votegov/templates/navigation/links--language-block.html.twig
+++ b/web/themes/custom/votegov/templates/navigation/links--language-block.html.twig
@@ -64,7 +64,7 @@
         {%- if item.link -%}
           {# Replace default title with combo of endonym and english versions #}
           {% set link_title %}
-            <strong lang="{{ key }}" class="nonvfont">{{ item.link['#title'] }}</strong> <span lang="en">{{ item.link['#english'] }}</span>
+            <strong lang="{{ key }}" class="nonvfont">{{ item.link['#title'] }}</strong> <span class="nonvfont" lang="en">{{ item.link['#english'] }}</span>
           {% endset %}
           {# Add class to exclude navajo font from link render #}
           {% set link_options = item.link['#options'] | merge({


### PR DESCRIPTION
## Jira ticket

[VOTE-2518](https://cm-jira.usa.gov/browse/VOTE-2518)

## Description

Excluded navajo font from language selection.

## Deployment and testing

### Post-deploy steps

1. run `npm run build` in votegov theme
2. run `lando retune`

### QA/Testing instructions

1. Load up the local site
2. Open up the language selector dropdown
3. Click on Dine (Navajo)
4. Verify that the strings look normal (shown below) and no special characters
![image](https://github.com/user-attachments/assets/acad1a7d-35b6-4618-ace4-e88f21e648ed)

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [] The file changes are relevant to the task objective.
- [] Code is readable and includes appropriate commenting.
- [] Code standards and best practices are followed.
- [] QA/Test steps were successfully completed, if applicable.
- [] Applicable logs are free of errors.
