### PR TITLE
Vote-2909: Regression fix for link styles

### DIFF
--- a/web/themes/custom/votegov/src/sass/base/link.scss
+++ b/web/themes/custom/votegov/src/sass/base/link.scss
@@ -2,9 +2,7 @@
 @use "mixins" as *;
 
 a {
-  main &,
-  // targeting links within NVRF form
-  .usa-form & {
+  main & {
     @include vote-link-bg;
   }
 }

--- a/web/themes/custom/votegov/src/sass/uswds-overrides/usa-form.scss
+++ b/web/themes/custom/votegov/src/sass/uswds-overrides/usa-form.scss
@@ -1,5 +1,6 @@
 @use "uswds-core" as *;
 @use "variables" as *;
+@use "mixins" as *;
 
 .usa-form {
   @include u-maxw('tablet');
@@ -18,6 +19,9 @@
 
 .nvrf-app-container {
   .usa-form {
+    a {
+      @include vote-link-bg;
+    }
     .usa-input {
       height: 40px !important;
     }


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[Vote-2909](https://cm-jira.usa.gov/browse/VOTE-2909)

## Description

Addressing a bug that was added after the NVRF link hover styles were added.  This will fix the issues with links styled as buttons losing the text color after being visited 


https://github.com/user-attachments/assets/a30eeb0d-54a1-4e9c-82e4-9c4b1da7ef43



## Deployment and testing

### Post-deploy steps

1. cd into the `votegov` theme and run `npm run build` and clear cache 

### QA/Testing instructions

1. Spot check site to ensure no other links have regression added 
2. visit the log in page and verify that the button has been fixed 
3. visit the NVRF form and verify that the original fix is still applied [see this pr for reference](https://github.com/usagov/vote-gov-drupal/pull/989)

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
