### PR TITLE
Vote-2825: Migrate Frontend tests to use page objects

### DIFF
--- a/testing/cypress/e2e/frontEndTests/accessability-toolbar.cy.js
+++ b/testing/cypress/e2e/frontEndTests/accessability-toolbar.cy.js
@@ -1,4 +1,5 @@
 /// <reference types="cypress" />
+import { pageObjects } from '../../support/pageObjects.js'
 
 describe('check accessability tool bar', () => {
   beforeEach('visit site', () => {
@@ -6,37 +7,62 @@ describe('check accessability tool bar', () => {
   })
 
   it('verify that tool bar is present', () => {
-    cy.get('[data-test="themeSwitcher"]').should('be.visible')
+    pageObjects
+    .themeSwitcher()
+    .should('be.visible')
   })
 
   it('verify page switches themes', () => {
-    cy.get('[data-test="themeContrast"]').click()
+    pageObjects
+    .themeContrast()
+    .click()
     cy.get('[data-theme="contrast"]').should('exist')
-    cy.get('[data-test="themeContrast"]').click()
+    
+    pageObjects
+    .themeContrast()
+    .click()
     cy.get('[data-theme="default"]').should('exist')
   })
 
   it('verify text enlarges', () => {
-    cy.get('[data-test="themeText"]').click()
+    pageObjects
+    .themeText()
+    .click()
     cy.get('[data-scale="large"]').should('exist')
-    cy.get('[data-test="themeText"]').click()
+
+    pageObjects
+    .themeText()
+    .click()
     cy.get('[data-scale="x-large"]').should('exist')
-    cy.get('[data-test="themeText"]').click()
+
+    pageObjects
+    .themeText()
+    .click()
     cy.get('[data-scale="default"]').should('exist')
   
   })
 
-  it.only('verify theme presents across pages', () => {
+  it('verify theme presents across pages', () => {
     // verify contrast theme 
-    cy.get('[data-test="themeContrast"]').click()
+    pageObjects
+    .themeContrast()
+    .click()
     cy.visit('/about-us').get('[data-theme="contrast"]').should('exist')
-    cy.get('[data-test="themeContrast"]').click()
+    
+    pageObjects
+    .themeContrast()
+    .click()
     cy.visit('/').get('[data-theme="default"]').should('exist')
 
     // verify text enlargement
-    cy.get('[data-test="themeText"]').click()
+    pageObjects
+    .themeText()
+    .click()
     cy.visit('/about-us').get('[data-scale="large"]').should('exist')
-    cy.get('[data-test="themeText"]').click()
+
+    pageObjects
+    .themeText()
+    .click()
     cy.visit('/').get('[data-scale="x-large"]').should('exist')
   })
 

--- a/testing/cypress/e2e/frontEndTests/email-signup.cy.js
+++ b/testing/cypress/e2e/frontEndTests/email-signup.cy.js
@@ -1,17 +1,14 @@
 /// <reference types="cypress" />
 
+import { pageObjects } from "../../support/pageObjects"
+
 describe('check email sign up function', () => {
   it('check that test is present once typed', () => {
     cy.visit('/')
-  
-    cy.get('[data-test="emailSignup"]').type('test@test.com')
-  
-    cy.get('[data-test="emailSignup"]').should('have.value', 'test@test.com')
-  
+
+    pageObjects
+    .emailSignup()
+    .type('test@test.com')
+    .should('have.value', 'test@test.com')
   })
 })
-
-
-
-
-

--- a/testing/cypress/e2e/frontEndTests/footer-contact.cy.js
+++ b/testing/cypress/e2e/frontEndTests/footer-contact.cy.js
@@ -1,11 +1,15 @@
 // <reference types="cypress" />
 
+import { pageObjects } from "../../support/pageObjects"
+
 describe('Check Homepage for vote.gov', () =>{
 
   it('Test Footer Contact on Home Page', () => {
     // check that the footer contact section is present on home page
     cy.visit('/')
-    cy.get('[data-test="footerContact"]').should('be.visible')
-  })
 
+    pageObjects
+    .footerContact()
+    .should('be.visible')
+  })
 })

--- a/testing/cypress/e2e/frontEndTests/government-banner.cy.js
+++ b/testing/cypress/e2e/frontEndTests/government-banner.cy.js
@@ -1,5 +1,7 @@
 // <reference types="cypress" />
 
+import { pageObjects } from "../../support/pageObjects"
+
 describe('check govt banner', () => {
   beforeEach('visit page', () => {
     cy.visit('/')
@@ -7,15 +9,32 @@ describe('check govt banner', () => {
 
   it('verify that drop down works', () => {
     cy.visit('/')
-    cy.get('[data-test="headerLogo"]').should('be.visible')
-    cy.get('[data-test="headerButton"]').click().get('[data-test="headerBanner"]').should('be.visible')
+
+    pageObjects
+    .headerLogo()
+    .should('be.visible')
+
+    pageObjects
+    .headerButton()
+    .click()
+    .then(() => {
+        pageObjects
+        .headerBanner()
+        .should('be.visible')
+      })
+
     // check to see if button hides banner as well
-    cy.get('[data-test="headerButton"]').click().get('[data-test="headerBanner"]').should('not.be.visible')
+    pageObjects
+    .headerButton()
+    .click()
+    .then(() => {
+        pageObjects
+        .headerBanner()
+        .should('not.be.visible')
+      })
   })
 
   it('verify class is present', () =>{
-    cy.get('[data-test="govBanner"]').find('[class="usa-banner__header"]').should('exist')
+  cy.get('[class="usa-banner__header"]').should('exist')
   })
 })
-
-

--- a/testing/cypress/e2e/frontEndTests/government-banner.cy.js
+++ b/testing/cypress/e2e/frontEndTests/government-banner.cy.js
@@ -8,8 +8,6 @@ describe('check govt banner', () => {
   })
 
   it('verify that drop down works', () => {
-    cy.visit('/')
-
     pageObjects
     .headerLogo()
     .should('be.visible')

--- a/testing/cypress/e2e/frontEndTests/language-selector.cy.js
+++ b/testing/cypress/e2e/frontEndTests/language-selector.cy.js
@@ -1,6 +1,7 @@
 /// <reference types="cypress" />
 
 const testPages = require("../../fixtures/language-selection.json")
+const { pageObjects } = require("../../support/pageObjects")
 
 // * This is written to verify that each language will give the user a valid webpage.  This is done by checking the response status should be 200 and also checking that the drop down is visible when clicked
 
@@ -10,25 +11,24 @@ describe('Test language selector', () => {
     cy.visit({
       url: page.route,
     })
-      cy.get('[data-test="languageButton"]').click().get('[data-test="languageSwitcher"]').should('be.visible').then(selection => {
-        cy.get(selection).get('[ data-test="langItem"]').each(li => {
-            cy.get(li).find('a').each(link => {
-              cy.request({
-                url: link.prop('href'),
-                failOnStatusCode: false
-              }).then((response) => {
-                expect(response.status).to.eq(200)
-              })
-          })
-        })
-      })
+
+    pageObjects.languageButton().click();
+    pageObjects.languageSwitcher().should('be.visible').then(($switcher) => {
+      pageObjects.langItem().each(($li) => {
+        cy.wrap($li).find('a').each(($link) => {
+          const url = $link.prop('href');
+          cy.request({ url, failOnStatusCode: false }).its('status').should('eq', 200);
+        });
+      });
+    });
     })
   })
 
-  it('Verify active language options', () => {
+  it.only('Verify active language options', () => {
     cy.visit('/')
     cy.fixture('language-options.json').then((expectedMenuItems) => {
-      cy.get('[data-test="languageButton"]').click().get('[data-test="languageSwitcher"]').find('li').then(($list) => {
+      pageObjects.languageButton().click();
+      pageObjects.languageSwitcher().find('li').then(($list) => {
         const actualMenuItems = $list.map((index, item) => {
           return Cypress.$(item).attr('data-lang');
         }).get();

--- a/testing/cypress/e2e/frontEndTests/language-selector.cy.js
+++ b/testing/cypress/e2e/frontEndTests/language-selector.cy.js
@@ -24,7 +24,7 @@ describe('Test language selector', () => {
     })
   })
 
-  it.only('Verify active language options', () => {
+  it('Verify active language options', () => {
     cy.visit('/')
     cy.fixture('language-options.json').then((expectedMenuItems) => {
       pageObjects.languageButton().click();

--- a/testing/cypress/e2e/frontEndTests/menu.cy.js
+++ b/testing/cypress/e2e/frontEndTests/menu.cy.js
@@ -50,6 +50,5 @@ describe('Check main menu', () => {
 
     pageObjects
     cy.get('[data-test="mobileNav"]').should('not.be.visible')
-
   })
 })

--- a/testing/cypress/e2e/frontEndTests/menu.cy.js
+++ b/testing/cypress/e2e/frontEndTests/menu.cy.js
@@ -1,29 +1,54 @@
 // <reference types="cypress" />
 
+import { pageObjects } from "../../support/pageObjects"
+
 describe('Check main menu', () => {
   beforeEach('visit page', () => {
     cy.visit('/')
   })
 
   it('main menu - desktop', () => {
-    cy.get('[data-test="mainNav"]').find('li').then(li => {
-      cy.get(li[1]).realClick()
-      cy.get('[data-test="subMenu"]').should('be.visible')
-    })
+    pageObjects
+    .mainNav()
+    .find('li')
+    .then(li => {
+      cy.wrap(li[1]).click()
+      .then(() => {
+        pageObjects
+        .subMenu().should('be.visible');
+      });
+    });
   })
 
   it('main menu - mobile', () => {
     // set viewport to mobile
     cy.viewport('iphone-6')
-    cy.get('[data-test="mobileBtn"]').click()
-    cy.get('[data-test="mobileNav"]').should('be.visible')
-    cy.get('[data-test="mobileNav"]').find('li').then(li => {
-      cy.get(li[1]).click()
-      cy.get('[data-test="subMenu"]').should('be.visible')
-    })
-    cy.get('[data-test="searchBox"]').should('be.visible')
+
+    pageObjects
+    .mobileBtn().click()
+
+    pageObjects
+    .mobileNav().should('be.visible')
+
+    pageObjects
+    .mobileNav()
+    .find('li')
+    .then(li => {
+      cy.wrap(li[1]).click()
+      .then(() => {
+        pageObjects
+        .subMenu().should('be.visible');
+      });
+    });
+
+    pageObjects
+    .searchBox().should('be.visible')
+    
     // close menu
-    cy.get('[data-test="mainCloseBtn"]').click()
+    pageObjects
+    .mainCloseBtn().click()
+
+    pageObjects
     cy.get('[data-test="mobileNav"]').should('not.be.visible')
 
   })

--- a/testing/cypress/e2e/frontEndTests/nvrf-download.cy.js
+++ b/testing/cypress/e2e/frontEndTests/nvrf-download.cy.js
@@ -1,5 +1,7 @@
 /// <reference types="cypress" />
 
+import { pageObjects } from "../../support/pageObjects"
+
 describe('Verify NVRF download', () => {
   
   beforeEach('visit page', () => {
@@ -14,7 +16,9 @@ describe('Verify NVRF download', () => {
         return orig.call(this, url, '_self', features)
       }
     })
-    cy.get('[data-test="nvrfDownload"]').click();
+
+    pageObjects
+    .nvrfDownload().click()
     cy.url().invoke('toLowerCase').should('include', 'eng')
   })
 })

--- a/testing/cypress/e2e/frontEndTests/search-bar.cy.js
+++ b/testing/cypress/e2e/frontEndTests/search-bar.cy.js
@@ -1,11 +1,16 @@
 /// <reference types="cypress" />
 
+import { pageObjects } from "../../support/pageObjects"
+
 describe('Check Search Bar Function', () => {
   it('Check Search directs to right page', () => {
     cy.visit('/')
 
-    cy.get('[data-test="searchBox"]').type('Kansas')
-    cy.get('[data-test="searchBtn"]').click()
+    pageObjects
+    .searchBox().type('Kansas')
+
+    pageObjects
+    .searchBtn().click()
 
     cy.url().should('contain', 'search.vote.gov')
   })

--- a/testing/cypress/e2e/frontEndTests/state-pages.cy.js
+++ b/testing/cypress/e2e/frontEndTests/state-pages.cy.js
@@ -1,25 +1,33 @@
 /// <reference types="cypress" />
 
+import { pageObjects } from "../../support/pageObjects"
+
 describe('test state pages', () => {
   it('test - online', () => {
     cy.visit('/register/ak')
-    cy.get('[data-test="registrationInfo"]').should('be.visible').and('contain', 'Online registration deadline:')
+    pageObjects
+    .registrationInfo().should('be.visible').and('contain', 'Online registration deadline:')
   })
 
   it('test - in person', () => {
     cy.visit('/register/as')
-    cy.get('[data-test="registrationInfo"]').should('be.visible').and('contain', 'In person registration deadline:')
+    pageObjects
+    .registrationInfo().should('be.visible').and('contain', 'In person registration deadline:')
   })
 
   it('test - mail in', () => {
     cy.visit('/register/ar')
-    cy.get('[data-test="registrationInfo"]').should('be.visible').and('contain', 'Register by mail deadline:')
-    cy.get('[data-test="nvrfForm"]').should('be.visible')
+    pageObjects
+    .registrationInfo().should('be.visible').and('contain', 'Register by mail deadline:')
+
+    pageObjects
+    .nvrfForm().should('be.visible')
   })
 
   it('test - not needed', () => {
     cy.visit('/register/nd')
-    cy.get('[data-test="registrationInfo"]').should('not.exist')
+    pageObjects
+    .registrationInfo().should('not.exist')
   })
 
 })

--- a/testing/cypress/e2e/frontEndTests/state-pages.cy.js
+++ b/testing/cypress/e2e/frontEndTests/state-pages.cy.js
@@ -29,5 +29,4 @@ describe('test state pages', () => {
     pageObjects
     .registrationInfo().should('not.exist')
   })
-
 })

--- a/testing/cypress/e2e/frontEndTests/state-registration.cy.js
+++ b/testing/cypress/e2e/frontEndTests/state-registration.cy.js
@@ -1,5 +1,7 @@
 /// <reference types="Cypress" />
 
+import { pageObjects } from "../../support/pageObjects"
+
 describe('Validate state selection options', () => {
   beforeEach('visit page', () => {
     cy.visit('/register')
@@ -7,19 +9,30 @@ describe('Validate state selection options', () => {
 
   it('Verify that type search is working', () => {
     // * Check that 'South' renders expected states
-    cy.get('[data-test="stateInput"]').type('South')
-    cy.get('[data-test="stateList"]').should('contain', 'South Carolina', 'South Dakota')
+    pageObjects
+    .stateInput().type('South')
+    pageObjects
+    .stateList().should('contain', 'South Carolina', 'South Dakota')
     cy.reload()
+
     // * Check that 'Virgin' renders expected states
-    cy.get('[data-test="stateInput"]').type('Virgin')
-    cy.get('[data-test="stateList"]').should('contain', 'U.S. Virgin Island', 'Virginia', 'West Virginia')
+    pageObjects
+    .stateInput().type('Virgin')
+    pageObjects
+    .stateList().should('contain', 'U.S. Virgin Island', 'Virginia', 'West Virginia')
     cy.reload()
+
     // * Check that 'Carolina' renders expected states
-    cy.get('[data-test="stateInput"]').type('Carolina')
-    cy.get('[data-test="stateList"]').should('contain', 'South Carolina', 'North Carolina')
+    pageObjects
+    .stateInput().type('Carolina')
+    pageObjects
+    .stateList().should('contain', 'South Carolina', 'North Carolina')
     cy.reload()
+
     // * Check that 'mar' renders expected states
-    cy.get('[data-test="stateInput"]').type('mar')
-    cy.get('[data-test="stateList"]').should('contain', 'Maryland', 'Northern Mariana Islands')
+    pageObjects
+    .stateInput().type('mar')
+    pageObjects
+    .stateList().should('contain', 'Maryland', 'Northern Mariana Islands')
   })
 })

--- a/testing/cypress/fixtures/testing-page.json
+++ b/testing/cypress/fixtures/testing-page.json
@@ -1,8 +1,0 @@
-[
-
-  {
-    "name": "homePage",
-    "route": "http://vote-gov.lndo.site/"
-  }
-
-]

--- a/testing/cypress/support/pageObjects.js
+++ b/testing/cypress/support/pageObjects.js
@@ -1,0 +1,116 @@
+class PageObjects {
+  // frontend test page objects 
+
+  // * accessability tool bar
+  themeSwitcher() {
+    return cy.get('[data-test="themeSwitcher"]')
+  }
+
+  themeContrast() {
+    return cy.get('[data-test="themeContrast"]')
+  }
+
+  themeText() {
+    return  cy.get('[data-test="themeText"]')
+  }
+
+  // * email signup 
+  emailSignup() {
+    return cy.get('[data-test="emailSignup"]')
+  }
+
+  // * footer contact
+  footerContact() {
+    return cy.get('[data-test="footerContact"]')
+  }
+
+  // * govt banner
+  headerLogo() {
+    return cy.get('[data-test="headerLogo"]')
+  }
+
+  headerButton() {
+    return cy.get('[data-test="headerButton"]')
+  }
+
+  headerBanner() { 
+    return cy.get('[data-test="headerBanner"]')
+  }
+
+  // * language selector
+  languageButton() {
+    return cy.get('[data-test="languageButton"]')
+  }
+
+  languageSwitcher() {
+    return cy.get('[data-test="languageSwitcher"]')
+  }
+
+  langItem() {
+    return cy.get('[ data-test="langItem"]')
+  }
+
+  // * main menu
+  mainNav() {
+    return cy.get('[data-test="mainNav"]')
+  }
+
+  subNav() {
+    return cy.get('[data-test="subMenu"]')
+  }
+
+  mobileBtn() {
+    return cy.get('[data-test="mobileBtn"]')
+  }
+
+  mobileNav() {
+    return cy.get('[data-test="mobileNav"]')
+  }
+
+  subMenu() {
+    return cy.get('[data-test="subMenu"]')
+  }
+
+  searchBox() {
+    return cy.get('[data-test="searchBox"]')
+  }
+
+  mainCloseBtn() {
+    return cy.get('[data-test="mainCloseBtn"]')
+  }
+
+  // * nvrf download
+  nvrfDownload() {
+    return cy.get('[data-test="nvrfDownload"]')
+  }
+
+  // * search bar
+  searchBox() {
+    return cy.get('[data-test="searchBox"]')
+  }
+
+  searchBtn() {
+    return cy.get('[data-test="searchBtn"]')
+  }
+
+  // * state pages
+  registrationInfo() {
+    return cy.get('[data-test="registrationInfo"]')
+  }
+
+  nvrfForm() {
+    return cy.get('[data-test="nvrfForm"]')
+  }
+
+  // * state registration
+  stateInput() {
+    return cy.get('[data-test="stateInput"]')
+  }
+
+  stateList() {
+    return cy.get('[data-test="stateList"]')
+  }
+
+}
+
+export const pageObjects = new PageObjects()


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[Vote-2825](https://cm-jira.usa.gov/browse/VOTE-2825)

## Description

Updating frontend tests to utilize page objects.  The goal of of this is to help with troubleshooting and being able to maintain tests if an update is needed. This also allows us to reuse testing objects in multiple tests or the same if they are reused. 

## Deployment and testing

### Post-deploy steps

n/a

### QA/Testing instructions

1. pull down locally
2. cd into `testing` and run `npm run cy:frontEnd` and verify that tests are still passing 

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
