### PR TITLE
Vote-3051: not needed template update

### DIFF
--- a/web/themes/custom/votegov/templates/node/node--state-territory--not-needed.html.twig
+++ b/web/themes/custom/votegov/templates/node/node--state-territory--not-needed.html.twig
@@ -7,48 +7,31 @@
 #}
 
 {% block aside %}
-{# keep empty for not needed #}
+	{# keep empty for not needed #}
 {% endblock %}
 
 {% block content %}
-  {% if registration_not_needed is not empty %}
-    <h2>{{ registration_not_needed.heading }}</h2>
+	{% if registration_not_needed is not empty %}
+		{# setting link text to be in inline hyper link #}
+		{% if registration_not_needed.link_text %}
+			{% set link_markup %}
+			<a href="{{ more_info_link }}">{{ registration_not_needed.link_text | render | trim | t({'@state_name': title_english}) }}</a>
+			{% endset %}
+		{% endif %}
+		{# setting body text to have palceholder for both state name and link #}
+		{% set body = registration_not_needed.text['#markup']| t({'@state_name': title_english, '@link': {'#markup': link_markup } | render}) %}
 
-    {{ registration_not_needed.text }}
+		{% include '@votegov/component/info-card.html.twig' with {
+          'heading': registration_not_needed.heading,
+          'body': body,
+      } %}
 
-    {% if more_info_link and registration_not_needed.link_text %}
-      <p>
-        {% include '@votegov/component/button.html.twig' with {
-          'label': registration_not_needed.link_text,
-          'href': more_info_link
-        } %}
-      </p>
-    {% endif %}
+	{% endif %}
+	{% if military_overseas_registration is not empty %}
+		{% include '@votegov/component/info-card.html.twig' with {
+        'heading': military_overseas_registration.heading,
+        'body': military_overseas_registration.text,
+      } %}
+	{% endif %}
 
-    {% if military_overseas_registration is not empty %}
-      {{ military_overseas_registration }}
-    {% endif %}
-  {% endif %}
-
-  {# JSON Schema #}
-  {# Commenting this out until we have a chance to review and improve #}
-{#  <script type="application/ld+json">#}
-{#  {#}
-{#    "@context": "https://schema.org",#}
-{#    "@type": "FAQPage",#}
-{#    "mainEntity": [{#}
-{#      "@type": "Question",#}
-{#      "name": "{{ 'How to register to vote' | t({ '@state_name': state_name }) }}",#}
-{#      "acceptedAnswer": {#}
-{#        "@type": "Answer",#}
-{#        "text": "{{ 'Voter registration is not required in @state_name. @link on @state_name’s election website.' | t({#}
-{#      '@link': { "#markup": "<a href=\"#{more_info_link}\">#{more_info_link_text}</a>"} | render | replace({'"': "\""}),#}
-{#      '@state_name': state_name,#}
-{#      '@of_state_name': of_state_name,#}
-{#      '@in_state_name': in_state_name#}
-{#    }) }}"#}
-{#    }#}
-{#    }{{ end }}]#}
-{#  }#}
-{#</script>#}
 {% endblock %}

--- a/web/themes/custom/votegov/templates/node/node--state-territory.html.twig
+++ b/web/themes/custom/votegov/templates/node/node--state-territory.html.twig
@@ -221,5 +221,13 @@
       } %}
     {% endif %}
   {% endblock %}
+
+    {# Checking if updated date is set and then render the field #}
+  {% if content.field_updated_date | field_value is not empty %}
+  <p class="vote-date--updated">
+    {# Striptags and raw filters were added to accomodate Navajo date formats. #}
+    {{'Last updated:' | t }} {{ content.field_updated_date | render | replace(t_numbers[language].numbers | default([])) | striptags('<span>') | raw }}
+  </p>
+  {% endif %}
 </div>
 </div>


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[Vote-3051](https://cm-jira.usa.gov/browse/VOTE-3051)

## Description

Updating the not needed template to use the `@link` place holder like check registration.  

Also adding back the last updated field to template.  

![Screenshot 2024-10-29 at 3 02 49 PM](https://github.com/user-attachments/assets/793763ab-fc9a-4602-ab00-8f27eee6b489)


## Deployment and testing

### Post-deploy steps

1. `lando retune` and cd into `votegov` theme and run `npm run build`

### QA/Testing instructions

1. visit `Alabama` and select the not needed registration type.. also be sure to update the `Not needed` content block as well
2. verify that content is displaying correctly 

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
