### PR TITLE
Vote-2887: Config for Outside US Info Card

### DIFF
--- a/web/themes/custom/votegov/templates/node/node--state-territory.html.twig
+++ b/web/themes/custom/votegov/templates/node/node--state-territory.html.twig
@@ -189,7 +189,10 @@
     {% endif %}
 
     {% if military_overseas_registration is not empty %}
-      {{ military_overseas_registration }}
+      {% include '@votegov/component/info-card.html.twig' with {
+        'heading': military_overseas_registration.heading,
+        'body': military_overseas_registration.text,
+      } %}
     {% endif %}
   {% endblock %}
 </div>


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[Vote-2887](https://cm-jira.usa.gov/browse/VOTE-2887)

## Description

Setting up config for the outside of us info card on state pages.

## Deployment and testing

### Post-deploy steps

1. run `lando retune`

### QA/Testing instructions

1. Log into site and create a new state page, go to the `State Display` content tab 
2. Scroll to the `Military and overseas registration` and add text - skip the link text that will need to be addressed in the future
3. Visit page and check that it is matching the design in the figma 

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.