### PR TITLE
VOTE-2054: update hero template to handle variations

### DIFF
--- a/web/themes/custom/votegov/templates/component/hero.html.twig
+++ b/web/themes/custom/votegov/templates/component/hero.html.twig
@@ -1,19 +1,45 @@
-{% set classes = [
+{#
+/**
+ * @file
+ * Default theme implementation of hero component.
+ *
+ * Component template variables:
+ * - variant: string (required)
+ * - heading: string (required)
+ * - body: string
+ * - link_href: string
+ * - link_label: string
+ * - media: string (scaled_lg image variant or larger)
+ *
+ * Usage example:
+ * {% include '@votegov/component/hero.html.twig' with {
+ *   'variant': 'homepage',
+ *   'heading': var_title,
+ *   'body': var_body,
+ *   'link_href': var_link_url,
+ *   'link_label': var_link_label
+ *   'media': var_media
+ * } %}
+ *
+#}
+
+{% set usa_attributes = create_attribute() %}
+{% set usa_classes = [
   'vote-hero',
   'vote-hero--' ~ variant | default('dark')
 ] %}
 
-<section{{ attributes.addClass(classes) }}>
+<section{{ usa_attributes.addClass(usa_classes) }}>
   <div class="vote-hero__container">
     <div class="vote-hero__callout">
-      {% if paragraph.field_background_color.value == 'dark' %}
+      {% if variant == 'dark' %}
         {{ drupal_entity('block', 'votegov_breadcrumbs') }}
       {% endif %}
       <div class="vote-hero__content">
         <h1 class="vote-hero__heading">
           {{ heading }}
         </h1>
-        {% if body %}
+        {% if body | render %}
           <div class="vote-hero__text usa-intro">
             {{ body }}
           </div>
@@ -22,12 +48,12 @@
           {% include '@votegov/component/button.html.twig' with {
             'href': link_href,
             'label': link_label,
-            'secondary': link_secondary
+            'secondary': true
           } %}
         {% endif %}
       </div>
     </div>
-    {% if media %}
+    {% if media | render %}
       <div class="vote-hero__image">
         {{ media }}
       </div>

--- a/web/themes/custom/votegov/templates/component/hero.html.twig
+++ b/web/themes/custom/votegov/templates/component/hero.html.twig
@@ -1,0 +1,36 @@
+{% set classes = [
+  'vote-hero',
+  'vote-hero--' ~ variant | default('dark')
+] %}
+
+<section{{ attributes.addClass(classes) }}>
+  <div class="vote-hero__container">
+    <div class="vote-hero__callout">
+      {% if paragraph.field_background_color.value == 'dark' %}
+        {{ drupal_entity('block', 'votegov_breadcrumbs') }}
+      {% endif %}
+      <div class="vote-hero__content">
+        <h1 class="vote-hero__heading">
+          {{ heading }}
+        </h1>
+        {% if body %}
+          <div class="vote-hero__text usa-intro">
+            {{ body }}
+          </div>
+        {% endif %}
+        {% if link_href %}
+          {% include '@votegov/component/button.html.twig' with {
+            'href': link_href,
+            'label': link_label,
+            'secondary': link_secondary
+          } %}
+        {% endif %}
+      </div>
+    </div>
+    {% if media %}
+      <div class="vote-hero__image">
+        {{ media }}
+      </div>
+    {% endif %}
+  </div>
+</section>

--- a/web/themes/custom/votegov/templates/layout/page--node--voter-guide.html.twig
+++ b/web/themes/custom/votegov/templates/layout/page--node--voter-guide.html.twig
@@ -3,6 +3,12 @@
 
 {% block main %}
   <main role="main" id="main-content">
+  {% include '@votegov/component/hero.html.twig' with {
+    'heading': title,
+    'body': node.field_subtitle.value  | check_markup(node.field_subtitle.format),
+    'media': drupal_field('field_media', 'node', node.id(), {type: 'media_thumbnail', settings: {image_style: 'scaled_lg' }}) | field_value,
+    'variant': 'dark'
+  } %}
     <section class="vote-hero vote-hero--dark">
       <div class="vote-hero__container">
         <div class="vote-hero__callout">

--- a/web/themes/custom/votegov/templates/layout/page--node--voter-guide.html.twig
+++ b/web/themes/custom/votegov/templates/layout/page--node--voter-guide.html.twig
@@ -3,32 +3,12 @@
 
 {% block main %}
   <main role="main" id="main-content">
-  {% include '@votegov/component/hero.html.twig' with {
-    'heading': title,
-    'body': node.field_subtitle.value  | check_markup(node.field_subtitle.format),
-    'media': drupal_field('field_media', 'node', node.id(), {type: 'media_thumbnail', settings: {image_style: 'scaled_lg' }}) | field_value,
-    'variant': 'dark'
-  } %}
-    <section class="vote-hero vote-hero--dark">
-      <div class="vote-hero__container">
-        <div class="vote-hero__callout">
-          {{ drupal_entity('block', 'votegov_breadcrumbs') }}
-          <div class="vote-hero__content">
-            <h1 class="vote-hero__heading">
-              {{ title }}
-            </h1>
-            <div class="vote-hero__text usa-intro">
-              {{ node.field_subtitle.value  | check_markup(node.field_subtitle.format) }}
-            </div>
-          </div>
-        </div>
-        {% if node.field_media.value %}
-          <div class="vote-hero__image">
-            {{ drupal_field('field_media', 'node', node.id(), {type: 'media_thumbnail', settings: {image_style: 'scaled_lg'}}) | field_value }}
-          </div>
-        {% endif %}
-      </div>
-    </section>
+    {% include '@votegov/component/hero.html.twig' with {
+      'heading': title,
+      'body': node.field_subtitle.value  | check_markup(node.field_subtitle.format),
+      'media': drupal_field('field_media', 'node', node.id(), {type: 'media_thumbnail', settings: {image_style: 'scaled_lg' }}) | field_value,
+      'variant': 'dark'
+    } %}
     <div class="vote-main-content-row vote-block-margin-y--narrow grid-container usa-in-page-nav-container">
       <aside
         class="usa-in-page-nav"

--- a/web/themes/custom/votegov/templates/paragraph/paragraph--hero.html.twig
+++ b/web/themes/custom/votegov/templates/paragraph/paragraph--hero.html.twig
@@ -9,11 +9,10 @@
 {% set savedCache = content | render %}
 
 {% include '@votegov/component/hero.html.twig' with {
-  'heading': content.field_heading,
-  'body': content.field_body,
+  'heading': content.field_heading | field_value,
+  'body': content.field_body | field_value,
   'link_href': paragraph.field_link.0.url,
   'link_label': paragraph.field_link.0.title,
-  'link_secondary': true,
-  'media': content.field_media,
+  'media': content.field_media | field_value,
   'variant': content.field_background_color | field_value | render
 } %}

--- a/web/themes/custom/votegov/templates/paragraph/paragraph--hero.html.twig
+++ b/web/themes/custom/votegov/templates/paragraph/paragraph--hero.html.twig
@@ -4,8 +4,11 @@
  * Default theme implementation to display a paragraph: Hero.
  */
 #}
+{% set pageType = currentnode.bundle() %}
+
 {% set classes = [
   'vote-hero',
+  'vote-hero--' ~ pageType,
   'vote-hero--' ~ content.field_background_color | field_value | render
 ] %}
 
@@ -18,7 +21,7 @@
   {{ title_suffix }}
   <div class="vote-hero__container">
     <div class="vote-hero__callout">
-      {% if paragraph.field_background_color.value == 'dark' %}
+      {% if pageType != 'landing' %}
         {{ drupal_entity('block', 'votegov_breadcrumbs') }}
       {% endif %}
       <div class="vote-hero__content">
@@ -30,17 +33,19 @@
             {{ content.field_body | field_value }}
           </div>
         {% endif %}
-        {% include '@votegov/component/button.html.twig' with {
-          'href': paragraph.field_link.0.url,
-          'label': paragraph.field_link.0.title,
-          'secondary': true
-        } %}
+        {% if content.field_link | render  %}
+          {% include '@votegov/component/button.html.twig' with {
+            'href': paragraph.field_link.0.url,
+            'label': paragraph.field_link.0.title,
+            'secondary': true
+          } %}
+        {% endif %}
       </div>
     </div>
     {% if content.field_media | render %}
-    <div class="vote-hero__image">
-      {{ content.field_media | field_value }}
-    </div>
-  {% endif %}
+      <div class="vote-hero__image">
+        {{ content.field_media | field_value }}
+      </div>
+    {% endif %}
   </div>
 </section>

--- a/web/themes/custom/votegov/templates/paragraph/paragraph--hero.html.twig
+++ b/web/themes/custom/votegov/templates/paragraph/paragraph--hero.html.twig
@@ -4,48 +4,16 @@
  * Default theme implementation to display a paragraph: Hero.
  */
 #}
-{% set pageType = currentnode.bundle() %}
-
-{% set classes = [
-  'vote-hero',
-  'vote-hero--' ~ pageType,
-  'vote-hero--' ~ content.field_background_color | field_value | render
-] %}
 
 {# Caching the data in content object #}
 {% set savedCache = content | render %}
 
-<section{{ attributes.addClass(classes) }}>
-  {# Hold these title_* placeholders for potential integration #}
-  {{ title_prefix }}
-  {{ title_suffix }}
-  <div class="vote-hero__container">
-    <div class="vote-hero__callout">
-      {% if pageType != 'landing' %}
-        {{ drupal_entity('block', 'votegov_breadcrumbs') }}
-      {% endif %}
-      <div class="vote-hero__content">
-        <h1 class="vote-hero__heading">
-          {{ content.field_heading | field_value }}
-        </h1>
-        {% if content.field_body | render %}
-          <div class="vote-hero__text usa-intro">
-            {{ content.field_body | field_value }}
-          </div>
-        {% endif %}
-        {% if content.field_link | render  %}
-          {% include '@votegov/component/button.html.twig' with {
-            'href': paragraph.field_link.0.url,
-            'label': paragraph.field_link.0.title,
-            'secondary': true
-          } %}
-        {% endif %}
-      </div>
-    </div>
-    {% if content.field_media | render %}
-      <div class="vote-hero__image">
-        {{ content.field_media | field_value }}
-      </div>
-    {% endif %}
-  </div>
-</section>
+{% include '@votegov/component/hero.html.twig' with {
+  'heading': content.field_heading,
+  'body': content.field_body,
+  'link_href': paragraph.field_link.0.url,
+  'link_label': paragraph.field_link.0.title,
+  'link_secondary': true,
+  'media': content.field_media,
+  'variant': content.field_background_color | field_value | render
+} %}


### PR DESCRIPTION
## Jira ticket

[VOTE-2054](https://cm-jira.usa.gov/browse/VOTE-2054)

## Description

- migrates hero into it's own component template 
- passes content with variables between paragraph template and hero component
- includes new hero component on voter guide template

## Deployment and testing

### QA/Testing instructions

1. lando retune
2. go to landing page and confirm hero works as expected
3. go to voter guide page and confirm works as expected

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
