### PR TITLE
Vote-2957: No Online Registration

### DIFF
--- a/config/sync/core.entity_form_display.block_content.state_display_content.default.yml
+++ b/config/sync/core.entity_form_display.block_content.state_display_content.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.block_content.state_display_content.field_in_person_registration
     - field.field.block_content.state_display_content.field_mail_registration
     - field.field.block_content.state_display_content.field_military_and_overseas_regi
+    - field.field.block_content.state_display_content.field_no_online_registration
     - field.field.block_content.state_display_content.field_nvrf_details
     - field.field.block_content.state_display_content.field_online_registration
     - field.field.block_content.state_display_content.field_registration_intro
@@ -45,13 +46,13 @@ content:
     third_party_settings: {  }
   field_election_date:
     type: datetime_default
-    weight: 10
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }
   field_election_text:
     type: text_textarea
-    weight: 11
+    weight: 12
     region: content
     settings:
       rows: 3
@@ -62,7 +63,7 @@ content:
         hide_guidelines: '0'
   field_in_person_registration:
     type: vote_fields_state_content
-    weight: 7
+    weight: 8
     region: content
     settings:
       form_subfield_display:
@@ -72,7 +73,7 @@ content:
     third_party_settings: {  }
   field_mail_registration:
     type: vote_fields_state_content
-    weight: 5
+    weight: 6
     region: content
     settings:
       form_subfield_display:
@@ -82,7 +83,7 @@ content:
     third_party_settings: {  }
   field_military_and_overseas_regi:
     type: vote_fields_state_content
-    weight: 8
+    weight: 9
     region: content
     settings:
       form_subfield_display:
@@ -90,9 +91,19 @@ content:
         text: text
         link_text: 0
     third_party_settings: {  }
+  field_no_online_registration:
+    type: vote_fields_state_content
+    weight: 5
+    region: content
+    settings:
+      form_subfield_display:
+        - heading
+        - text
+        - link_text
+    third_party_settings: {  }
   field_nvrf_details:
     type: vote_fields_state_content
-    weight: 6
+    weight: 7
     region: content
     settings:
       form_subfield_display:
@@ -122,7 +133,7 @@ content:
     third_party_settings: {  }
   field_registration_not_needed:
     type: vote_fields_state_content
-    weight: 9
+    weight: 10
     region: content
     settings:
       form_subfield_display:
@@ -140,13 +151,13 @@ content:
     third_party_settings: {  }
   langcode:
     type: language_select
-    weight: 13
+    weight: 14
     region: content
     settings:
       include_locked: true
     third_party_settings: {  }
   translation:
-    weight: 12
+    weight: 13
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_view_display.block_content.state_display_content.default.yml
+++ b/config/sync/core.entity_view_display.block_content.state_display_content.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.block_content.state_display_content.field_in_person_registration
     - field.field.block_content.state_display_content.field_mail_registration
     - field.field.block_content.state_display_content.field_military_and_overseas_regi
+    - field.field.block_content.state_display_content.field_no_online_registration
     - field.field.block_content.state_display_content.field_nvrf_details
     - field.field.block_content.state_display_content.field_online_registration
     - field.field.block_content.state_display_content.field_registration_intro
@@ -75,6 +76,13 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 8
+    region: content
+  field_no_online_registration:
+    type: vote_fields_state_content_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 12
     region: content
   field_nvrf_details:
     type: vote_fields_state_content_default

--- a/config/sync/field.field.block_content.state_display_content.field_no_online_registration.yml
+++ b/config/sync/field.field.block_content.state_display_content.field_no_online_registration.yml
@@ -1,0 +1,21 @@
+uuid: 398183c8-0c7a-4960-aaf6-d3bb2caa3f9c
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.state_display_content
+    - field.storage.block_content.field_no_online_registration
+  module:
+    - vote_fields
+id: block_content.state_display_content.field_no_online_registration
+field_name: field_no_online_registration
+entity_type: block_content
+bundle: state_display_content
+label: 'No Online registration'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: vote_fields_state_content

--- a/config/sync/field.storage.block_content.field_no_online_registration.yml
+++ b/config/sync/field.storage.block_content.field_no_online_registration.yml
@@ -1,0 +1,19 @@
+uuid: fb15b55f-486c-41b1-9c7b-5296239c2e10
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - vote_fields
+id: block_content.field_no_online_registration
+field_name: field_no_online_registration
+entity_type: block_content
+type: vote_fields_state_content
+settings: {  }
+module: vote_fields
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/themes/custom/votegov/templates/node/node--state-territory.html.twig
+++ b/web/themes/custom/votegov/templates/node/node--state-territory.html.twig
@@ -64,6 +64,8 @@
 {% set check_registration = state_display_content.field_check_registration.0 | default([]) | merge(content.field_check_registration.0 | default([])) %}
 {% set election_date = state_display_content.field_election_date.0 | default([]) | merge(content.field_election_date.0 | default([])) %}
 {% set election_text = state_display_content.field_election_text.0 | default([]) | merge(content.field_election_text.0 | default([])) %}
