### PR TITLE
VOTE-3037 Hide untranslated state links in registration tool

### DIFF
--- a/config/sync/views.view.state_territory.yml
+++ b/config/sync/views.view.state_territory.yml
@@ -150,6 +150,59 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+        view_node:
+          id: view_node
+          table: node
+          field: view_node
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: entity_link
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: ''
+          output_url_as_text: true
+          absolute: false
       pager:
         type: none
         options:
@@ -222,8 +275,7 @@ display:
           plugin_id: language
           operator: in
           value:
-            '***LANGUAGE_site_default***': '***LANGUAGE_site_default***'
-            en: en
+            '***LANGUAGE_language_interface***': '***LANGUAGE_language_interface***'
           group: 1
           exposed: false
           expose:

--- a/web/themes/custom/votegov/templates/paragraph/paragraph--registration-tool.html.twig
+++ b/web/themes/custom/votegov/templates/paragraph/paragraph--registration-tool.html.twig
@@ -28,6 +28,8 @@
         {% endif %}
       </div>
     </div>
+    {% set results = drupal_view_result('state_territory', 'block') %}
+    {% if results | length %}
     <form id="vote-registration-tool__form" class="vote-registration-tool__form">
       <label class="{{ not content.field_body | render ? 'usa-sr-only' }} vote-registration-tool__label"
             for="vote-registration-tool__input">
@@ -40,7 +42,6 @@
       <div class="vote-registration-tool__list-container">
         <div id="vote-registration-tool__results" class="vote-registration-tool__nav">
           <ul class="vote-registration-tool__list" aria-label="{{ 'States and territories list' | t }}" data-test="stateList">
-            {% set results = drupal_view_result('state_territory', 'block') %}
             {% for result in results %}
               {% set nodeID = result._entity.id() %}
               {% set node_path = path('entity.node.canonical', {'node': nodeID}) %}
@@ -56,5 +57,6 @@
         </div>
       </div>
     </form>
+    {% endif %}
   </div>
 </section>


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

https://cm-jira.usa.gov/browse/VOTE-3037

## Description

Hide state links in registration tool when the pages are unpublished or untranslated.

## Deployment and testing

### Post-deploy steps

1. `lando retune`

### QA/Testing instructions

1. visit http://vote-gov.lndo.site/node/77/translations and add a translation for Japanese and confirm that the state list does not display on the page when you view it
2. visit http://vote-gov.lndo.site/node/8/translations and add a translation for Japanese and then visit http://vote-gov.lndo.site/ja/register and confirm only the link for Alaska displays in the list

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
