### PR TITLE
VOTE-3006 empty link text bug

### DIFF
--- a/web/themes/custom/votegov/templates/node/node--state-territory.html.twig
+++ b/web/themes/custom/votegov/templates/node/node--state-territory.html.twig
@@ -40,7 +40,7 @@
 
 {# State content with fallbacks. #}
 {# Get default state display content from the block type. #}
-{% set state_display_content = drupal_entity('block_content', 22) | children %}
+{% set state_display_content = drupal_entity('block_content', 23) | children %}
 {% set registration_not_needed = state_display_content.field_registration_not_needed.0 | default([]) | merge(content.field_registration_not_needed.0 | default([])) %}
 {% set online_registration = state_display_content.field_online_registration.0 | default([]) | merge(content.field_online_registration.0 | default([])) %}
 {% set military_overseas_registration = state_display_content.field_military_and_overseas_regi.0 | default([]) | merge(content.field_military_and_overseas_regi.0 | default([])) %}
@@ -115,7 +115,9 @@
 
 {% if online_registration_vars is not empty %}
   {% set body = online_registration_vars.text['#markup'] | t(body_vars) %}
-  {% set link_title = online_registration_vars.link_text['#markup'] | t({'@state_name': title_english}) %}
+  {% if online_registration_vars.link_text %}
+    {% set link_title = online_registration_vars.link_text['#markup'] | t({'@state_name': title_english}) %}
+  {% endif %}
   {% include '@votegov/component/info-card.html.twig' with {
     'heading': online_registration_vars.heading,
     'body': body,
@@ -156,7 +158,7 @@
   {% set mail_body %}
     {{ mail_registration.text }}
 
-    {% if state_mail_pdf_link %}
+    {% if state_mail_pdf_link and mail_registration.link_text %}
       <p>{{ link(mail_registration.link_text, state_mail_pdf_link) }}</p>
     {% endif %}
   {% endset %}
@@ -166,11 +168,13 @@
     'body': mail_body | render | trim | t({'@state_mail_deadline': bymail_deadline ,'@state_name': title_english}),
     'footer': mail_footer
   } %}
-  {# No mail registration content #}
+{# No mail registration content #}
 {% else %}
   {% if not has_mail and (no_mail_registration is not empty) %}
     {% set no_mail_body = no_mail_registration.text['#markup'] | t({'@state_name': title_english}) %}
-    {% set no_mail_link_title = no_mail_registration.link_text['#markup'] | t({'@state_name': title_english }) %}
+    {% if no_mail_registration.link_text %}
+      {% set no_mail_link_title = no_mail_registration.link_text['#markup'] | t({'@state_name': title_english }) %}
+    {% endif %}
 
     {% include '@votegov/component/info-card.html.twig' with {
       'heading': no_mail_registration.heading,
@@ -186,7 +190,9 @@
 
     {% if has_in_person and (inperson_registration is not empty) %}
       {% set body = inperson_registration.text['#markup'] | t({'@state_in-person_deadline': inperson_deadline | render }) %}
-      {% set link_title = inperson_registration.link_text['#markup'] | t({'@state_name': title_english }) %}
+      {% if inperson_registration.link_text %}
+        {% set link_title = inperson_registration.link_text['#markup'] | t({'@state_name': title_english }) %}
+      {% endif %}
       {% include '@votegov/component/info-card.html.twig' with {
         'heading': inperson_registration.heading,
         'body': body,

--- a/web/themes/custom/votegov/templates/node/node--state-territory.html.twig
+++ b/web/themes/custom/votegov/templates/node/node--state-territory.html.twig
@@ -136,7 +136,7 @@
       <h3>{{ nvrf_details.heading }}</h3>
     {% endif %}
 
-    {{ nvrf_details.text }}
+    {{ nvrf_details.text['#markup'] | t({'@state_name': title_english}) }}
 
     {% if nvrf_details.link_text %}
       {# Set path to form dynamically using page route. #}


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket
https://cm-jira.usa.gov/browse/VOTE-3006

## Description

This ticket fixes the following bug:
When the optional "link text" field is left empty in any of the registration content blocks, Drupal throws an error.

## Deployment and testing

### Post-deploy steps

1. lando retune

### QA/Testing instructions

1. Go to http://vote-gov.lndo.site/admin/content/block/23?destination=/admin/content/block
2. Remove the "link text" from all blocks except "Check your registration".
3. View the Alabama page and confirm the blocks show up without the link buttons.
4. Edit Alabama and uncheck "Online" and "In person" registration types.
5. View the Alabama page and confirm the "no online" and "no in-person" blocks show without a link.
6. Edit Alabama and recheck "Online" and "In person" registration types. Uncheck the "mail" type.
7. View the Alabama page and confirm the "no mail" blocks shows without a link.
8. Go to http://vote-gov.lndo.site/node/7/edit?destination=/admin/content and add override content.

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been included above.
- [ ] No merge conflicts exist with the target branch.
- [ ] Automated tests have passed on this PR.
- [ ] A reviewer has been designated.
- [ ] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