+{# this is for no online registration #}
+{% set registration_intro = state_display_content.field_registration_intro.0 | default([]) | merge(content.field_registration_intro.0 | default([])) %}
 
 {# Registration types #}
 {% set registration_types = content.field_registration_type | field_value | column('#markup') %}
@@ -119,9 +121,6 @@
     {% endif %}
 
     {% if has_online and (online_registration is not empty) %}
-      {{ online_registration }}
-      {{ online_deadline }}
-      {{ registration_link }}
       {% set body = online_registration.text['#markup'] | t({'@state_online_deadline': online_deadline | render, '@state_name': title_english}) %}
       {% set link_title = online_registration.link_text['#markup'] | t({'@state_name': title_english }) %}
       {% include '@votegov/component/info-card.html.twig' with {

--- a/web/themes/custom/votegov/templates/node/node--state-territory.html.twig
+++ b/web/themes/custom/votegov/templates/node/node--state-territory.html.twig
@@ -22,8 +22,6 @@
 {% set state_name = label | field_value | render %}
 {% set accepts_nvrf = node.field_accepts_nvrf.value == 1 %}
 
-{% set has_mail = "by-mail" in (content.field_registration_type | field_value | column('#markup')) %}
-
 {# Links with fallbacks. #}
 {% set more_info_link = content.field_override_more_info_link | field_value | default(content.field_more_info_link | field_value) | render | trim %}
 {% set confirm_registration_link = content.field_override_confirm_reg_link | field_value | default(content.field_confirm_registration_link | field_value) | render | trim %}
@@ -64,15 +62,8 @@
 {% set check_registration = state_display_content.field_check_registration.0 | default([]) | merge(content.field_check_registration.0 | default([])) %}
 {% set election_date = state_display_content.field_election_date.0 | default([]) | merge(content.field_election_date.0 | default([])) %}
 {% set election_text = state_display_content.field_election_text.0 | default([]) | merge(content.field_election_text.0 | default([])) %}
-{# this is for no online registration #}
-{% set registration_intro = state_display_content.field_registration_intro.0 | default([]) | merge(content.field_registration_intro.0 | default([])) %}
+{% set no_online_registration = state_display_content.field_no_online_registration.0 | default([]) | merge(content.field_no_online_registration.0 | default([])) %}
 
-{# Registration types #}
-{% set registration_types = content.field_registration_type | field_value | column('#markup') %}
-{% set has_in_person = "in-person" in registration_types %}
-{% set has_mail = "by-mail" in registration_types %}
-{% set has_online = "online" in registration_types %}
-{% set not_needed = "not-needed" in registration_types %}
 
 {# Registration types #}
 {% set registration_types = content.field_registration_type | field_value | column('#markup') %}
@@ -120,18 +111,22 @@
       {{ registration_intro.text }}
     {% endif %}
 
-    {% if has_online and (online_registration is not empty) %}
-      {% set body = online_registration.text['#markup'] | t({'@state_online_deadline': online_deadline | render, '@state_name': title_english}) %}
-      {% set link_title = online_registration.link_text['#markup'] | t({'@state_name': title_english }) %}
-      {% include '@votegov/component/info-card.html.twig' with {
-        'heading': online_registration.heading,
-        'body': body,
-          'link': {
-            'url': registration_link,
-            'title': link_title,
-          }
-      } %}
-    {% endif %}
+{# setting online registration variables #}
+{% set online_registration_vars = has_online ? online_registration : no_online_registration %}
+{% set body_vars = has_online ? {'@state_online_deadline': online_deadline | render, '@state_name': title_english} : {'@state_name': title_english} %}
+
+{% if online_registration_vars is not empty %}
+  {% set body = online_registration_vars.text['#markup'] | t(body_vars) %}
+  {% set link_title = online_registration_vars.link_text['#markup'] | t({'@state_name': title_english}) %}
+  {% include '@votegov/component/info-card.html.twig' with {
+    'heading': online_registration_vars.heading,
+    'body': body,
+    'link': {
+      'url': registration_link,
+      'title': link_title,
+    }
+  } %}
+{% endif %}
 
     {% if has_mail and mail_registration is not empty %}
       {% set mail_body %}


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[Vote-2957](https://cm-jira.usa.gov/browse/VOTE-2957)

## Description

Adding a new content field to the State display content block to to display content when a state does not offer online registration. 

Please note: I have added the option for a button, after talking with Susan she was not sure if they would like one or not but something we can remove later on. 

## Deployment and testing

### Post-deploy steps

1. run `lando retune` and cd into the `votegov` theme and run `npm run build`

### QA/Testing instructions

1. create a new state display content block `/block/add/state_display_content?destination=/admin/content/block` and verify that there is a field type for no online registration. 
2. add text to this field, please reach out if you need some dummy text and I can provide it for you. 
3. visit a state page and uncheck `online registration` return back to the page and verify that the text that was inputted for that field is showing.

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
