### PR TITLE
VOTE-2275: Enable and configure stage file proxy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,6 +70,7 @@
         "drupal/s3fs": "^3.1",
         "drupal/samlauth": "^3.8",
         "drupal/simple_sitemap": "^4.1",
+        "drupal/stage_file_proxy": "^3.1",
         "drupal/svg_image": "^3.0",
         "drupal/tome": "^1.8",
         "drupal/translatable_menu_link_uri": "^2.0@dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9185d8b23ae757482f2aba325ef5afed",
+    "content-hash": "1d1eaf8b48c424734a0489d18ae5bab2",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -4551,6 +4551,101 @@
             "support": {
                 "source": "https://cgit.drupalcode.org/simple_sitemap",
                 "issues": "https://drupal.org/project/issues/simple_sitemap"
+            }
+        },
+        {
+            "name": "drupal/stage_file_proxy",
+            "version": "3.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/stage_file_proxy.git",
+                "reference": "3.1.2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/stage_file_proxy-3.1.2.zip",
+                "reference": "3.1.2",
+                "shasum": "1aba8488efc193db71a991e8f8f76825af219079"
+            },
+            "require": {
+                "drupal/core": "^10.3 || ^11",
+                "php": ">=8.1"
+            },
+            "conflict": {
+                "drush/drush": "<12"
+            },
+            "require-dev": {
+                "drupal/coder": "^8.3",
+                "drush/drush": ">=12"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "3.1.2",
+                    "datestamp": "1724012934",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "scripts": {
+                "phpcs": [
+                    "vendor/bin/phpcs -p ."
+                ],
+                "phpcbf": [
+                    "vendor/bin/phpcbf -p ."
+                ],
+                "test": [
+                    "@phpcs"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "BarisW",
+                    "homepage": "https://www.drupal.org/user/107229"
+                },
+                {
+                    "name": "geek-merlin",
+                    "homepage": "https://www.drupal.org/user/229048"
+                },
+                {
+                    "name": "greggles",
+                    "homepage": "https://www.drupal.org/user/36762"
+                },
+                {
+                    "name": "markdorison",
+                    "homepage": "https://www.drupal.org/user/346106"
+                },
+                {
+                    "name": "moshe weitzman",
+                    "homepage": "https://www.drupal.org/user/23"
+                },
+                {
+                    "name": "msonnabaum",
+                    "homepage": "https://www.drupal.org/user/75278"
+                },
+                {
+                    "name": "netaustin",
+                    "homepage": "https://www.drupal.org/user/199298"
+                },
+                {
+                    "name": "robwilmshurst",
+                    "homepage": "https://www.drupal.org/user/144488"
+                },
+                {
+                    "name": "smustgrave",
+                    "homepage": "https://www.drupal.org/user/3252890"
+                }
+            ],
+            "description": "Provides stage_file_proxy module.",
+            "homepage": "https://www.drupal.org/project/stage_file_proxy",
+            "support": {
+                "source": "https://git.drupalcode.org/project/stage_file_proxy"
             }
         },
         {

--- a/config/local/config_split.patch.core.extension.yml
+++ b/config/local/config_split.patch.core.extension.yml
@@ -4,5 +4,6 @@ adding:
     devel: 0
     disable_language: 0
     field_ui: 0
+    stage_file_proxy: 0
     views_ui: 0
 removing: {  }

--- a/config/local/stage_file_proxy.settings.yml
+++ b/config/local/stage_file_proxy.settings.yml
@@ -1,0 +1,9 @@
+_core:
+  default_config_hash: LqXuXXQCTd1NWw7dGLef0PCi3_aEEWQuogAblo4hHaE
+hotlink: false
+origin: 'https://vote.gov'
+origin_dir: s3/files
+proxy_headers: ''
+use_imagecache_root: true
+verify: true
+excluded_extensions: ''

--- a/config/sync/stage_file_proxy.settings.yml
+++ b/config/sync/stage_file_proxy.settings.yml
@@ -1,9 +1,0 @@
-_core:
-  default_config_hash: LqXuXXQCTd1NWw7dGLef0PCi3_aEEWQuogAblo4hHaE
-hotlink: false
-origin: 'https://vote.gov'
-origin_dir: ''
-proxy_headers: ''
-use_imagecache_root: true
-verify: true
-excluded_extensions: ''

--- a/config/sync/stage_file_proxy.settings.yml
+++ b/config/sync/stage_file_proxy.settings.yml
@@ -1,0 +1,9 @@
+_core:
+  default_config_hash: LqXuXXQCTd1NWw7dGLef0PCi3_aEEWQuogAblo4hHaE
+hotlink: false
+origin: 'http://vote-gov.lndo.site'
+origin_dir: ''
+proxy_headers: ''
+use_imagecache_root: true
+verify: true
+excluded_extensions: ''

--- a/config/sync/stage_file_proxy.settings.yml
+++ b/config/sync/stage_file_proxy.settings.yml
@@ -1,7 +1,7 @@
 _core:
   default_config_hash: LqXuXXQCTd1NWw7dGLef0PCi3_aEEWQuogAblo4hHaE
 hotlink: false
-origin: 'http://vote-gov.lndo.site'
+origin: 'https://vote.gov'
 origin_dir: ''
 proxy_headers: ''
 use_imagecache_root: true


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[VOTE-2275](https://cm-jira.usa.gov/browse/VOTE-2275)

## Description

Enables and configures stage file proxy module so images are pulled from production site

## Deployment and testing

### QA/Testing instructions

1. lando retune
2. On line 171 of `web/sites/settings.local.php` change `.production` to `.local` so it is like this: `$config['config_split.config_split.local']['status'] = TRUE;`
3. run lando drush cim
4. Navigate to any state page and confirm the missing hero images are now coming through

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
