### PR TITLE
VOTE-2822 add checkbox to enable NVRF link

### DIFF
--- a/config/sync/core.entity_form_display.block_content.registration_form_selector.default.yml
+++ b/config/sync/core.entity_form_display.block_content.registration_form_selector.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.block_content.registration_form_selector.field_description
     - field.field.block_content.registration_form_selector.field_digital_form_link_label
     - field.field.block_content.registration_form_selector.field_digital_form_paragraph
+    - field.field.block_content.registration_form_selector.field_enable_digital_form_link
     - field.field.block_content.registration_form_selector.field_heading
     - field.field.block_content.registration_form_selector.field_registration_form_link
     - field.field.block_content.registration_form_selector.field_submit_button_label
@@ -21,6 +22,7 @@ third_party_settings:
       children:
         - field_digital_form_paragraph
         - field_digital_form_link_label
+        - field_enable_digital_form_link
       label: 'Digital form'
       region: content
       parent_name: ''
@@ -89,6 +91,13 @@ content:
     settings:
       rows: 5
       placeholder: ''
+    third_party_settings: {  }
+  field_enable_digital_form_link:
+    type: boolean_checkbox
+    weight: 11
+    region: content
+    settings:
+      display_label: true
     third_party_settings: {  }
   field_heading:
     type: string_textfield

--- a/config/sync/core.entity_view_display.block_content.registration_form_selector.default.yml
+++ b/config/sync/core.entity_view_display.block_content.registration_form_selector.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.block_content.registration_form_selector.field_description
     - field.field.block_content.registration_form_selector.field_digital_form_link_label
     - field.field.block_content.registration_form_selector.field_digital_form_paragraph
+    - field.field.block_content.registration_form_selector.field_enable_digital_form_link
     - field.field.block_content.registration_form_selector.field_heading
     - field.field.block_content.registration_form_selector.field_registration_form_link
     - field.field.block_content.registration_form_selector.field_submit_button_label
@@ -49,6 +50,16 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 8
+    region: content
+  field_enable_digital_form_link:
+    type: boolean
+    label: hidden
+    settings:
+      format: boolean
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 10
     region: content
   field_heading:
     type: string

--- a/config/sync/field.field.block_content.registration_form_selector.field_digital_form_link_label.yml
+++ b/config/sync/field.field.block_content.registration_form_selector.field_digital_form_link_label.yml
@@ -10,7 +10,7 @@ field_name: field_digital_form_link_label
 entity_type: block_content
 bundle: registration_form_selector
 label: 'Digital form link label'
-description: 'Entering a value in this field triggers the digital form page to be generated on the public site.'
+description: ''
 required: false
 translatable: true
 default_value: {  }

--- a/config/sync/field.field.block_content.registration_form_selector.field_enable_digital_form_link.yml
+++ b/config/sync/field.field.block_content.registration_form_selector.field_enable_digital_form_link.yml
@@ -1,0 +1,21 @@
+uuid: de568db6-d383-421a-801a-886cc5ba331a
+langcode: es
+status: true
+dependencies:
+  config:
+    - block_content.type.registration_form_selector
+    - field.storage.block_content.field_enable_digital_form_link
+id: block_content.registration_form_selector.field_enable_digital_form_link
+field_name: field_enable_digital_form_link
+entity_type: block_content
+bundle: registration_form_selector
+label: 'Enable digital form link'
+description: 'Selecting this option launches the digital form to the public.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/field.storage.block_content.field_enable_digital_form_link.yml
+++ b/config/sync/field.storage.block_content.field_enable_digital_form_link.yml
@@ -1,0 +1,18 @@
+uuid: 4ffc187c-ed58-45f2-bb27-f679508d87b7
+langcode: es
+status: true
+dependencies:
+  module:
+    - block_content
+id: block_content.field_enable_digital_form_link
+field_name: field_enable_digital_form_link
+entity_type: block_content
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/themes/custom/votegov/templates/block/block-content--registration-form-selector.html.twig
+++ b/web/themes/custom/votegov/templates/block/block-content--registration-form-selector.html.twig
@@ -16,6 +16,7 @@
 
   <h2>{{ content.field_heading | field_value | render | replace({"@state_name": currentnode.getTitle()}) | raw }}</h2>
 
+  {% if (elements['#block_content'].field_enable_digital_form_link.value == 1) %}
   {{ content.field_digital_form_paragraph | field_value }}
 
   {% if content.field_digital_form_link_label | render %}
@@ -30,6 +31,7 @@
         'data': 'nvrf-pdf-tool-registration'
       } %}
     </p>
+  {% endif %}
   {% endif %}
 
   <form class="usa-form" method="get" id="register_form_download" data-test="nvrfForm">

--- a/web/themes/custom/votegov/templates/component/button.html.twig
+++ b/web/themes/custom/votegov/templates/component/button.html.twig
@@ -28,7 +28,7 @@
 
 {% if label %}
   {% if href %}
-    <div>{{ link(label, href, create_attribute().addClass(classes).setAttribute(data_label, data)) }}</div>
+    {{ link(label, href, create_attribute().addClass(classes).setAttribute(data_label, data)) }}
   {% else %}
     <button{{ create_attribute().addClass(classes).setAttribute('type', 'button').setAttribute('id', (id | clean_id)) }}>{{ label }}</button>
   {% endif %}

--- a/web/themes/custom/votegov/templates/component/hero.html.twig
+++ b/web/themes/custom/votegov/templates/component/hero.html.twig
@@ -45,11 +45,13 @@
           </div>
         {% endif %}
         {% if link_href %}
+          <div>
           {% include '@votegov/component/button.html.twig' with {
             'href': link_href,
             'label': link_label,
             'secondary': true
           } %}
+          </div>
         {% endif %}
       </div>
     </div>


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

https://cm-jira.usa.gov/browse/VOTE-2822

## Description

Added a new checkbox to enable or display the NVRF link from the state page.
I also cleaned up an issue with the button component.

## Deployment and testing

### Post-deploy steps

1. `lando retune`

### QA/Testing instructions

1. visit http://vote-gov.lndo.site/admin/content/block/3?destination=/admin/content/block and check the new box in the digital form group.
2. visit http://vote-gov.lndo.site/register/washington and make sure the text and link are showing
3. visit http://vote-gov.lndo.site/admin/content/block/3?destination=/admin/content/block and uncheck the new box 
4. visit http://vote-gov.lndo.site/register/washington and make sure the text and link are not showing
5. try this in another language

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
