### PR TITLE
VOTE-3020 Reenable the NVRF details field in the state override content

### DIFF
--- a/config/sync/core.entity_view_display.node.state_territory.full.yml
+++ b/config/sync/core.entity_view_display.node.state_territory.full.yml
@@ -167,7 +167,7 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 27
+    weight: 26
     region: content
   field_in_state_name:
     type: string
@@ -210,7 +210,7 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 28
+    weight: 27
     region: content
   field_mail_registration_link:
     type: link
@@ -222,7 +222,7 @@ content:
       rel: '0'
       target: '0'
     third_party_settings: {  }
-    weight: 32
+    weight: 31
     region: content
   field_media:
     type: entity_reference_entity_view
@@ -238,7 +238,7 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 29
+    weight: 28
     region: content
   field_more_info_link:
     type: link
@@ -251,6 +251,13 @@ content:
       target: '0'
     third_party_settings: {  }
     weight: 6
+    region: content
+  field_nvrf_details:
+    type: vote_fields_state_content_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 32
     region: content
   field_of_state_name:
     type: string
@@ -287,7 +294,7 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 30
+    weight: 29
     region: content
   field_override_confirm_reg_link:
     type: link
@@ -354,7 +361,7 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 31
+    weight: 30
     region: content
   field_registration_type:
     type: list_key
@@ -387,7 +394,6 @@ hidden:
   field_identification_inst: true
   field_mailing_address_inst: true
   field_metatags: true
-  field_nvrf_details: true
   field_nvrf_fields: true
   field_nvrf_last_updated_date: true
   field_override_mail_reg_link: true


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket
https://cm-jira.usa.gov/browse/VOTE-3020

## Description

Fix the NVRF detail override bug. When set, NVRF details override now displays in place of the default content.

## Deployment and testing

### Post-deploy steps

1. lando retune
2. cd theme - npm run build

### QA/Testing instructions

1. Edit a state page
2. Add test content to the NVRF Details override field.
3. Make sure that "Accepts NVRF" is checked within the state data. Save the data.
4. On the state page, confirm the override content shows up in place of the default NVRF content.

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been included above.
- [ ] No merge conflicts exist with the target branch.
- [ ] Automated tests have passed on this PR.
- [ ] A reviewer has been designated.
- [ ] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
