### PR TITLE
VOTE-2962: Add state data points index page for Tome generation.

### DIFF
--- a/scripts/upkeep
+++ b/scripts/upkeep
@@ -111,6 +111,7 @@ echo "**************************************************"
 echo "Removing miscellaneous files..."
 echo "**************************************************"
 rm -rf ${html_path}/disabled-state-mail-in-forms 2>/dev/null
+rm -rf ${html_path}/state-data-points-index 2>/dev/null
 echo "Removing miscellaneous files...completed!"
 echo ""
 

--- a/web/modules/custom/vote_nvrf/src/Controller/NvrfPageController.php
+++ b/web/modules/custom/vote_nvrf/src/Controller/NvrfPageController.php
@@ -179,4 +179,5 @@ class NvrfPageController extends ControllerBase {
       '#cache' => ['max-age' => 0],
     ];
   }
+
 }

--- a/web/modules/custom/vote_nvrf/src/Controller/NvrfPageController.php
+++ b/web/modules/custom/vote_nvrf/src/Controller/NvrfPageController.php
@@ -127,4 +127,56 @@ class NvrfPageController extends ControllerBase {
     ];
   }
 
+  /**
+   * NVRF Page Controller which outputs state data endpoint links.
+   */
+  public function stateDataPointsIndex() {
+    // Get the current language.
+    $current_language = \Drupal::languageManager()->getCurrentLanguage()->getId();
+
+    // Get the default language.
+    $default_language = \Drupal::languageManager()->getDefaultLanguage()->getId();
+
+    // Check if the current language is not the default.
+    if ($current_language !== $default_language) {
+      // Return a 404 response if no matches are found.
+      throw new NotFoundHttpException();
+    }
+
+    $node_storage = \Drupal::entityTypeManager()->getStorage('node');
+    $nodes = $node_storage->loadByProperties([
+      'type' => 'state_territory',
+      'status' => 1,
+      'field_accepts_nvrf' => TRUE,
+    ]);
+
+    $output = '<ul>';
+
+    foreach ($nodes as $node) {
+      $languages = [
+        'en',
+        'es',
+      ];
+      $title = $node->get('title')->value;
+      $abbrev = $node->get('field_state_abbreviation')->value;
+
+      foreach ($languages as $langcode) {
+        $url = '/nvrf/assets/state/' . $abbrev . '/data.json';
+        // Add language code to url for non-english pages.
+        if ('en' !== $langcode) {
+          $url = "/$langcode" . $url;
+        }
+
+        $output .= '<li><a href="' . $url . '">' . $title . '(' . $langcode . ')' . '</a></li>';
+      }
+    }
+
+    $output .= '</ul>';
+
+    return [
+      '#markup' => $output,
+      '#attached' => ['library' => []],
+      '#cache' => ['max-age' => 0],
+    ];
+  }
 }

--- a/web/modules/custom/vote_nvrf/vote_nvrf.routing.yml
+++ b/web/modules/custom/vote_nvrf/vote_nvrf.routing.yml
@@ -18,3 +18,9 @@ vote_nvrf.disabled_nvrf_pages:
     _controller: '\Drupal\vote_nvrf\Controller\NvrfPageController::disabledStateFormsContent'
   requirements:
     _permission: 'access content'
+vote_nvrf.state_data_points_index:
+  path: '/state-data-points-index'
+  defaults:
+    _controller: '\Drupal\vote_nvrf\Controller\NvrfPageController::stateDataPointsIndex'
+  requirements:
+    _permission: 'access content'


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[VOTE-2962](https://cm-jira.usa.gov/browse/VOTE-2962)

## Description

Create a custom page with an index of state data points for Tome to access and generate static pages for.

## Deployment and testing

### Post-deploy steps
- Locally, run lando retune to install updates.

### QA/Testing instructions

- Goto /state-data-points-index and confirm that an index of state links displays pointing to /{langcode}/nvrf/assets/states/{state_abbreviation}/data.json
- From the console, run `lando drush tome:static`
- Confirm that the static directories are created under the following directory structure
html/{langcode}/nvrf/assets/states/{state_abbreviation}/data.json

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
