### PR TITLE
VOTE-2569: Create custom page to dislay state nvrf app links which ar…

### DIFF
--- a/scripts/upkeep
+++ b/scripts/upkeep
@@ -39,7 +39,6 @@ echo "Running 'drush tome:static' in '${environment}'..."
 echo "**************************************************"
 drush tome:static --uri=${ssg_endpoint} --path-count=1 --retry-count=3 -y
 drush tome:static-export-path '/sitemap.xml,/sitemap_generator/default/sitemap.xsl' --uri=${ssg_sitemap_endpoint} --retry-count=3 -y
-drush tome:static-export-path '/disabled-state-mail-in-forms' --uri=${ssg_endpoint} --retry-count=3 -y
 drush cr
 echo "'drush tome:static' task...completed!"
 echo ""

--- a/scripts/upkeep
+++ b/scripts/upkeep
@@ -39,6 +39,7 @@ echo "Running 'drush tome:static' in '${environment}'..."
 echo "**************************************************"
 drush tome:static --uri=${ssg_endpoint} --path-count=1 --retry-count=3 -y
 drush tome:static-export-path '/sitemap.xml,/sitemap_generator/default/sitemap.xsl' --uri=${ssg_sitemap_endpoint} --retry-count=3 -y
+drush tome:static-export-path '/disabled-state-mail-in-forms' --uri=${ssg_endpoint} --retry-count=3 -y
 drush cr
 echo "'drush tome:static' task...completed!"
 echo ""
@@ -105,6 +106,13 @@ echo "Deleting taxonomy directories..."
 echo "**************************************************"
 rm -rf ${html_path}/taxonomy 2>/dev/null
 echo "Deleting taxonomy directories...completed!"
+echo ""
+
+echo "**************************************************"
+echo "Removing miscellaneous files..."
+echo "**************************************************"
+rm -rf ${html_path}/disabled-state-mail-in-forms 2>/dev/null
+echo "Removing miscellaneous files...completed!"
 echo ""
 
 echo "**************************************************"

--- a/web/modules/custom/vote_nvrf/src/Controller/NvrfPageController.php
+++ b/web/modules/custom/vote_nvrf/src/Controller/NvrfPageController.php
@@ -97,6 +97,11 @@ class NvrfPageController extends ControllerBase {
 
       foreach ($languages as $langcode => $route) {
         $url = Url::fromRoute($route, ['state_name' => $state_name])->toString();
+        // Add language code to url for non-english pages.
+        if ('en' !== $langcode) {
+          $url = "/$langcode" . $url;
+        }
+
         $output .= '<li><a href="' . $url . '">' . $title . '(' . $langcode . ')' . '</a></li>';
       }
     }

--- a/web/modules/custom/vote_nvrf/src/Controller/NvrfPageController.php
+++ b/web/modules/custom/vote_nvrf/src/Controller/NvrfPageController.php
@@ -76,6 +76,18 @@ class NvrfPageController extends ControllerBase {
    * NVRF Page Controller which outputs disabled nvrf app state links.
    */
   public function disabledStateFormsContent() {
+    // Get the current language.
+    $current_language = \Drupal::languageManager()->getCurrentLanguage()->getId();
+
+    // Get the default language.
+    $default_language = \Drupal::languageManager()->getDefaultLanguage()->getId();
+
+    // Check if the current language is not the default.
+    if ($current_language !== $default_language) {
+      // Return a 404 response if no matches are found.
+      throw new NotFoundHttpException();
+    }
+
     $node_storage = \Drupal::entityTypeManager()->getStorage('node');
     $nodes = $node_storage->loadByProperties([
       'type' => 'state_territory',

--- a/web/modules/custom/vote_nvrf/vote_nvrf.routing.yml
+++ b/web/modules/custom/vote_nvrf/vote_nvrf.routing.yml
@@ -12,3 +12,9 @@ vote_nvrf.nvrf_page_es:
   requirements:
     _permission: 'access content'
     state_name: '[a-z-]+'
+vote_nvrf.disabled_nvrf_pages:
+  path: '/disabled-state-mail-in-forms'
+  defaults:
+    _controller: '\Drupal\vote_nvrf\Controller\NvrfPageController::disabledStateFormsContent'
+  requirements:
+    _permission: 'access content'


### PR DESCRIPTION


<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[VOTE-2569](https://cm-jira.usa.gov/browse/VOTE-2569)

## Description

Create custom page to dislay state nvrf app links which are disabled for tome to generate static redirect pages for them.

## Deployment and testing

### Post-deploy steps

n/a

### QA/Testing instructions

1. Goto /disabled-state-mail-in-forms and confirm the list of State/Translations.
2. Click on the links and confirm that they redirect to the respective state registration page.
3. Locally from your terminal run 'lando drush tome:static-export-path /disabled-state-mail-in-forms' and confirm that the static pages created form the state nvrf app page redirect to the state page.
4. Confirm that the nvrf app which are enabled for other states are still rendering and not redirecting.

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been included above.
- [ ] No merge conflicts exist with the target branch.
- [ ] Automated tests have passed on this PR.
- [ ] A reviewer has been designated.
- [ ] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
