### PR TITLE
Vote-2123: Verify Language options are active

### DIFF
--- a/testing/cypress/e2e/frontEndTests/language-selector.cy.js
+++ b/testing/cypress/e2e/frontEndTests/language-selector.cy.js
@@ -25,7 +25,7 @@ describe('Test language selector', () => {
     })
   })
 
-  it.only('Verify active language options', () => {
+  it('Verify active language options', () => {
     cy.visit('/')
     cy.fixture('language-options.json').then((expectedMenuItems) => {
       cy.get('[data-test="languageButton"]').click().get('[data-test="languageSwitcher"]').find('li').then(($list) => {

--- a/testing/cypress/e2e/frontEndTests/language-selector.cy.js
+++ b/testing/cypress/e2e/frontEndTests/language-selector.cy.js
@@ -24,4 +24,19 @@ describe('Test language selector', () => {
       })
     })
   })
+
+  it.only('Verify active language options', () => {
+    cy.visit('/')
+    cy.fixture('language-options.json').then((expectedMenuItems) => {
+      cy.get('[data-test="languageButton"]').click().get('[data-test="languageSwitcher"]').find('li').then(($list) => {
+        const actualMenuItems = $list.map((index, item) => {
+          return Cypress.$(item).attr('data-lang');
+        }).get();
+        expectedMenuItems.forEach((expectedItem, index) => {
+          cy.wrap(actualMenuItems).should('contain', expectedItem, `Expected language option "${expectedItem}" to exist, but is missing`);
+        });
+      });
+    });
+  });
+  
 })

--- a/testing/cypress/fixtures/language-options.json
+++ b/testing/cypress/fixtures/language-options.json
@@ -1,0 +1,21 @@
+[
+  "lang-en",
+  "lang-es",
+  "lang-am",
+  "lang-ar",
+  "lang-bn",
+  "lang-zh-hans",
+  "lang-zh",
+  "lang-fr",
+  "lang-ht",
+  "lang-hi",
+  "lang-km",
+  "lang-ko",
+  "lang-nv",
+  "lang-pt",
+  "lang-ru",
+  "lang-so",
+  "lang-tl",
+  "lang-vi",
+  "lang-ypk"
+]


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[Vote-2123](https://cm-jira.usa.gov/browse/VOTE-2723)

## Description

Adding test to check the language options and verify that the expected options are active and have not been removed. 

**Goal of test:**  This test will reference the current list of active translations by targeting the `data-lang` attribute and checking the list that is on the site compared to the json file that is saved

## Deployment and testing

### Post-deploy steps

n/a

### QA/Testing instructions

1. log in as an admin and visit `/es/node/91/edit` and unpublished this translation 
2. go to your terminal and cd into `testing` and run `npm run cy:open` and select the `language-selector.cy.js` test and verify that it is failing 
3. go back to the admin page and republish the spanish translation and rerun the test.. it should now be passing

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
