### PR TITLE
Vote-2826: Migrate Cypress Backend Test to Page Objects

### DIFF
--- a/testing/cypress/e2e/backEndTests/basic-page.cy.js
+++ b/testing/cypress/e2e/backEndTests/basic-page.cy.js
@@ -17,20 +17,24 @@ describe('test for basic page', () => {
       .pageTitle()
       .type('Test Page')
 
-      // pageObjects
-      pageContent()
+      pageObjects
+      .pageContent()
       .then(field => {
         cy.get(field[0]).clear().realType('test page')
       })
 
-      // pageObjects
-      pageDetails().then(dropdown => {
+      pageObjects
+      .pageDetails().then(dropdown => {
         cy.get(dropdown[1]).click()
-        urlAlias().click()
-        urlAuto().click()
-        setAlias().type('/cypress-url-alias-test')
+        pageObjects
+        .urlAlias().click()
+        pageObjects
+        .urlAuto().click()
+        pageObjects
+        .setAlias().type('/cypress-url-alias-test')
       })
-      submitBtn().click()
+      pageObjects
+      .submitBtn().click()
       cy.url().should('contain', 'cypress-url-alias-test')
 
     cy.logout()

--- a/testing/cypress/e2e/backEndTests/basic-page.cy.js
+++ b/testing/cypress/e2e/backEndTests/basic-page.cy.js
@@ -1,24 +1,36 @@
 /// <reference types="cypress" />
+import { pageObjects } from '../../support/pageObjects.js'
 
 describe('test for basic page', () => {
+
+  beforeEach('visit site', () => {
+    cy.signin(Cypress.env('roles').site_admin.username, Cypress.env('test_pass'))
+    cy.visit('/node/add/page')
+  })
+
     it('test url alias', () => {
 
-      cy.signin(Cypress.env('roles').site_admin.username, Cypress.env('test_pass'))
-      
-      // Can set url alias
-      cy.visit('/node/add/page')
-      cy.get('[data-drupal-selector="edit-title-0-value"]').type('Test Page')
 
-      cy.get('[class="ck-blurred ck ck-content ck-editor__editable ck-rounded-corners ck-editor__editable_inline"]').then(field => {
+      // Can set url alias
+
+      pageObjects
+      .pageTitle()
+      .type('Test Page')
+
+      // pageObjects
+      pageContent()
+      .then(field => {
         cy.get(field[0]).clear().realType('test page')
       })
-      cy.get('[class="claro-details__summary claro-details__summary--accordion-item"]').then(dropdown => {
+
+      // pageObjects
+      pageDetails().then(dropdown => {
         cy.get(dropdown[1]).click()
-        cy.get('[data-drupal-selector="edit-path-0"]').click()
-        cy.get('[data-drupal-selector="edit-path-0-pathauto"]').click()
-        cy.get('[data-drupal-selector="edit-path-0-alias"]').type('/cypress-url-alias-test')
+        urlAlias().click()
+        urlAuto().click()
+        setAlias().type('/cypress-url-alias-test')
       })
-      cy.get('[data-drupal-selector="edit-submit"]').click()
+      submitBtn().click()
       cy.url().should('contain', 'cypress-url-alias-test')
 
     cy.logout()

--- a/testing/cypress/e2e/backEndTests/content-editor-access.cy.js
+++ b/testing/cypress/e2e/backEndTests/content-editor-access.cy.js
@@ -1,4 +1,5 @@
 /// <reference types="cypress" />
+import { pageObjects } from '../../support/pageObjects.js'
 
 describe('Test Content Editor Role Access', () => {
   beforeEach('login as content editor', () => {
@@ -8,7 +9,7 @@ describe('Test Content Editor Role Access', () => {
   after('logout of content editor role', () => {
     cy.logout()
   })
-  
+
   it('verify access to email signup', () => {
     cy.request({
           url: '/block/4',
@@ -102,7 +103,8 @@ describe('Test Content Editor Role Access', () => {
 
   it('verify ability to publish', () => {
     cy.visit('/node/add/page')
-    cy.get('[data-drupal-selector="edit-moderation-state-0-state"]').find('option').then(option => {
+    pageObjects
+    .publishState().find('option').then(option => {
       cy.wrap(option).should('not.contain', 'Published')
     })
   })

--- a/testing/cypress/e2e/backEndTests/content-manager-access.cy.js
+++ b/testing/cypress/e2e/backEndTests/content-manager-access.cy.js
@@ -1,4 +1,6 @@
-// <reference types="cypress" />
+/// <reference types="cypress" />
+import { pageObjects } from '../../support/pageObjects.js'
+
 
 describe('Test Content Manager Role Access', () => {
   beforeEach('login as content manager', () => {
@@ -33,7 +35,7 @@ describe('Test Content Manager Role Access', () => {
     cy.request('/node/63/edit').then((response) => {
       expect(response.status).to.eq(200)
         })
-    
+
       cy.request('/node/add/landing').then((response) => {
       expect(response.status).to.eq(200)
         })
@@ -78,7 +80,8 @@ describe('Test Content Manager Role Access', () => {
 
   it('verify ability to publish', () => {
     cy.visit('/node/add/page')
-    cy.get('[data-drupal-selector="edit-moderation-state-0-state"]').find('option').then(option => {
+    pageObjects
+    .publishState().find('option').then(option => {
       cy.wrap(option).should('contain', 'Published')
     })
   })

--- a/testing/cypress/e2e/backEndTests/footer-menu-editor.cy.js
+++ b/testing/cypress/e2e/backEndTests/footer-menu-editor.cy.js
@@ -1,5 +1,5 @@
-// <reference types="cypress" />
-
+/// <reference types="cypress" />
+import { pageObjects } from '../../support/pageObjects.js'
 
 describe('Footer Menu Function', () => {
 
@@ -9,9 +9,9 @@ describe('Footer Menu Function', () => {
     cy.signin(Cypress.env('roles').site_admin.username, Cypress.env('test_pass'))
 
     cy.visit('/admin/structure/menu/manage/footer/add')
-
-    cy.get('[data-drupal-selector="edit-title-0-value"]').type('Cypress Test Link')
-    cy.get('[data-drupal-selector="edit-link-0-uri"]').type('https://www.bixal.com/')
+    pageObjects
+    .linkTitle().type('Cypress Test Link')
+    .linkUrl().type('https://www.bixal.com/')
     cy.get('[data-drupal-selector="edit-menu-link-display-settings"]').click().get('[data-drupal-selector="edit-weight-0-value"]').clear().type('-99')
 
 
@@ -32,7 +32,7 @@ describe('Footer Menu Function', () => {
     cy.get('[class="edit dropbutton__item dropbutton-action"]').then(dropDown => {
       cy.get(dropDown[0]).click()
       cy.get('[data-drupal-selector="edit-delete"]').click()
-      
+
       cy.get('[class="ui-dialog-buttonset form-actions"]').find('button').then(btn => {
         cy.get(btn[0]).click()
       })

--- a/testing/cypress/e2e/backEndTests/footer-menu-editor.cy.js
+++ b/testing/cypress/e2e/backEndTests/footer-menu-editor.cy.js
@@ -11,16 +11,23 @@ describe('Footer Menu Function', () => {
     cy.visit('/admin/structure/menu/manage/footer/add')
     pageObjects
     .linkTitle().type('Cypress Test Link')
+    pageObjects
     .linkUrl().type('https://www.bixal.com/')
-    cy.get('[data-drupal-selector="edit-menu-link-display-settings"]').click().get('[data-drupal-selector="edit-weight-0-value"]').clear().type('-99')
+    pageObjects
+    .displaySettings().click()
+    pageObjects
+    .linkWeight().clear().type('-99')
 
-
-    cy.get('[data-drupal-selector="edit-submit"]').click()
+    pageObjects
+    .submitBtn().click()
 
     // check that the link is working as expected
     cy.visit('/')
 
-    cy.get('[data-test="footer"]').find('[data-test="footerLinks"]').then(link => {
+    pageObjects
+    .footer()
+    pageObjects
+    .footerLinks().then(link => {
       cy.get(link[0]).find('a').should('contain', 'Cypress Test Link')
       .should('have.attr', 'href').and('contain', 'bixal.com')
     })
@@ -29,11 +36,16 @@ describe('Footer Menu Function', () => {
 
     cy.visit('/admin/structure/menu/manage/footer')
 
-    cy.get('[class="edit dropbutton__item dropbutton-action"]').then(dropDown => {
+    pageObjects
+    .editDropdown()
+    .then(dropDown => {
       cy.get(dropDown[0]).click()
-      cy.get('[data-drupal-selector="edit-delete"]').click()
+      pageObjects
+      .deleteBtn().click()
 
-      cy.get('[class="ui-dialog-buttonset form-actions"]').find('button').then(btn => {
+      pageObjects
+      .confirmDelete()
+      .find('button').then(btn => {
         cy.get(btn[0]).click()
       })
     })

--- a/testing/cypress/e2e/backEndTests/site-admin-access.cy.js
+++ b/testing/cypress/e2e/backEndTests/site-admin-access.cy.js
@@ -1,5 +1,7 @@
 // <reference types="cypress" />
 
+import { pageObjects } from "../../support/pageObjects"
+
 describe('Test Site Admin Role access', () => {
   beforeEach('login as site admin', () => {
     cy.signin(Cypress.env('roles').site_admin.username, Cypress.env('test_pass'))
@@ -19,7 +21,7 @@ describe('Test Site Admin Role access', () => {
     cy.request('/block/1').then((response) => {
       expect(response.status).to.eq(200)
         })
-    
+
     // only site admin should be able to create banner
     cy.request('//block/add/government_banner').then((response) => {
       expect(response.status).to.eq(200)
@@ -30,7 +32,7 @@ describe('Test Site Admin Role access', () => {
     cy.request('/node/63/edit').then((response) => {
       expect(response.status).to.eq(200)
         })
-    
+
     cy.request('/node/add/landing').then((response) => {
       expect(response.status).to.eq(200)
         })
@@ -59,8 +61,8 @@ describe('Test Site Admin Role access', () => {
     cy.request('/media/add').then((response) => {
       expect(response.status).to.eq(200)
         })
-    
-    // admin cole should be able to delete 
+
+    // admin cole should be able to delete
     cy.request('/media/6/delete?').then((response) => {
       expect(response.status).to.eq(200)
         })
@@ -74,7 +76,8 @@ describe('Test Site Admin Role access', () => {
 
   it('verify ability to publish', () => {
     cy.visit('/node/add/page')
-    cy.get('[data-drupal-selector="edit-moderation-state-0-state"]').find('option').then(option => {
+    pageObjects
+    .publishState().find('option').then(option => {
       cy.wrap(option).should('contain', 'Published')
     })
   })

--- a/testing/cypress/e2e/backEndTests/user-content-access.cy.js
+++ b/testing/cypress/e2e/backEndTests/user-content-access.cy.js
@@ -1,4 +1,6 @@
 /// <reference types="cypress" />
+import { pageObjects } from "../../support/pageObjects"
+
 
 describe('Test User Role Access to Content Moderation', () => {
 
@@ -7,70 +9,91 @@ describe('Test User Role Access to Content Moderation', () => {
 
     // Can create a draft
     cy.visit('/node/add/page')
-    cy.get('[data-drupal-selector="edit-title-0-value"]').type('Test Page')
+    pageObjects
+      .pageTitle().type('Test Page')
 
-    cy.get('[class="ck-blurred ck ck-content ck-editor__editable ck-rounded-corners ck-editor__editable_inline"]').then(field => {
-      cy.get(field[0]).clear().realType('test page')
-    })
-    cy.get('[class="claro-details__summary claro-details__summary--accordion-item"]').then(dropdown => {
-      cy.get(dropdown[1]).click()
-      cy.get('[data-drupal-selector="edit-path-0"]').click()
-      cy.get('[data-drupal-selector="edit-path-0-pathauto"]').click()
-      cy.get('[data-drupal-selector="edit-path-0-alias"]').type('/cypress-content-moderation-test')
-    })
-    cy.get('[data-drupal-selector="edit-submit"]').click()
+    pageObjects
+      .pageContent().then(field => {
+        cy.get(field[0]).clear().realType('test page')
+      })
+
+    pageObjects
+      .pageDetails().then(dropdown => {
+        cy.get(dropdown[1]).click()
+        pageObjects
+          .urlAlias().click()
+        pageObjects
+          .urlAuto().click()
+        pageObjects
+          .setAlias().type('/cypress-content-moderation-test')
+      })
+    pageObjects
+      .submitBtn().click()
     cy.url().should('contain', 'cypress-content-moderation-test')
 
-    // Can view draft content 
+    // Can view draft content
     cy.request('/cypress-content-moderation-test').then((response) => {
-      expect(response.status).to.eq(200)})
-   
+      expect(response.status).to.eq(200)
+    })
+
     // Can modify draft content
     cy.visit('/cypress-content-moderation-test')
-    cy.get('[class="usa-button-group__item"]').then(btn => {
-      cy.get(btn[1]).click()
-    })
+    pageObjects
+      .editBar().then(btn => {
+        cy.get(btn[1]).click()
+      })
     cy.url().should('contain', 'edit')
 
     // Can publish content
     cy.visit('/cypress-content-moderation-test')
-    cy.get('[data-drupal-selector="edit-new-state"]').select('Published')
-    cy.get('[data-drupal-selector="edit-submit"]').click()
+    pageObjects
+      .publishOpt().select('Published')
+    pageObjects
+      .submitBtn().click()
     cy.get('[class="usa-alert__body"]').should('contain', 'The moderation state has been updated.')
 
-    // Can move content to archived status 
+    // Can move content to archived status
     cy.visit('/cypress-content-moderation-test')
-    cy.get('[class="usa-button-group__item"]').then(btn => {
-      cy.get(btn[1]).click()
-    })
-    cy.get('[data-drupal-selector="edit-moderation-state-0-state"]').select('Archived')
-    cy.get('[data-drupal-selector="edit-submit"]').click()
+    pageObjects
+      .editBar().then(btn => {
+        cy.get(btn[1]).click()
+      })
+    pageObjects
+      .publishState().select('Archived')
+    pageObjects
+      .submitBtn().click()
     cy.get('[id="edit-current"]').should('contain', 'Archived')
 
     // Can move archived content to draft
     cy.visit('/cypress-content-moderation-test')
-    cy.get('[data-drupal-selector="edit-new-state"]').select('Draft')
-    cy.get('[data-drupal-selector="edit-submit"]').click()
+    pageObjects
+      .publishOpt().select('Draft')
+    pageObjects
+      .submitBtn().click()
     cy.get('[id="edit-current"]').should('contain', 'Draft')
 
     // Can delete content
     cy.visit('/cypress-content-moderation-test')
-    cy.get('[class="usa-button-group__item"]').then(btn => {
-      cy.get(btn[2]).click()
-    })
+    pageObjects
+      .editBar().then(btn => {
+        cy.get(btn[2]).click()
+      })
     cy.get('[class="page-title"]').should('contain', 'delete')
 
     // Can create and delete media
     cy.request('/admin/structure/media/add').then((response) => {
-      expect(response.status).to.eq(200)})
+      expect(response.status).to.eq(200)
+    })
     cy.visit('/admin/content/media')
-    cy.get('[class="edit dropbutton__item dropbutton-action"]').should('contain', 'Edit')
+    pageObjects
+      .editDropdown().should('contain', 'Edit')
 
-  // Can update the content moderation settings
-  cy.request('/admin/config/workflow/workflows/manage/publishing_content').then((response) => {
-    expect(response.status).to.eq(200)})
+    // Can update the content moderation settings
+    cy.request('/admin/config/workflow/workflows/manage/publishing_content').then((response) => {
+      expect(response.status).to.eq(200)
+    })
 
-      cy.logout()
+    cy.logout()
   })
 
   it('Test Content Manager', () => {
@@ -78,60 +101,75 @@ describe('Test User Role Access to Content Moderation', () => {
 
     // Can create a draft
     cy.visit('/node/add/page')
-    cy.get('[data-drupal-selector="edit-title-0-value"]').type('Test Page')
+    pageObjects
+      .pageTitle().type('Test Page')
 
-    cy.get('[class="ck-blurred ck ck-content ck-editor__editable ck-rounded-corners ck-editor__editable_inline"]').then(field => {
-      cy.get(field[0]).clear().realType('test page')
-    })
+    pageObjects
+      .pageContent().then(field => {
+        cy.get(field[0]).clear().realType('test page')
+      })
 
-    cy.get('[data-drupal-selector="edit-submit"]').click()
+    pageObjects
+      .submitBtn().click()
     cy.url().should('contain', 'test-page')
 
-    // Can view draft content 
+    // Can view draft content
     cy.request('/test-page').then((response) => {
-      expect(response.status).to.eq(200)})
-   
+      expect(response.status).to.eq(200)
+    })
+
     // Can modify draft content
     cy.visit('/test-page')
-    cy.get('[class="usa-button-group__item"]').then(btn => {
-      cy.get(btn[1]).click()
-    })
+    pageObjects
+      .editBar().then(btn => {
+        cy.get(btn[1]).click()
+      })
     cy.url().should('contain', 'edit')
 
     // Can publish content
     cy.visit('/test-page')
-    cy.get('[data-drupal-selector="edit-new-state"]').select('Published')
-    cy.get('[data-drupal-selector="edit-submit"]').click()
+    pageObjects
+      .publishOpt().select('Published')
+    pageObjects
+      .submitBtn().click()
     cy.get('[class="usa-alert__body"]').should('contain', 'The moderation state has been updated.')
 
-    // Can move content to archived status 
+    // Can move content to archived status
     cy.visit('/test-page')
-    cy.get('[class="usa-button-group__item"]').then(btn => {
-      cy.get(btn[1]).click()
-    })
-    cy.get('[data-drupal-selector="edit-moderation-state-0-state"]').select('Archived')
-    cy.get('[data-drupal-selector="edit-submit"]').click()
+    pageObjects
+      .editBar().then(btn => {
+        cy.get(btn[1]).click()
+      })
+    pageObjects
+      .publishState().select('Archived')
+    pageObjects
+      .submitBtn().click()
     cy.get('[id="edit-current"]').should('contain', 'Archived')
 
     // Can move archived content to draft
     cy.visit('/test-page')
-    cy.get('[data-drupal-selector="edit-new-state"]').select('Draft')
-    cy.get('[data-drupal-selector="edit-submit"]').click()
+    pageObjects
+      .publishOpt().select('Draft')
+    pageObjects
+      .submitBtn().click()
     cy.get('[id="edit-current"]').should('contain', 'Draft')
 
     // Can delete content
     cy.visit('/test-page')
-    cy.get('[class="usa-button-group__item"]').then(btn => {
-      cy.get(btn[2]).click()
-    })
+    pageObjects
+      .editBar().then(btn => {
+        cy.get(btn[2]).click()
+      })
     cy.get('[class="page-title"]').should('contain', 'delete')
 
     // Can create and delete media
     cy.request('/media/add').then((response) => {
-      expect(response.status).to.eq(200)})
+      expect(response.status).to.eq(200)
+    })
 
     cy.visit('/admin/content/media')
-    cy.get('[class="edit dropbutton__item dropbutton-action"]').should('contain', 'Edit')
+    pageObjects
+      .editDropdown().should('contain', 'Edit')
 
     // should not be able to update the content moderation settings
     cy.request({
@@ -149,56 +187,70 @@ describe('Test User Role Access to Content Moderation', () => {
 
     // Can create a draft
     cy.visit('/node/add/page')
-    cy.get('[data-drupal-selector="edit-title-0-value"]').type('Test Page')
+    pageObjects
+      .pageTitle().type('Test Page')
 
-    cy.get('[class="ck-blurred ck ck-content ck-editor__editable ck-rounded-corners ck-editor__editable_inline"]').then(field => {
-      cy.get(field[0]).clear().realType('test page')
-    })
-    cy.get('[data-drupal-selector="edit-submit"]').click()
+    pageObjects
+      .pageContent().then(field => {
+        cy.get(field[0]).clear().realType('test page')
+      })
+    pageObjects
+      .submitBtn().click()
     cy.url().should('contain', 'test')
 
-    // Can view own draft content  
+    // Can view own draft content
     cy.request('/test-page').then((response) => {
-      expect(response.status).to.eq(200)})
+      expect(response.status).to.eq(200)
+    })
     // can view other draft content
     cy.request('/cypress-content-moderation-test').then((response) => {
-      expect(response.status).to.eq(200)})
-   
-    // Can modify draft content 
-    cy.visit('/test-page-0')
-    cy.get('[class="usa-button-group__item"]').then(btn => {
-      cy.get(btn[1]).click()
+      expect(response.status).to.eq(200)
     })
+
+    // Can modify draft content
+    cy.visit('/test-page-0')
+    pageObjects
+      .editBar().then(btn => {
+        cy.get(btn[1]).click()
+      })
     cy.url().should('contain', 'edit')
- 
+
     // Can not publish content
     cy.visit('/test-page-0')
-    cy.get('[data-drupal-selector="edit-submit"]').should('not.exist')
+    pageObjects
+      .submitBtn().should('not.exist')
 
     // can view archived content
     cy.request('/admin/content/moderated').then((response) => {
-      expect(response.status).to.eq(200)})
+      expect(response.status).to.eq(200)
+    })
 
     // Can move archived content to draft
     cy.visit('/cypress-content-moderation-test')
-    cy.get('[class="usa-button-group__item"]').then(btn => {
-      cy.get(btn[1]).click()
-    })
-    cy.get('[data-drupal-selector="edit-submit"]').click()
+    pageObjects
+      .editBar().then(btn => {
+        cy.get(btn[1]).click()
+      })
+    pageObjects
+      .submitBtn().click()
 
     // Can not delete content
     cy.visit('/admin/content')
-    cy.get('[class="dropbutton__toggle"]').then(btn => {
-      cy.get(btn[0]).click()
-    })
-    cy.get('[class="translate dropbutton__item dropbutton-action secondary-action"]').should('not.contain', 'delete')
+    pageObjects
+      .editDropDown().then(btn => {
+        cy.get(btn[0]).click()
+      })
+    pageObjects
+      .editOpt().should('not.contain', 'delete')
 
     // Can create media but not delete media
     cy.request('/media/add').then((response) => {
-      expect(response.status).to.eq(200)})
+      expect(response.status).to.eq(200)
+    })
 
     cy.visit('/admin/content/media')
-    cy.get('[class="translate dropbutton__item dropbutton-action"]').should('not.contain', 'edit')
+    pageObjects
+      .editOpt().should('not.contain', 'edit')
 
     // should not be able to update the content moderation settings
     cy.request({
@@ -211,28 +263,28 @@ describe('Test User Role Access to Content Moderation', () => {
     cy.logout()
   })
 
-  // ! commenting out this test for the time being until content is published. 
   it('test anonymous user access', () => {
-    // Can view published content  
-  cy.request('/').then((response) => {
-    expect(response.status).to.eq(200)})
+    // Can view published content
+    cy.request('/').then((response) => {
+      expect(response.status).to.eq(200)
+    })
 
-     // Can not view draft content  
+    // Can not view draft content
     cy.request({
       url: '/cypress-content-moderation-test',
-      failOnStatusCode:false,
-        }).then((resp) => {
+      failOnStatusCode: false,
+    }).then((resp) => {
       expect(resp.status).to.eq(403)
-        })
+    })
 
 
-      // can not view archived content 
+    // can not view archived content
     cy.request({
       url: '/admin/content/moderated',
-      failOnStatusCode:false,
-        }).then((resp) => {
+      failOnStatusCode: false,
+    }).then((resp) => {
       expect(resp.status).to.eq(403)
-          })
+    })
   })
 })
 

--- a/testing/cypress/support/pageObjects.js
+++ b/testing/cypress/support/pageObjects.js
@@ -1,5 +1,5 @@
 class PageObjects {
-  // frontend test page objects 
+  // frontend test page objects
 
   // * accessability tool bar
   themeSwitcher() {
@@ -14,7 +14,7 @@ class PageObjects {
     return  cy.get('[data-test="themeText"]')
   }
 
-  // * email signup 
+  // * email signup
   emailSignup() {
     return cy.get('[data-test="emailSignup"]')
   }
@@ -33,7 +33,7 @@ class PageObjects {
     return cy.get('[data-test="headerButton"]')
   }
 
-  headerBanner() { 
+  headerBanner() {
     return cy.get('[data-test="headerBanner"]')
   }
 
@@ -109,6 +109,37 @@ class PageObjects {
 
   stateList() {
     return cy.get('[data-test="stateList"]')
+  }
+
+  // Backend Tests
+
+  // * Basic Page
+  pageTitle() {
+    return cy.get('[data-drupal-selector="edit-title-0-value"]')
+  }
+
+  pageContent() {
+    return cy.get('[class="ck-blurred ck ck-content ck-editor__editable ck-rounded-corners ck-editor__editable_inline"]')
+  }
+
+  pageDetails() {
+    return cy.get('[class="claro-details__summary claro-details__summary--accordion-item"]')
+  }
+
+  urlAlias() {
+    return cy.get('[data-drupal-selector="edit-path-0"]')
+  }
+
+  urlAuto() {
+    return cy.get('[data-drupal-selector="edit-path-0-pathauto"]')
+  }
+
+  setAlias() {
+    return cy.get('[data-drupal-selector="edit-path-0-alias"]')
+  }
+
+  submitBtn() {
+    return cy.get('[data-drupal-selector="edit-submit"]')
   }
 
 }

--- a/testing/cypress/support/pageObjects.js
+++ b/testing/cypress/support/pageObjects.js
@@ -142,6 +142,20 @@ class PageObjects {
     return cy.get('[data-drupal-selector="edit-submit"]')
   }
 
+  // Content Editor, Manager Access
+    publishState() {
+      return cy.get('[data-drupal-selector="edit-moderation-state-0-state"]')
+    }
+
+  // Footer Menu
+    linkTitle() {
+      return cy.get('[data-drupal-selector="edit-title-0-value"]')
+    }
+
+    linkUrl() {
+      return cy.get('[data-drupal-selector="edit-link-0-uri"]')
+    }
+
 }
 
 export const pageObjects = new PageObjects()

--- a/testing/cypress/support/pageObjects.js
+++ b/testing/cypress/support/pageObjects.js
@@ -1,7 +1,13 @@
 class PageObjects {
   // frontend test page objects
+  footer() {
+    return cy.get('[data-test="footer"]')
+  }
 
-  // * accessability tool bar
+  footerLinks() {
+    return cy.get('[data-test="footerLinks"]')
+  }
+
   themeSwitcher() {
     return cy.get('[data-test="themeSwitcher"]')
   }
@@ -11,20 +17,17 @@ class PageObjects {
   }
 
   themeText() {
-    return  cy.get('[data-test="themeText"]')
+    return cy.get('[data-test="themeText"]')
   }
 
-  // * email signup
   emailSignup() {
     return cy.get('[data-test="emailSignup"]')
   }
 
-  // * footer contact
   footerContact() {
     return cy.get('[data-test="footerContact"]')
   }
 
-  // * govt banner
   headerLogo() {
     return cy.get('[data-test="headerLogo"]')
   }
@@ -37,7 +40,6 @@ class PageObjects {
     return cy.get('[data-test="headerBanner"]')
   }
 
-  // * language selector
   languageButton() {
     return cy.get('[data-test="languageButton"]')
   }
@@ -50,7 +52,6 @@ class PageObjects {
     return cy.get('[ data-test="langItem"]')
   }
 
-  // * main menu
   mainNav() {
     return cy.get('[data-test="mainNav"]')
   }
@@ -79,12 +80,10 @@ class PageObjects {
     return cy.get('[data-test="mainCloseBtn"]')
   }
 
-  // * nvrf download
   nvrfDownload() {
     return cy.get('[data-test="nvrfDownload"]')
   }
 
-  // * search bar
   searchBox() {
     return cy.get('[data-test="searchBox"]')
   }
@@ -93,7 +92,6 @@ class PageObjects {
     return cy.get('[data-test="searchBtn"]')
   }
 
-  // * state pages
   registrationInfo() {
     return cy.get('[data-test="registrationInfo"]')
   }
@@ -102,7 +100,6 @@ class PageObjects {
     return cy.get('[data-test="nvrfForm"]')
   }
 
-  // * state registration
   stateInput() {
     return cy.get('[data-test="stateInput"]')
   }
@@ -112,8 +109,6 @@ class PageObjects {
   }
 
   // Backend Tests
-
-  // * Basic Page
   pageTitle() {
     return cy.get('[data-drupal-selector="edit-title-0-value"]')
   }
@@ -142,20 +137,53 @@ class PageObjects {
     return cy.get('[data-drupal-selector="edit-submit"]')
   }
 
-  // Content Editor, Manager Access
-    publishState() {
-      return cy.get('[data-drupal-selector="edit-moderation-state-0-state"]')
-    }
+  publishState() {
+    return cy.get('[data-drupal-selector="edit-moderation-state-0-state"]')
+  }
 
-  // Footer Menu
-    linkTitle() {
-      return cy.get('[data-drupal-selector="edit-title-0-value"]')
-    }
+  linkTitle() {
+    return cy.get('[data-drupal-selector="edit-title-0-value"]')
+  }
 
-    linkUrl() {
-      return cy.get('[data-drupal-selector="edit-link-0-uri"]')
-    }
+  linkUrl() {
+    return cy.get('[data-drupal-selector="edit-link-0-uri"]')
+  }
 
+  displaySettings() {
+    return cy.get('[data-drupal-selector="edit-menu-link-display-settings"]')
+  }
+
+  linkWeight() {
+    return cy.get('[data-drupal-selector="edit-weight-0-value"]')
+  }
+
+  editDropdown() {
+    return cy.get('[class="edit dropbutton__item dropbutton-action"]')
+  }
+
+  deleteBtn() {
+    return cy.get('[data-drupal-selector="edit-delete"]')
+  }
+
+  confirmDelete() {
+    return cy.get('[class="ui-dialog-buttonset form-actions"]')
+  }
+
+  editBar() {
+    return cy.get('[data-test="editMenu"]')
+  }
+
+  publishOpt() {
+    return cy.get('[data-drupal-selector="edit-new-state"]')
+  }
+
+  editDropDown() {
+    return cy.get('[class="dropbutton__toggle"]')
+  }
+
+  editOpt() {
+    return cy.get('[class="translate dropbutton__item dropbutton-action"]')
+  }
 }
 
 export const pageObjects = new PageObjects()

--- a/web/themes/custom/votegov/templates/navigation/menu-local-task.html.twig
+++ b/web/themes/custom/votegov/templates/navigation/menu-local-task.html.twig
@@ -15,6 +15,6 @@
  * @see template_preprocess_menu_local_task()
  */
 #}
-<li{{ attributes.addClass('usa-button-group__item') }}>
+<li{{ attributes.addClass('usa-button-group__item') }} data-test="editMenu">
   <a href="{{ link['#url'] }}" class="usa-button {{ is_active ? 'usa-button--active' }}">{{ link['#title'] }}</a>
 </li>


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[Vote-2826](https://cm-jira.usa.gov/browse/VOTE-2826)

## Description

This Pr will update the Cypress backend test to use page objects and allow it to use the same process as frontend tests 

## Deployment and testing

### Post-deploy steps

1. 'lando retune'

### QA/Testing instructions

1. cd into `testing` and run `npm i`
2. run `npm run cy:backEnd` and verify that tests are still passing 



## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
