### PR TITLE
VOTE-2885 configure state mail registration section

### DIFF
--- a/config/sync/core.entity_form_display.block_content.state_display_content.default.yml
+++ b/config/sync/core.entity_form_display.block_content.state_display_content.default.yml
@@ -29,7 +29,11 @@ content:
     type: vote_fields_state_content
     weight: 3
     region: content
-    settings: {  }
+    settings:
+      form_subfield_display:
+        - heading
+        - text
+        - link_text
     third_party_settings: {  }
   field_display_title:
     type: string_textfield
@@ -60,43 +64,71 @@ content:
     type: vote_fields_state_content
     weight: 7
     region: content
-    settings: {  }
+    settings:
+      form_subfield_display:
+        - heading
+        - text
+        - link_text
     third_party_settings: {  }
   field_mail_registration:
     type: vote_fields_state_content
     weight: 5
     region: content
-    settings: {  }
+    settings:
+      form_subfield_display:
+        - heading
+        - text
+        - link_text
     third_party_settings: {  }
   field_military_and_overseas_regi:
     type: vote_fields_state_content
     weight: 8
     region: content
-    settings: {  }
+    settings:
+      form_subfield_display:
+        heading: heading
+        text: text
+        link_text: 0
     third_party_settings: {  }
   field_nvrf_details:
     type: vote_fields_state_content
     weight: 6
     region: content
-    settings: {  }
+    settings:
+      form_subfield_display:
+        - heading
+        - text
+        - link_text
     third_party_settings: {  }
   field_online_registration:
     type: vote_fields_state_content
     weight: 4
     region: content
-    settings: {  }
+    settings:
+      form_subfield_display:
+        - heading
+        - text
+        - link_text
     third_party_settings: {  }
   field_registration_intro:
     type: vote_fields_state_content
     weight: 2
     region: content
-    settings: {  }
+    settings:
+      form_subfield_display:
+        heading: heading
+        text: text
+        link_text: 0
     third_party_settings: {  }
   field_registration_not_needed:
     type: vote_fields_state_content
     weight: 9
     region: content
-    settings: {  }
+    settings:
+      form_subfield_display:
+        - heading
+        - text
+        - link_text
     third_party_settings: {  }
   info:
     type: string_textfield

--- a/config/sync/core.entity_view_display.node.state_territory.full.yml
+++ b/config/sync/core.entity_view_display.node.state_territory.full.yml
@@ -212,6 +212,18 @@ content:
     third_party_settings: {  }
     weight: 28
     region: content
+  field_mail_registration_link:
+    type: link
+    label: hidden
+    settings:
+      trim_length: null
+      url_only: true
+      url_plain: true
+      rel: '0'
+      target: '0'
+    third_party_settings: {  }
+    weight: 32
+    region: content
   field_media:
     type: entity_reference_entity_view
     label: hidden
@@ -380,7 +392,6 @@ hidden:
   field_address_location_inst: true
   field_content_version: true
   field_identification_inst: true
-  field_mail_registration_link: true
   field_mailing_address_inst: true
   field_metatags: true
   field_nvrf_fields: true

--- a/web/modules/custom/vote_fields/config/schema/vote_fields.schema.yml
+++ b/web/modules/custom/vote_fields/config/schema/vote_fields.schema.yml
@@ -13,3 +13,13 @@ field.value.vote_fields_state_content:
     link_text:
       type: string
       label: Link text
+
+field.field_settings.vote_fields_state_content:
+  type: mapping
+  label: Field settings
+  mapping:
+    form_subfield_display:
+      type: list
+      label: Fields to display in the form
+      sequence:
+        type: string

