### PR TITLE
Vote-2990: Link Style Update to Emergency Banner

### DIFF
--- a/web/themes/custom/votegov/src/sass/uswds-overrides/usa-site-alert.scss
+++ b/web/themes/custom/votegov/src/sass/uswds-overrides/usa-site-alert.scss
@@ -39,3 +39,13 @@
     }
   }
 }
+
+.usa-site-alert--emergency .usa-alert__body {
+  a {
+    color: $base-white;
+
+    &:hover {
+      @include u-color('gray-10')
+    }
+  }
+}


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[Vote-2990](https://cm-jira.usa.gov/browse/VOTE-2990)

## Description

Updating link color for emergency banner.  

<details>
  <summary>Before and After</summary>
**Before:**

![Screenshot 2024-10-15 at 2 00 36 PM](https://github.com/user-attachments/assets/0de78b3b-0484-4c58-a129-6a45d8b0a0f8)

**After:**
![Screenshot 2024-10-15 at 1 59 29 PM](https://github.com/user-attachments/assets/8f7bf4e2-2cd7-49d9-b8fd-5a9704df5cfa)

![Screenshot 2024-10-15 at 1 59 38 PM](https://github.com/user-attachments/assets/f711779c-cc98-43b8-aa41-9c6be08ae04d)

</details>

Solution:
- Adjusted base color to be white, and added hover affect to match the [USWDS Component](https://designsystem.digital.gov/components/site-alert/)

## Deployment and testing

### Post-deploy steps

1. cd into the `votegov` theme and run `npm run build`

### QA/Testing instructions

1. visit `block/add/sitewide_alert?destination=/admin/content/site-alerts` and add a new `Emergency` banner
2. when adding text be sure to create a link in order to have the proper text show up 
3. verify that the link text is white and that there is a hover affect as well when you hover over it

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been included above.
- [ ] No merge conflicts exist with the target branch.
- [ ] Automated tests have passed on this PR.
- [ ] A reviewer has been designated.
- [ ] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
