### PR TITLE
VOTE-2883 state page updates elections date

### DIFF
--- a/config/sync/core.entity_view_display.block_content.state_display_content.default.yml
+++ b/config/sync/core.entity_view_display.block_content.state_display_content.default.yml
@@ -44,7 +44,7 @@ content:
     label: above
     settings:
       timezone_override: ''
-      format_type: medium
+      format_type: long_date
     third_party_settings: {  }
     weight: 10
     region: content

--- a/web/themes/custom/votegov/templates/node/node--state-territory.html.twig
+++ b/web/themes/custom/votegov/templates/node/node--state-territory.html.twig
@@ -40,6 +40,8 @@
 {% set mail_registration = state_display_content.field_mail_registration.0 | default([]) | merge(content.field_mail_registration.0 | default([])) %}
 {% set inperson_registration = state_display_content.field_in_person_registration.0 | default([]) | merge(content.field_in_person_registration.0 | default([])) %}
 {% set check_registration = state_display_content.field_check_registration.0 | default([]) | merge(content.field_check_registration.0 | default([])) %}
+{% set election_date = state_display_content.field_election_date.0 | default([]) | merge(content.field_election_date.0 | default([])) %}
+{% set election_text = state_display_content.field_election_text.0 | default([]) | merge(content.field_election_text.0 | default([])) %}
 
 <div{{ attributes.addClass(classes) }}>
   {# Hold these title_* placeholders for potential integration #}
@@ -55,6 +57,12 @@
     {% if check_registration is not empty %}
       {{ check_registration }}
       {{ confirm_registration_link }}
+    {% endif %}
+
+     {# Election Date #}
+    {% if (election_date is not empty) and (election_text is not empty) %}
+      {% set election_date_text = election_text['#text'] | t({'@date': election_date | render }) %}
+      {{ election_date_text }}
     {% endif %}
 
     {% if registration_intro is not empty %}


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

https://cm-jira.usa.gov/browse/VOTE-2883

## Description

Create a template for the new State Display content block.
Display the election date field with hardcoded content.

## Deployment and testing

### Post-deploy steps

1. lando retune

### QA/Testing instructions

1. Login to admin and create a new State Display Content block. http://vote-gov.lndo.site/admin/content/block
2. Set the Election Date and the Election text for English and Spanish. You don't have to fill out optional fields. 
3. Visit http://vote-gov.lndo.site/register/alabama and confirm the election date display matches the designs.
4. Test English and Spanish and confirm the election date translates. 
5. Go back to the State Display Content block. Unset the election date.
6. View the state page again and confirm all content for the election date no longer displays.

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
