### PR TITLE
Vote-2958: No mail registration block

### DIFF
--- a/config/sync/core.entity_form_display.block_content.state_display_content.default.yml
+++ b/config/sync/core.entity_form_display.block_content.state_display_content.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.block_content.state_display_content.field_in_person_registration
     - field.field.block_content.state_display_content.field_mail_registration
     - field.field.block_content.state_display_content.field_military_and_overseas_regi
+    - field.field.block_content.state_display_content.field_no_mail_registration
     - field.field.block_content.state_display_content.field_no_online_registration
     - field.field.block_content.state_display_content.field_nvrf_details
     - field.field.block_content.state_display_content.field_online_registration
@@ -27,7 +28,7 @@ mode: default
 content:
   field_check_registration:
     type: vote_fields_state_content
-    weight: 3
+    weight: 2
     region: content
     settings:
       form_subfield_display:
@@ -72,7 +73,7 @@ content:
     third_party_settings: {  }
   field_mail_registration:
     type: vote_fields_state_content
-    weight: 6
+    weight: 5
     region: content
     settings:
       form_subfield_display:
@@ -90,9 +91,19 @@ content:
         text: text
         link_text: 0
     third_party_settings: {  }
+  field_no_mail_registration:
+    type: vote_fields_state_content
+    weight: 6
+    region: content
+    settings:
+      form_subfield_display:
+        - heading
+        - text
+        - link_text
+    third_party_settings: {  }
   field_no_online_registration:
     type: vote_fields_state_content
-    weight: 5
+    weight: 4
     region: content
     settings:
       form_subfield_display:
@@ -112,7 +123,7 @@ content:
     third_party_settings: {  }
   field_online_registration:
     type: vote_fields_state_content
-    weight: 4
+    weight: 3
     region: content
     settings:
       form_subfield_display:

--- a/config/sync/core.entity_view_display.block_content.state_display_content.default.yml
+++ b/config/sync/core.entity_view_display.block_content.state_display_content.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.block_content.state_display_content.field_in_person_registration
     - field.field.block_content.state_display_content.field_mail_registration
     - field.field.block_content.state_display_content.field_military_and_overseas_regi
+    - field.field.block_content.state_display_content.field_no_mail_registration
     - field.field.block_content.state_display_content.field_no_online_registration
     - field.field.block_content.state_display_content.field_nvrf_details
     - field.field.block_content.state_display_content.field_online_registration
@@ -75,6 +76,13 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 8
+    region: content
+  field_no_mail_registration:
+    type: vote_fields_state_content_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 13
     region: content
   field_no_online_registration:
     type: vote_fields_state_content_default

--- a/config/sync/field.field.block_content.state_display_content.field_no_mail_registration.yml
+++ b/config/sync/field.field.block_content.state_display_content.field_no_mail_registration.yml
@@ -1,0 +1,21 @@
+uuid: e83b3278-b739-423f-bf0a-c0b06adae44c
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.state_display_content
+    - field.storage.block_content.field_no_mail_registration
+  module:
+    - vote_fields
+id: block_content.state_display_content.field_no_mail_registration
+field_name: field_no_mail_registration
+entity_type: block_content
+bundle: state_display_content
+label: 'No Mail Registration'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: vote_fields_state_content

