### PR TITLE
VOTE-2741: split feature card styles from all card styles

### DIFF
--- a/web/themes/custom/votegov/src/sass/uswds-overrides/usa-card.scss
+++ b/web/themes/custom/votegov/src/sass/uswds-overrides/usa-card.scss
@@ -63,100 +63,100 @@
 
 // FEATURE CARD STYLES
 .vote-card-group {
-.usa-card {
-  @include at-media-max('tablet-lg') {
-    @include u-margin(0);
-    border-bottom: 1px solid $bg-light-medium;
+  .usa-card {
+    @include at-media-max('tablet-lg') {
+      @include u-margin(0);
+      border-bottom: 1px solid $bg-light-medium;
 
-    &:first-child {
-      border-top: 1px solid $bg-light-medium;
+      &:first-child {
+        border-top: 1px solid $bg-light-medium;
+      }
     }
   }
-}
 
-.vote-card__link {
-  @include u-display('block');
-  @include u-text-decoration('no-underline');
+  .vote-card__link {
+    @include u-display('block');
+    @include u-text-decoration('no-underline');
 
-  @include hover {
-    background-color: transparent;
-  }
-
-  @include at-media('tablet-lg') {
     @include hover {
-      svg {
-        fill: $base-white;
-      }
+      background-color: transparent;
+    }
 
-      .usa-card__heading,
-      .usa-card__body {
-        color: $base-white;
-      }
+    @include at-media('tablet-lg') {
+      @include hover {
+        svg {
+          fill: $base-white;
+        }
 
-      .usa-card__container {
-        background-color: var(--usa-card-container-bg);
-        border: 2px solid $base-dark;
-        box-shadow: 0px 4px 4px 0px rgba($base-dark, 0.25);
+        .usa-card__heading,
+        .usa-card__body {
+          color: $base-white;
+        }
+
+        .usa-card__container {
+          background-color: var(--usa-card-container-bg);
+          border: 2px solid $base-dark;
+          box-shadow: 0px 4px 4px 0px rgba($base-dark, 0.25);
+        }
       }
     }
   }
-}
 
-.usa-card__container {
-  @include at-media('tablet-lg') {
-    @include u-padding-x(4);
-    @include u-padding-y(5);
-    @include u-margin(0);
-    border: 2px solid transparent;
-    outline: 1px solid $base-dark;
-    transition: 0.3s background-color;
+  .usa-card__container {
+    @include at-media('tablet-lg') {
+      @include u-padding-x(4);
+      @include u-padding-y(5);
+      @include u-margin(0);
+      border: 2px solid transparent;
+      outline: 1px solid $base-dark;
+      transition: 0.3s background-color;
+
+      > * + * {
+        @include u-margin-top(3);
+      }
+    }
+
+    @include at-media-max('tablet-lg') {
+      @include u-flex-direction('row');
+      @include u-margin(0);
+      @include u-padding-y(4);
+      border-radius: unset;
+      gap: 1.5rem;
+    }
+  }
+
+  .usa-card__heading {
+    @include at-media('tablet-lg') {
+      @include u-text('center');
+    }
+
+    @include at-media-max('tablet-lg') {
+      @include u-text-decoration('underline');
+    }
+  }
+
+  .vote-feature-card__content {
+    @include at-media-max('tablet-lg') {
+      @include grid-col('auto');
+    }
 
     > * + * {
-      @include u-margin-top(3);
+      @include u-margin-top(2);
     }
   }
 
-  @include at-media-max('tablet-lg') {
-    @include u-flex-direction('row');
-    @include u-margin(0);
-    @include u-padding-y(4);
-    border-radius: unset;
-    gap: 1.5rem;
-  }
-}
+  .vote-feature-card__icon {
+    @include u-height(9);
+    @include u-width(9);
+    @include u-minw(8);
 
-.usa-card__heading {
-  @include at-media('tablet-lg') {
-    @include u-text('center');
-  }
+    @include at-media('tablet-lg') {
+      @include u-margin-x('auto');
+    }
 
-  @include at-media-max('tablet-lg') {
-    @include u-text-decoration('underline');
+    svg {
+      fill: var(--vote-feature-card-icon-fill);
+    }
   }
-}
-
-.vote-feature-card__content {
-  @include at-media-max('tablet-lg') {
-    @include grid-col('auto');
-  }
-
-  > * + * {
-    @include u-margin-top(2);
-  }
-}
-
-.vote-feature-card__icon {
-  @include u-height(9);
-  @include u-width(9);
-  @include u-minw(8);
-
-  @include at-media('tablet-lg') {
-    @include u-margin-x('auto');
-  }
-
-  svg {
-    fill: var(--vote-feature-card-icon-fill);
-  }
-}
 }
 

--- a/web/themes/custom/votegov/src/sass/uswds-overrides/usa-card.scss
+++ b/web/themes/custom/votegov/src/sass/uswds-overrides/usa-card.scss
@@ -2,6 +2,23 @@
 @use "variables" as *;
 @use "mixins" as *;
 
+// GLOBAL CARD STYLES
+.usa-card-group {
+  .usa-card__container {
+    @include u-padding-x(4);
+    @include u-padding-y(5);
+    margin-left: 1rem;
+    margin-right: 1rem;
+    border: 2px solid transparent;
+    outline: 1px solid $base-dark;
+    transition: 0.3s background-color;
+
+    > * + * {
+      @include u-margin-top(3);
+    }
+  }
+}
+
 .usa-card {
   --usa-card-container-bg: #{$base-primary};
   --usa-card-body: #{$base-dark};
@@ -14,14 +31,39 @@
   }
 
 
-  @include at-media('tablet-lg') {
+  @include at-media('tablet') {
     @include u-margin(0);
   }
 
   > * {
     @include u-height('full');
   }
+}
 
+.usa-card__container {
+  background-color: transparent;
+}
+
+.usa-card__heading {
+  @include u-font-family('serif');
+  @include u-font-size('serif', 9);
+  @include u-text('bold');
+  @include u-line-height('serif', 4);
+}
+
+.usa-card__body {
+  @include u-font('sans', 6);
+  @include u-padding(0);
+  color: var(--usa-card-body);
+
+  &:last-child {
+    @include u-padding-bottom(0);
+  }
+}
+
+// FEATURE CARD STYLES
+.vote-card-group {
+.usa-card {
   @include at-media-max('tablet-lg') {
     @include u-margin(0);
     border-bottom: 1px solid $bg-light-medium;
@@ -61,8 +103,6 @@
 }
 
 .usa-card__container {
-  background-color: transparent;
-
   @include at-media('tablet-lg') {
     @include u-padding-x(4);
     @include u-padding-y(5);
@@ -86,27 +126,12 @@
 }
 
 .usa-card__heading {
-  @include u-font-family('serif');
-  @include u-font-size('serif', 9);
-  @include u-text('bold');
-  @include u-line-height('serif', 4);
-
   @include at-media('tablet-lg') {
     @include u-text('center');
   }
 
   @include at-media-max('tablet-lg') {
     @include u-text-decoration('underline');
-  }
-}
-
-.usa-card__body {
-  @include u-font('sans', 6);
-  @include u-padding(0);
-  color: var(--usa-card-body);
-
-  &:last-child {
-    @include u-padding-bottom(0);
   }
 }
 
@@ -133,3 +158,5 @@
     fill: var(--vote-feature-card-icon-fill);
   }
 }
+}
+


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[VOTE-2741](https://cm-jira.usa.gov/browse/VOTE-2741)

## Description

Splits the card styles that just apply to the feature cards from the rest of the styles that the nvrf also inherits from.

## Deployment and testing

### QA/Testing instructions

1. lando retune
2. visit landing page
3. test feature cards on all screen sizes, confirm no changes
4. visit http://vote-gov.lndo.site/register/washington/mail-in-form-filler
5. navigate to the second page
6. confirm the cards inherit the same styles *the mobile cards should stack and not change visually 

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
