### PR TITLE
Feature/vote 2112/data attribute nvrf button

### DIFF
--- a/web/themes/custom/votegov/templates/block/block-content--registration-form-selector.html.twig
+++ b/web/themes/custom/votegov/templates/block/block-content--registration-form-selector.html.twig
@@ -23,7 +23,9 @@
     <p>
       {% include '@votegov/component/button.html.twig' with {
         'href': 'internal:' ~ form_path,
-        'label': elements['#block_content'].field_digital_form_link.0.title
+        'label': elements['#block_content'].field_digital_form_link.0.title,
+        'data_label': 'data-state-ext',
+        'data': 'nvrf-pdf-tool-registration'
       } %}
     </p>
   {% endif %}

--- a/web/themes/custom/votegov/templates/component/button.html.twig
+++ b/web/themes/custom/votegov/templates/component/button.html.twig
@@ -28,7 +28,7 @@
 
 {% if label %}
   {% if href %}
-    <div>{{ link(label, href, create_attribute({'class': classes})) }}</div>
+    <div>{{ link(label, href, create_attribute().addClass(classes).setAttribute(data_label, data)) }}</div>
   {% else %}
     <button{{ create_attribute().addClass(classes).setAttribute('type', 'button').setAttribute('id', (id | clean_id)) }}>{{ label }}</button>
   {% endif %}


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

https://cm-jira.usa.gov/browse/VOTE-2112

## Description

Add a custom attribute for GA data to button component
Add data-state-ext attribute to the NVRF button

## Deployment and testing

### Post-deploy steps

1. lando retune

### QA/Testing instructions

1. Add the NVRF button content in the [NVRF selector block](http://vote-gov.lndo.site/admin/content/block/3?destination=/admin/content/block)
2. View the source code and confirm the NVRF button has the data-state-ext attribute set to "nvrf-pdf-tool-registration"

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been included above.
- [ ] No merge conflicts exist with the target branch.
- [ ] Automated tests have passed on this PR.
- [ ] A reviewer has been designated.
- [ ] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
