### PR TITLE
Vote-2843: Update to spacing for search box

### DIFF
--- a/web/themes/custom/votegov/src/sass/uswds-overrides/usa-nav.scss
+++ b/web/themes/custom/votegov/src/sass/uswds-overrides/usa-nav.scss
@@ -271,7 +271,11 @@
   }
 }
 
+
 .usa-nav__secondary {
+  // setting bottom as a variable to help with spacing for larger text sizes from a11y bar
+  $nav-bottom: 5.5rem;
+
   @include at-media-max('tablet-lg') {
     @include u-margin(0);
     @include grid-container;
@@ -281,15 +285,23 @@
       border-top: 1px solid $bg-light-medium;
     }
   }
-
+  
   @include at-media('tablet-lg') {
     [dir="rtl"] & {
       right: unset;
     }
-
+    
     @include u-right(0);
-    bottom: 5.5rem;
+    bottom: $nav-bottom;
     inset-inline-end: 5rem;
+
+    [data-scale="large"] & {
+      bottom: $nav-bottom - 0.25rem;
+    }
+
+    [data-scale="x-large"] & {
+      bottom: $nav-bottom - 0.5rem;
+    }
   }
 }
 


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[Vote-2843](https://cm-jira.usa.gov/browse/VOTE-2843)

## Description

Addressing bug with spacing not staying consistent with the search box when toggling on the text size button from the a11y bar

**Before:**

https://github.com/user-attachments/assets/47bfa4ec-fda1-4077-b5bc-2f55fc1099d9

**After:**

https://github.com/user-attachments/assets/cbe9512f-0226-499a-b3b9-1b2d26aa753e

## Deployment and testing

### Post-deploy steps

1. cd into the `votegov` theme and run `npm run build` to compile the assets

### QA/Testing instructions

1. toggle the larger text button on the a11y bard and verify that the vertical space stays consistant as the text size grows 

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been included above.
- [ ] No merge conflicts exist with the target branch.
- [ ] Automated tests have passed on this PR.
- [ ] A reviewer has been designated.
- [ ] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
