### PR TITLE
VOTE-2886 state enhancement in person

### DIFF
--- a/web/themes/custom/votegov/templates/node/node--state-territory.html.twig
+++ b/web/themes/custom/votegov/templates/node/node--state-territory.html.twig
@@ -76,8 +76,16 @@
     {% endif %}
 
     {% if inperson_registration is not empty %}
-      {{ inperson_registration }}
-      {{ inperson_deadline }}
+      {% set body = inperson_registration.text['#markup'] | t({'@state_in-person_deadline': inperson_deadline | render }) %}
+      {% set link_title = inperson_registration.link_text['#markup'] | t({'@state_name': title_english }) %}
+      {% include '@votegov/component/info-card.html.twig' with {
+        'heading': inperson_registration.heading,
+        'body': body,
+          'link': {
+            'url': more_info_link,
+            'title': link_title,
+          }
+      } %}
     {% endif %}
 
     {% if military_overseas_registration is not empty %}

--- a/web/themes/custom/votegov/templates/node/node--state-territory.html.twig
+++ b/web/themes/custom/votegov/templates/node/node--state-territory.html.twig
@@ -41,11 +41,17 @@
 {% set inperson_registration = state_display_content.field_in_person_registration.0 | default([]) | merge(content.field_in_person_registration.0 | default([])) %}
 {% set check_registration = state_display_content.field_check_registration.0 | default([]) | merge(content.field_check_registration.0 | default([])) %}
 
+{# Registration types #}
+{% set registration_types = content.field_registration_type | field_value | column('#markup') %}
+{% set has_in_person = "in-person" in registration_types %}
+{% set has_mail = "by-mail" in registration_types %}
+{% set has_online = "online" in registration_types %}
+{% set not_needed = "not-needed" in registration_types %}
+
 <div{{ attributes.addClass(classes) }}>
   {# Hold these title_* placeholders for potential integration #}
   {{ title_prefix }}
   {{ title_suffix }}
-
   <div class="vote-narrow-container-left-align">
   {% if drupal_view('inline_alert', 'embed_1') | render | striptags | trim %}
     {{ drupal_view('inline_alert', 'embed_1') }}
@@ -75,7 +81,7 @@
       {{ state_mail_pdf_link }}
     {% endif %}
 
-    {% if inperson_registration is not empty %}
+    {% if has_in_person and (inperson_registration is not empty) %}
       {% set body = inperson_registration.text['#markup'] | t({'@state_in-person_deadline': inperson_deadline | render }) %}
       {% set link_title = inperson_registration.link_text['#markup'] | t({'@state_name': title_english }) %}
       {% include '@votegov/component/info-card.html.twig' with {


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket
https://cm-jira.usa.gov/browse/VOTE-2886

## Description

Configure the display of the "In Person" registration card

## Deployment and testing

### Post-deploy steps

1. lando retune

### QA/Testing instructions

1. Login as admin and create a "State content display" block. Set the general in-person fields for English and Spanish. Use the content in [this document](https://docs.google.com/document/d/1TVAf-R2nLTKh7kmCTe3mBKSqWn8hcGr1TsjirdCXptQ/edit#heading=h.w121gvnnkl64).
2. View the English Alabama page and confirm the "In-person" block displays with the corresponding content.
3. View the Spanish Alabama page and confirm the "In-person" block displays with the corresponding content.
4. Verify the registration date correctly displays for both English and Spanish.
5. Edit the Alabama page. Uncheck the "in-person" registration checkbox.
6. Confirm the "in-person block does not display for either language.
7. Re-enable the "in-person" registration type.
8. In the state page configuration, set the override fields for both English and Spanish.
9. View the English Alabama page and confirm the "In-person" block displays with the override content.
10. View the Spanish Alabama page and confirm the "In-person" block displays with the override content.

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
