### PR TITLE
Vote-2841: Hover style fix - NVRF Links

### DIFF
--- a/web/themes/custom/votegov/src/sass/base/link.scss
+++ b/web/themes/custom/votegov/src/sass/base/link.scss
@@ -2,7 +2,9 @@
 @use "mixins" as *;
 
 a {
-  main & {
+  main &,
+  // targeting links within NVRF form
+  .usa-form & {
     @include vote-link-bg;
   }
 }

--- a/web/themes/custom/votegov/src/sass/uswds-overrides/usa-form.scss
+++ b/web/themes/custom/votegov/src/sass/uswds-overrides/usa-form.scss
@@ -41,9 +41,3 @@
     opacity: 1; //override Firefox
   }
 }
-
-// .usa-form a:where(:not(.usa-button)):active {
-//   text-decoration: none;
-//   background-color: var(--vote-link-hover--bg-color);
-//   color: var(--vote-link-hover--color);
-// }

--- a/web/themes/custom/votegov/src/sass/uswds-overrides/usa-form.scss
+++ b/web/themes/custom/votegov/src/sass/uswds-overrides/usa-form.scss
@@ -24,8 +24,6 @@
   }
 }
 
-
-
 ::placeholder {
   --input-placeholder--text: inherit;
   color: var(--input-placeholder--text);

--- a/web/themes/custom/votegov/src/sass/uswds-overrides/usa-form.scss
+++ b/web/themes/custom/votegov/src/sass/uswds-overrides/usa-form.scss
@@ -23,7 +23,7 @@
     }
   }
 
-  a:where(:not(.usa-button)):active {
+  a:where(:not(.usa-button)):is(:active, :focus) {
     text-decoration: none;
     background-color: var(--vote-link-hover--bg-color);
     color: var(--vote-link-hover--color);

--- a/web/themes/custom/votegov/src/sass/uswds-overrides/usa-form.scss
+++ b/web/themes/custom/votegov/src/sass/uswds-overrides/usa-form.scss
@@ -22,7 +22,14 @@
       height: 40px !important;
     }
   }
+
+  a:where(:not(.usa-button)):active {
+    text-decoration: none;
+    background-color: var(--vote-link-hover--bg-color);
+    color: var(--vote-link-hover--color);
+  }
 }
+
 
 
 ::placeholder {
@@ -34,3 +41,9 @@
     opacity: 1; //override Firefox
   }
 }
+
+// .usa-form a:where(:not(.usa-button)):active {
+//   text-decoration: none;
+//   background-color: var(--vote-link-hover--bg-color);
+//   color: var(--vote-link-hover--color);
+// }

--- a/web/themes/custom/votegov/src/sass/uswds-overrides/usa-form.scss
+++ b/web/themes/custom/votegov/src/sass/uswds-overrides/usa-form.scss
@@ -22,12 +22,6 @@
       height: 40px !important;
     }
   }
-
-  a:where(:not(.usa-button)):is(:active, :focus) {
-    text-decoration: none;
-    background-color: var(--vote-link-hover--bg-color);
-    color: var(--vote-link-hover--color);
-  }
 }
 
 


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[Vote-2841](https://cm-jira.usa.gov/browse/VOTE-2841)

## Description

Addressing a hover style for links within the NVRF app.  When links were active there was no contrast between the background and text color 

**Solution** Updated the USWDS override file for `usa-form` and used the same styles from other link hover effects 

Before and After:
<img width="1393" alt="Screenshot 2024-09-16 at 3 34 39 PM" src="https://github.com/user-attachments/assets/42ef18b2-af82-4946-8f62-5f27fc5db9b1">


## Deployment and testing

### Post-deploy steps

1. cd into the `votegov` theme and run `npm run build`

### QA/Testing instructions

1. Start up local and visit a state page and start the digital form 
2. Fill out form and go to the last page for delivery and scroll to the section `A few important notes` and both links `type of identification` and `guide to voting`.  
3. click on the links or use your dom and turn on `:active` state and verity that the correct styles are being applied 

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