--- a/config/sync/field.storage.block_content.field_no_mail_registration.yml
+++ b/config/sync/field.storage.block_content.field_no_mail_registration.yml
@@ -1,0 +1,19 @@
+uuid: a507f1aa-1dc8-47f6-84d4-9ce4cf1ef11b
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - vote_fields
+id: block_content.field_no_mail_registration
+field_name: field_no_mail_registration
+entity_type: block_content
+type: vote_fields_state_content
+settings: {  }
+module: vote_fields
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/themes/custom/votegov/templates/node/node--state-territory.html.twig
+++ b/web/themes/custom/votegov/templates/node/node--state-territory.html.twig
@@ -154,7 +154,6 @@
 {# Mail registration content #}
 {% if has_mail and (mail_registration is not empty) %}
   {% set mail_body %}
-    <p><strong>{{ 'Mail-in registration deadline:' | t }}</strong> {{ bymail_deadline }}</p>
     {{ mail_registration.text }}
 
     {% if state_mail_pdf_link %}
@@ -164,7 +163,7 @@
 
   {% include '@votegov/component/info-card.html.twig' with {
     'heading': mail_registration.heading,
-    'body': mail_body | render | trim | t({'@state_name': state_name}),
+    'body': mail_body | render | trim | t({'@state_mail_deadline': bymail_deadline ,'@state_name': state_name}),
     'footer': mail_footer
   } %}
   {# No mail registration content #}

--- a/web/themes/custom/votegov/templates/node/node--state-territory.html.twig
+++ b/web/themes/custom/votegov/templates/node/node--state-territory.html.twig
@@ -45,6 +45,7 @@
 {% set online_registration = state_display_content.field_online_registration.0 | default([]) | merge(content.field_online_registration.0 | default([])) %}
 {% set military_overseas_registration = state_display_content.field_military_and_overseas_regi.0 | default([]) | merge(content.field_military_and_overseas_regi.0 | default([])) %}
 {% set mail_registration = state_display_content.field_mail_registration.0 | default([]) | merge(content.field_mail_registration.0 | default([])) %}
+{% set no_mail_registration = state_display_content.field_no_mail_registration.0 | default([]) | merge(content.field_no_mail_registration.0 | default([])) %}
 {% set nvrf_details = state_display_content.field_nvrf_details.0 | default([]) | merge(content.field_nvrf_details.0 | default([])) %}
 {% set inperson_registration = state_display_content.field_in_person_registration.0 | default([]) | merge(content.field_in_person_registration.0 | default([])) %}
 {% set check_registration = state_display_content.field_check_registration.0 | default([]) | merge(content.field_check_registration.0 | default([])) %}
@@ -125,46 +126,60 @@
   } %}
 {% endif %}
 
-     {% if has_mail and mail_registration is not empty %}
-      {% set mail_body %}
-        <p><strong>{{ 'Mail-in registration deadline:' | t }}</strong> {{ bymail_deadline }}</p>
-        {{ mail_registration.text }}
+   {% if has_mail and (mail_registration is not empty) %}
+  {% set mail_body %}
+    <p><strong>{{ 'Mail-in registration deadline:' | t }}</strong> {{ bymail_deadline }}</p>
+    {{ mail_registration.text }}
 
-        {% if state_mail_pdf_link and mail_registration.link_text %}
-          <p>{{ link(mail_registration.link_text, state_mail_pdf_link) }}</p>
-        {% endif %}
-      {% endset %}
+    {% if state_mail_pdf_link and mail_registration.link_text %}
+      <p>{{ link(mail_registration.link_text, state_mail_pdf_link) }}</p>
+    {% endif %}
+  {% endset %}
 
