### PR TITLE
VOTE-2415: Enable state_cache for cloud environments.

### DIFF
--- a/web/sites/default/settings.cloudgov.php
+++ b/web/sites/default/settings.cloudgov.php
@@ -111,6 +111,7 @@ foreach ($cf_service_data as $service_list) {
 
 $settings['php_storage']['twig']['directory'] = '../storage/php';
 $settings['cache']['bins']['data'] = 'cache.backend.php';
+$settings['state_cache'] = TRUE;
 $settings['trusted_host_patterns'][] = $applicaiton_fqdn_regex;
 
 // SSO - SAML Auth Config.


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[VOTE-2415](https://cm-jira.usa.gov/browse/VOTE-2415)

## Description

Enable state_cache in Drupal for cloud environments.

## Deployment and testing

### Post-deploy steps

n/a

### QA/Testing instructions

1. Login as an administrator, go to /admin/reports/status and confirm that State Cache is enabled.
Note: This is not enabled for local environments as you will need to add `$settings['state_cache'] = TRUE;` to your local settings file.

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
