### PR TITLE
VOTE-2718 Update FVAP card links in english

### DIFF
--- a/web/modules/custom/vote_utility/translations/es.po
+++ b/web/modules/custom/vote_utility/translations/es.po
@@ -321,7 +321,7 @@ msgid "Learn more from the Federal Voting Assistance Program (FVAP)."
 msgstr "Obtenga más información del Programa Federal de Asistencia para Votar (FVAP, sigla en inglés)."
 
 msgid "Voting as a U.S. citizen from outside the U.S."
-msgstr "Votar como ciudadano en el extrajero"
+msgstr "Votar como ciudadano en el extranjero"
 
 msgid "Secondary navigation"
 msgstr "navegación secundaria"

--- a/web/themes/custom/votegov/templates/component/feature-cards.html.twig
+++ b/web/themes/custom/votegov/templates/component/feature-cards.html.twig
@@ -10,14 +10,16 @@
 
     {# Start temporary cards. #}
     {% if language != "es" %}
-      {% set fvap_link = "https://www.fvap.gov/" %}
+      {% set fvap_link_military = "https://www.fvap.gov/military-voter" %}
+      {% set fvap_link_overseas = "https://www.fvap.gov/citizen-voter" %}
     {% else %}
-      {% set fvap_link = "https://www.fvap.gov/translated-materials" %}
+      {% set fvap_link_military = "https://www.fvap.gov/translated-materials" %}
+      {% set fvap_link_overseas = "https://www.fvap.gov/translated-materials" %}
     {% endif %}
 
     {# Temporary card for military FVAP.gov #}
     <article class="node--voter-guide node--view-mode-teaser usa-card">
-      <a extlinkjs-ignore class="vote-card__link" href={{ fvap_link }} target="_blank" title={{"Voting as a military service member" | t }}>
+      <a extlinkjs-ignore class="vote-card__link" href={{ fvap_link_military }} target="_blank" title={{"Voting as a military service member" | t }}>
         <div class="usa-card__container">
           <div class="vote-feature-card__icon">
             {{ source( directory ~ '/img/svg/Military.svg' ) }}
@@ -35,7 +37,7 @@
     </article>
     {# Temporary card for overseas FVAP.gov #}
     <article class="node--voter-guide node--view-mode-teaser usa-card">
-      <a extlinkjs-ignore class="vote-card__link" href={{ fvap_link }} target="_blank" title={{"Voting as a U.S. citizenfrom outside the U.S." | t }}>
+      <a extlinkjs-ignore class="vote-card__link" href={{ fvap_link_overseas }} target="_blank" title={{"Voting as a U.S. citizenfrom outside the U.S." | t }}>
         <div class="usa-card__container">
           <div class="vote-feature-card__icon">
             {{ source( directory ~ '/img/svg/Overseas.svg' ) }}

--- a/web/themes/custom/votegov/templates/component/feature-cards.html.twig
+++ b/web/themes/custom/votegov/templates/component/feature-cards.html.twig
@@ -9,7 +9,7 @@
     {{ cards }}
 
     {# Start temporary cards. #}
-    {% if language != "es" %}
+    {% if language == "en" %}
       {% set fvap_link_military = "https://www.fvap.gov/military-voter" %}
       {% set fvap_link_overseas = "https://www.fvap.gov/citizen-voter" %}
     {% else %}


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

https://cm-jira.usa.gov/browse/VOTE-2718

## Description

Give hardcoded FVAP cards unique links for English. Spanish links remain the same.

## Deployment and testing

### Post-deploy steps

1. lando retune

### QA/Testing instructions

1. On the English homepage, confirm the FVAP cards link to the corresponding links in the ticket.
2. On the Spanish homepage, confirm both cards go to the translated material link.
3. Confirm the overseas guide title is "Votar como ciudadano en el extranjero."

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [ ] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