--- a/web/modules/custom/vote_fields/src/Plugin/Field/FieldWidget/StateContentWidget.php
+++ b/web/modules/custom/vote_fields/src/Plugin/Field/FieldWidget/StateContentWidget.php
@@ -27,7 +27,7 @@ final class StateContentWidget extends WidgetBase {
     $settings['form_subfield_display'] = [
       'heading',
       'text',
-      'link_text'
+      'link_text',
     ];
 
     return $settings + parent::defaultSettings();
@@ -65,7 +65,7 @@ final class StateContentWidget extends WidgetBase {
       '#type' => 'textfield',
       '#title' => $this->t('Heading'),
       '#default_value' => $items[$delta]->heading ?? NULL,
-      '#access' => in_array('heading', $settings['form_subfield_display'])
+      '#access' => in_array('heading', $settings['form_subfield_display']),
     ];
 
     $element['text'] = [
@@ -74,14 +74,14 @@ final class StateContentWidget extends WidgetBase {
       '#default_value' => $items[$delta]->text ?? NULL,
       '#format' => 'simple_html',
       '#allowed_formats' => ['simple_html'],
-      '#access' => in_array('text', $settings['form_subfield_display'])
+      '#access' => in_array('text', $settings['form_subfield_display']),
     ];
 
     $element['link_text'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Link text'),
       '#default_value' => $items[$delta]->link_text ?? NULL,
-      '#access' => in_array('link_text', $settings['form_subfield_display'])
+      '#access' => in_array('link_text', $settings['form_subfield_display']),
     ];
 
     $element['#theme_wrappers'] = ['fieldset'];

--- a/web/modules/custom/vote_fields/src/Plugin/Field/FieldWidget/StateContentWidget.php
+++ b/web/modules/custom/vote_fields/src/Plugin/Field/FieldWidget/StateContentWidget.php
@@ -23,12 +23,49 @@ final class StateContentWidget extends WidgetBase {
   /**
    * {@inheritdoc}
    */
+  public static function defaultSettings(): array {
+    $settings['form_subfield_display'] = [
+      'heading',
+      'text',
+      'link_text'
+    ];
+
+    return $settings + parent::defaultSettings();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsForm(array $form, FormStateInterface $form_state): array {
+    $settings = $this->getSettings();
+
+    $element['form_subfield_display'] = [
+      '#type' => 'checkboxes',
+      '#title' => t('Fields to display in the form'),
+      '#options' => [
+        'heading' => 'Heading',
+        'text' => 'Text',
+        'link_text' => 'Link text',
+      ],
+      '#required' => TRUE,
+      '#default_value' => $settings['form_subfield_display'],
+      '#description' => t('Select all subfields that you want to display in the form.'),
+    ];
+
+    return $element;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state): array {
+    $settings = $this->getSettings();
 
     $element['heading'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Heading'),
       '#default_value' => $items[$delta]->heading ?? NULL,
+      '#access' => in_array('heading', $settings['form_subfield_display'])
     ];
 
     $element['text'] = [
@@ -37,12 +74,14 @@ final class StateContentWidget extends WidgetBase {
       '#default_value' => $items[$delta]->text ?? NULL,
       '#format' => 'simple_html',
       '#allowed_formats' => ['simple_html'],
+      '#access' => in_array('text', $settings['form_subfield_display'])
     ];
 
     $element['link_text'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Link text'),
       '#default_value' => $items[$delta]->link_text ?? NULL,
+      '#access' => in_array('link_text', $settings['form_subfield_display'])
     ];
 
     $element['#theme_wrappers'] = ['fieldset'];

--- a/web/themes/custom/votegov/templates/component/info-card.html.twig
+++ b/web/themes/custom/votegov/templates/component/info-card.html.twig
@@ -30,7 +30,7 @@
       {{ body }}
     </div>
   {% endif %}
-  {% if link %}
+  {% if link.url and link.title %}
     <div class="vote-info-card__button">
       {% include '@votegov/component/button.html.twig' with {
         'href': link.url,

--- a/web/themes/custom/votegov/templates/node/node--state-territory--not-needed.html.twig
+++ b/web/themes/custom/votegov/templates/node/node--state-territory--not-needed.html.twig
@@ -24,6 +24,10 @@
         } %}
       </p>
     {% endif %}
+
+    {% if military_overseas_registration is not empty %}
+      {{ military_overseas_registration }}
+    {% endif %}
   {% endif %}
 
   {# JSON Schema #}

--- a/web/themes/custom/votegov/templates/node/node--state-territory.html.twig
+++ b/web/themes/custom/votegov/templates/node/node--state-territory.html.twig
@@ -19,6 +19,11 @@
   'usa-in-page-nav-container'
 ] %}
 
+{% set state_name = label | field_value | render %}
+{% set accepts_nvrf = node.field_accepts_nvrf.value == 1 %}
+
+{% set has_mail = "by-mail" in (content.field_registration_type | field_value | column('#markup')) %}
+
 {# Links with fallbacks. #}
 {% set more_info_link = content.field_override_more_info_link | field_value | default(content.field_more_info_link | field_value) | render | trim %}
 {% set confirm_registration_link = content.field_override_confirm_reg_link | field_value | default(content.field_confirm_registration_link | field_value) | render | trim %}
@@ -29,8 +34,22 @@
 {# Deadlines with fallbacks. #}
 {% set online_deadline = content.field_online_deadline | field_value | default(content.field_g_online_deadline | field_value) %}
 {% set inperson_deadline = content.field_in_person_deadline | field_value | default(content.field_g_in_person_deadline | field_value) %}
-{% set postmarked_deadline = content.field_mail_postmarked_deadline | field_value | default(content.field_g_mail_postmarked_deadline | field_value) %}
-{% set received_deadline = content.field_mail_received_deadline | field_value | default(content.field_g_mail_received_deadline | field_value) %}
+{# Set postmarked deadline with fallback #}
+{% if content.field_mail_postmarked_deadline | render %}
+  {% set postmarked_deadline = 'Must be postmarked by @date' | t({'@date': content.field_mail_postmarked_deadline.0 | render}) %}
+{% else %}
+  {% set postmarked_deadline = content.field_g_mail_postmarked_deadline | field_value %}
+{% endif %}
+
+{# Set received deadline with fallback #}
+{% if content.field_mail_received_deadline | render %}
+  {% set received_deadline = 'Must be received by @date' | t({'@date': content.field_mail_received_deadline.0 | render}) %}
+{% else %}
+  {% set received_deadline = content.field_g_mail_received_deadline | field_value %}
+{% endif %}
+
+{# Set the deadline with fallback, prioritizing postmarked deadline. #}
+{% set bymail_deadline = postmarked_deadline | default(received_deadline) %}
 
 {# State content with fallbacks. #}
 {# Get default state display content from the block type. #}
@@ -40,6 +59,7 @@
 {% set online_registration = state_display_content.field_online_registration.0 | default([]) | merge(content.field_online_registration.0 | default([])) %}
 {% set military_overseas_registration = state_display_content.field_military_and_overseas_regi.0 | default([]) | merge(content.field_military_and_overseas_regi.0 | default([])) %}
 {% set mail_registration = state_display_content.field_mail_registration.0 | default([]) | merge(content.field_mail_registration.0 | default([])) %}
+{% set nvrf_details = state_display_content.field_nvrf_details.0 | default([]) | merge(content.field_nvrf_details.0 | default([])) %}
 {% set inperson_registration = state_display_content.field_in_person_registration.0 | default([]) | merge(content.field_in_person_registration.0 | default([])) %}
 {% set check_registration = state_display_content.field_check_registration.0 | default([]) | merge(content.field_check_registration.0 | default([])) %}
 {% set election_date = state_display_content.field_election_date.0 | default([]) | merge(content.field_election_date.0 | default([])) %}
@@ -114,11 +134,45 @@
       } %}
     {% endif %}
 
-    {% if mail_registration is not empty %}
-      {{ mail_registration }}
-      {{ postmarked_deadline }}
-      {{ received_deadline }}
-      {{ state_mail_pdf_link }}
+    {% if has_mail and mail_registration is not empty %}
+      {% set mail_body %}
+        <p><strong>{{ 'Mail-in registration deadline:' | t }}</strong> {{ bymail_deadline }}</p>
+        {{ mail_registration.text }}
+
+        {% if state_mail_pdf_link and mail_registration.link_text %}
+          <p>{{ link(mail_registration.link_text, state_mail_pdf_link) }}</p>
+        {% endif %}
+      {% endset %}
+
+      {% if accepts_nvrf and nvrf_details is not empty %}
+        {% set mail_footer %}
+          <hr>
+          {% if nvrf_details.heading %}
+            <h3>{{ nvrf_details.heading }}</h3>
+          {% endif %}
+
+          {{ nvrf_details.text }}
+
+          {% if nvrf_details.link_text %}
+            {# Set path to form dynamically using page route. #}
+            {% set form_route = language != 'es' ? 'vote_nvrf.nvrf_page' : 'vote_nvrf.nvrf_page_es' %}
+            {% set state_name = currentnode.label | lower | replace({' ': '-'}) %}
+
+            {% include '@votegov/component/button.html.twig' with {
+              'href': 'internal:' ~ path(form_route, {'state_name': state_name}),
+              'label': nvrf_details.link_text,
+              'data_label': 'data-state-ext',
+              'data': 'nvrf-pdf-tool-registration'
+            } %}
+          {% endif %}
+        {% endset %}
+      {% endif %}
+
+      {% include '@votegov/component/info-card.html.twig' with {
+        'heading': mail_registration.heading,
+        'body': mail_body | render | trim | t({'@state_name': state_name}),
+        'footer': mail_footer
+      } %}
     {% endif %}
 
     {% if has_in_person and (inperson_registration is not empty) %}


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

https://cm-jira.usa.gov/browse/VOTE-2885

## Description

1. Add ability to hide state display content subfields from the form
2. Configure state mail registration section

## Deployment and testing

### Post-deploy steps

1. `lando retune`

### QA/Testing instructions

1. visit http://vote-gov.lndo.site/block/add/state_display_content and confirm that the 'Link text' subfield is hidden for Registration Intro field.
2. visit http://vote-gov.lndo.site/register/washington and confirm the content for mail and NVRF displays
3. visit http://vote-gov.lndo.site/register/wyoming and confirm the content for mail displays but not NVRF

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