-      {% if accepts_nvrf and nvrf_details is not empty %}
-        {% set mail_footer %}
-          <hr>
-          {% if nvrf_details.heading %}
-            <h3>{{ nvrf_details.heading }}</h3>
-          {% endif %}
-
-          {{ nvrf_details.text }}
-
-          {% if nvrf_details.link_text %}
-            {# Set path to form dynamically using page route. #}
-            {% set form_route = language != 'es' ? 'vote_nvrf.nvrf_page' : 'vote_nvrf.nvrf_page_es' %}
-            {% set state_name = currentnode.label | lower | replace({' ': '-'}) %}
-
-            {% include '@votegov/component/button.html.twig' with {
-              'href': 'internal:' ~ path(form_route, {'state_name': state_name}),
-              'label': nvrf_details.link_text,
-              'data_label': 'data-state-ext',
-              'data': 'nvrf-pdf-tool-registration'
-            } %}
-          {% endif %}
-        {% endset %}
+  {% set mail_footer %}
+    {% if accepts_nvrf and nvrf_details is not empty %}
+      <hr>
+      {% if nvrf_details.heading %}
+        <h3>{{ nvrf_details.heading }}</h3>
       {% endif %}
 
-      {% include '@votegov/component/info-card.html.twig' with {
-        'heading': mail_registration.heading,
-        'body': mail_body | render | trim | t({'@state_name': state_name}),
-        'footer': mail_footer
-      } %}
+      {{ nvrf_details.text }}
+
+      {% if nvrf_details.link_text %}
+        {# Set path to form dynamically using page route. #}
+        {% set form_route = language!= 'es'? 'vote_nvrf.nvrf_page' : 'vote_nvrf.nvrf_page_es' %}
+        {% set state_name = currentnode.label | lower | replace({' ': '-'}) %}
+
+        {% include '@votegov/component/button.html.twig' with {
+          'href': 'internal:' ~ path(form_route, {'state_name': state_name}),
+          'label': nvrf_details.link_text,
+          'data_label': 'data-state-ext',
+          'data': 'nvrf-pdf-tool-registration'
+        } %}
+      {% endif %}
     {% endif %}
+  {% endset %}
+
+  {% include '@votegov/component/info-card.html.twig' with {
+    'heading': mail_registration.heading,
+    'body': mail_body | render | trim | t({'@state_name': state_name}),
+    'footer': mail_footer
+  } %}
+{% else %}
+  {% if not has_mail and (no_mail_registration is not empty) %}
+    {% set body = no_mail_registration.text['#markup'] | t({'@state_name': title_english}) %}
+    {% set link_title = no_mail_registration.link_text['#markup'] | t({'@state_name': title_english }) %}
+
+    {% include '@votegov/component/info-card.html.twig' with {
+      'heading': no_mail_registration.heading,
+      'body': body,
+      'link': {
+        'url':  more_info_link,
+        'title': link_title,
+      }
+    } %}
+  {% endif %}
+{% endif %}
 
     {% if has_in_person and (inperson_registration is not empty) %}
       {% set body = inperson_registration.text['#markup'] | t({'@state_in-person_deadline': inperson_deadline | render }) %}

--- a/web/themes/custom/votegov/templates/node/node--state-territory.html.twig
+++ b/web/themes/custom/votegov/templates/node/node--state-territory.html.twig
@@ -163,7 +163,7 @@
 
   {% include '@votegov/component/info-card.html.twig' with {
     'heading': mail_registration.heading,
-    'body': mail_body | render | trim | t({'@state_mail_deadline': bymail_deadline ,'@state_name': state_name}),
+    'body': mail_body | render | trim | t({'@state_mail_deadline': bymail_deadline ,'@state_name': title_english}),
     'footer': mail_footer
   } %}
   {# No mail registration content #}

--- a/web/themes/custom/votegov/templates/node/node--state-territory.html.twig
+++ b/web/themes/custom/votegov/templates/node/node--state-territory.html.twig
@@ -40,7 +40,7 @@
 
 {# State content with fallbacks. #}
 {# Get default state display content from the block type. #}
-{% set state_display_content = drupal_entity('block_content', 23) | children %}
+{% set state_display_content = drupal_entity('block_content', 22) | children %}
 {% set registration_not_needed = state_display_content.field_registration_not_needed.0 | default([]) | merge(content.field_registration_not_needed.0 | default([])) %}
 {% set online_registration = state_display_content.field_online_registration.0 | default([]) | merge(content.field_online_registration.0 | default([])) %}
 {% set military_overseas_registration = state_display_content.field_military_and_overseas_regi.0 | default([]) | merge(content.field_military_and_overseas_regi.0 | default([])) %}
@@ -126,37 +126,39 @@
   } %}
 {% endif %}
 
-   {% if has_mail and (mail_registration is not empty) %}
+{# NVRF details and logic to be used in the mail registration footer #}
+{% set mail_footer %}
+  {% if accepts_nvrf and nvrf_details is not empty %}
+    <hr>
+    {% if nvrf_details.heading %}
+      <h3>{{ nvrf_details.heading }}</h3>
+    {% endif %}
+
+    {{ nvrf_details.text }}
+
+    {% if nvrf_details.link_text %}
+      {# Set path to form dynamically using page route. #}
+      {% set form_route = language!= 'es'? 'vote_nvrf.nvrf_page' : 'vote_nvrf.nvrf_page_es' %}
+      {% set state_name = currentnode.label | lower | replace({' ': '-'}) %}
+
+      {% include '@votegov/component/button.html.twig' with {
+        'href': 'internal:' ~ path(form_route, {'state_name': state_name}),
+        'label': nvrf_details.link_text,
+        'data_label': 'data-state-ext',
+        'data': 'nvrf-pdf-tool-registration'
+      } %}
+    {% endif %}
+  {% endif %}
+{% endset %}
+
+{# Mail registration content #}
+{% if has_mail and (mail_registration is not empty) %}
   {% set mail_body %}
     <p><strong>{{ 'Mail-in registration deadline:' | t }}</strong> {{ bymail_deadline }}</p>
     {{ mail_registration.text }}
 
-    {% if state_mail_pdf_link and mail_registration.link_text %}
+    {% if state_mail_pdf_link %}
       <p>{{ link(mail_registration.link_text, state_mail_pdf_link) }}</p>
-    {% endif %}
-  {% endset %}
-
-  {% set mail_footer %}
-    {% if accepts_nvrf and nvrf_details is not empty %}
-      <hr>
-      {% if nvrf_details.heading %}
-        <h3>{{ nvrf_details.heading }}</h3>
-      {% endif %}
-
-      {{ nvrf_details.text }}
-
-      {% if nvrf_details.link_text %}
-        {# Set path to form dynamically using page route. #}
-        {% set form_route = language!= 'es'? 'vote_nvrf.nvrf_page' : 'vote_nvrf.nvrf_page_es' %}
-        {% set state_name = currentnode.label | lower | replace({' ': '-'}) %}
-
-        {% include '@votegov/component/button.html.twig' with {
-          'href': 'internal:' ~ path(form_route, {'state_name': state_name}),
-          'label': nvrf_details.link_text,
-          'data_label': 'data-state-ext',
-          'data': 'nvrf-pdf-tool-registration'
-        } %}
-      {% endif %}
     {% endif %}
   {% endset %}
 
@@ -165,18 +167,20 @@
     'body': mail_body | render | trim | t({'@state_name': state_name}),
     'footer': mail_footer
   } %}
+  {# No mail registration content #}
 {% else %}
   {% if not has_mail and (no_mail_registration is not empty) %}
-    {% set body = no_mail_registration.text['#markup'] | t({'@state_name': title_english}) %}
-    {% set link_title = no_mail_registration.link_text['#markup'] | t({'@state_name': title_english }) %}
+    {% set no_mail_body = no_mail_registration.text['#markup'] | t({'@state_name': title_english}) %}
+    {% set no_mail_link_title = no_mail_registration.link_text['#markup'] | t({'@state_name': title_english }) %}
 
     {% include '@votegov/component/info-card.html.twig' with {
       'heading': no_mail_registration.heading,
-      'body': body,
+      'body': no_mail_body,
       'link': {
         'url':  more_info_link,
-        'title': link_title,
-      }
+        'title': no_mail_link_title,
+      },
+      'footer': mail_footer
     } %}
   {% endif %}
 {% endif %}


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[Vote-2958](https://cm-jira.usa.gov/browse/VOTE-2958)

## Description

Adding a new field for no mail registration setting this up as well to allow a button if needed but can remove later on if that is the decision made

## Deployment and testing

### Post-deploy steps

1. run `lando retune` and cd into the `votegov` theme and run `npm run build`

### QA/Testing instructions

1. create a new state display content block `/block/add/state_display_content?destination=/admin/content/block` and verify that there is a field type for no mail registration. 
2. add text to this field, please reach out if you need some dummy text and I can provide it for you. 
3. visit a state page and uncheck `mail registration` return back to the page and verify that the text that was inputted for that field is showing.

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
