### PR TITLE
VOTE-2965: Fix body text wrap

### DIFF
--- a/web/themes/custom/votegov/src/sass/components/page-content.scss
+++ b/web/themes/custom/votegov/src/sass/components/page-content.scss
@@ -2,14 +2,19 @@
 @use "variables" as *;
 @use "mixins" as *;
 
-.vote-main-content-row {
-  display: flex;
+.vote-main-content-row, .usa-in-page-nav-container {
+  @include u-display('block');
+
+  @include at-media('tablet-lg') {
+    @include u-display('flex');
+  }
 }
 
 .vote-page-content {
   @include u-margin-top(4);
   @include u-margin-bottom(6);
   @include u-position('relative');
+  word-wrap: break-word;
 
   .field--name-field-media {
     @include at-media('desktop') {


### PR DESCRIPTION
[VOTE-2965](https://cm-jira.usa.gov/browse/VOTE-2965)

## Description

Solves the bug causing longer links to not wrap properly on voter guide pages and new state enhancement pages. This issue was identified during https://cm-jira.usa.gov/browse/VOTE-2888 

Before
<img width="371" alt="Screenshot 2024-10-08 at 5 51 36 PM" src="https://github.com/user-attachments/assets/805b3ca8-e2d9-46fe-bf66-95914c9fe166">

Now
<img width="376" alt="Screenshot 2024-10-08 at 5 50 35 PM" src="https://github.com/user-attachments/assets/71b27460-2cec-4f8b-85b0-6dd6eca01bfa">

Now

## Deployment and testing

### QA/Testing instructions

1. Edit a voter guide page
2. Add https://www.alabamainteractive.org/sos/voter_registration/voterRegistrationWelcome.action to the body somewhere
3. Confirm it wraps on smaller screen sizes

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
