### PR TITLE
Vote-2619: Revert "Bump vite from 4.5.3 to 4.5.5 in /web/modules/custom/vote_nvrf"

### DIFF
--- a/web/modules/custom/vote_nvrf/package-lock.json
+++ b/web/modules/custom/vote_nvrf/package-lock.json
@@ -1327,9 +1327,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.5.tgz",
-      "integrity": "sha512-ifW3Lb2sMdX+WU91s3R0FyQlAyLxOzCSCP37ujw0+r5POeHPwe6udWVIElKQq8gk3t7b8rkmvqC6IHBpCff4GQ==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.3.tgz",
+      "integrity": "sha512-kQL23kMeX92v3ph7IauVkXkikdDRsYMGTVl5KY2E9OY4ONLvkHf04MDTbnfo6NKxZiDLWzVpP5oTa8hQD8U3dg==",
       "dependencies": {
         "esbuild": "^0.18.10",
         "postcss": "^8.4.27",


### PR DESCRIPTION
Reverts usagov/vote-gov-drupal#992

ticket [Vote-2619](https://cm-jira.usa.gov/browse/VOTE-2916)