### PR TITLE
Vote-2546: add styles to help tool bar not grow in size

### DIFF
--- a/web/themes/custom/votegov/src/sass/components/a11y-toolbar.scss
+++ b/web/themes/custom/votegov/src/sass/components/a11y-toolbar.scss
@@ -6,7 +6,7 @@
 .vote-theme-options {
   @include u-position('fixed');
   @include u-display('flex');
-  @include u-z(300);;
+  @include u-z(300);
 
   @include at-media('tablet') {
     @include u-flex-direction('column');

--- a/web/themes/custom/votegov/src/sass/components/a11y-toolbar.scss
+++ b/web/themes/custom/votegov/src/sass/components/a11y-toolbar.scss
@@ -38,7 +38,7 @@
   cursor: pointer;
   width: 50px;
   height: 50px;
-  padding: 16px !important;
+  padding: 16px;
 
   @include at-media('tablet') {
     border-inline-start: 0;

--- a/web/themes/custom/votegov/src/sass/components/a11y-toolbar.scss
+++ b/web/themes/custom/votegov/src/sass/components/a11y-toolbar.scss
@@ -6,7 +6,7 @@
 .vote-theme-options {
   @include u-position('fixed');
   @include u-display('flex');
-  @include u-z(300);
+  @include u-z(300);;
 
   @include at-media('tablet') {
     @include u-flex-direction('column');
@@ -16,13 +16,13 @@
     border-inline-start-width: 0;
     border-start-end-radius: 0.5rem;
     border-end-end-radius: 0.5rem;
-    top: calc(50% - 3.125rem);
+    top: 50%;
     inset-inline-start: 0;
   }
 
   @include at-media-max('tablet') {
     @include u-bottom(2.5);
-    inset-inline-start: calc(50% - 3.125rem);
+    inset-inline-start: 35%;
   }
 }
 
@@ -33,11 +33,12 @@
   --theme-options-button--border: #{$base-dark};
   @include button-unstyled;
   @include u-display('block');
-  @include u-width('full');
-  @include u-padding(2);
   border: 2px solid var(--theme-options-button--border);
   background-color: var(--theme-options-button--bg);
   cursor: pointer;
+  width: 50px;
+  height: 50px;
+  padding: 16px !important;
 
   @include at-media('tablet') {
     border-inline-start: 0;
@@ -90,6 +91,9 @@
     @include u-display('block');
     background-color: var(--theme-options-button--icon);
     background-size: contain;
+    max-width: 16px;
+    max-height: 16px;
+
 
     @include at-media-max('tablet') {
       --theme-options-button--icon: #{$base-white};


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[Vote-2546](https://cm-jira.usa.gov/browse/VOTE-2546)

## Description

Addressing issue with the tool bar growing in scale if a user were to toggle the large text option
This was done by:
- setting a explicit height and width for each button 
- setting a max height and width for the icon 
- addressing an issue with the tool bar shift on the screen and making it more fixed on the screen for both desktop and mobile 

<details>
<summary>screen shots</summary>
<br>
A before and after 
<img width="1106" alt="Screenshot 2024-08-15 at 2 18 12 PM" src="https://github.com/user-attachments/assets/bb0dad09-9a5f-4e5c-b1f7-03fd14a8b9be">
<img width="1392" alt="Screenshot 2024-08-15 at 2 17 58 PM" src="https://github.com/user-attachments/assets/bdf796db-cf40-4c6a-a917-10ab1a83ec5c">



</details>

## Deployment and testing

### Post-deploy steps

1. cd into the `votegov` theme and run `lando retune`

### QA/Testing instructions

1. select the large text options in the A11y tool bar and verify that it does not grow in scale.. also can look at the current site for reference of the old behavior. 

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
