### PR TITLE
Vote-3054: Removed hard coded 2022 date from Japanese

### DIFF
--- a/web/modules/custom/vote_utility/translations/ja.po
+++ b/web/modules/custom/vote_utility/translations/ja.po
@@ -138,10 +138,10 @@ msgid "Register by mail deadline:"
 msgstr "郵送での登録締切："
 
 msgid "Must be postmarked by @date"
-msgstr "2022年5月28日 @date 消印有効"
+msgstr "年5月28日 @date 消印有効"
 
 msgid "Must be received by @date"
-msgstr "2022年5月28日 @date 必着"
+msgstr "年5月28日 @date 必着"
 
 # data.translations.register.dates__byonline_deadline
 msgid "Online registration deadline:"

--- a/web/modules/custom/vote_utility/translations/ja.po
+++ b/web/modules/custom/vote_utility/translations/ja.po
@@ -137,12 +137,6 @@ msgstr "州および地方選挙の日程を調べる"
 msgid "Register by mail deadline:"
 msgstr "郵送での登録締切："
 
-msgid "Must be postmarked by @date"
-msgstr "年5月28日 @date 消印有効"
-
-msgid "Must be received by @date"
-msgstr "年5月28日 @date 必着"
-
 # data.translations.register.dates__byonline_deadline
 msgid "Online registration deadline:"
 msgstr "オンライン登録の締め切り："

--- a/web/modules/custom/vote_utility/translations/ja.po
+++ b/web/modules/custom/vote_utility/translations/ja.po
@@ -137,6 +137,12 @@ msgstr "州および地方選挙の日程を調べる"
 msgid "Register by mail deadline:"
 msgstr "郵送での登録締切："
 
+msgid "Must be postmarked by @date"
+msgstr "@date 消印有効"
+
+msgid "Must be received by @date"
+msgstr "@date 必着"
+
 # data.translations.register.dates__byonline_deadline
 msgid "Online registration deadline:"
 msgstr "オンライン登録の締め切り："


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[Vote-3054](https://cm-jira.usa.gov/browse/VOTE-3054)

## Description

Removing hard coded `2022` in the Japanese translation 

## Deployment and testing

### Post-deploy steps

n/a

### QA/Testing instructions

1. review file changes and check that 2022 has been removed form mail in string 
2. review .po file and ensure no other hard coded years are present

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been included above.
- [ ] No merge conflicts exist with the target branch.
- [ ] Automated tests have passed on this PR.
- [ ] A reviewer has been designated.
- [ ] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
