### PR TITLE
VOTE-3015: Enable Japanese locally and on production.

### DIFF
--- a/config/local/config_split.patch.language.entity.ja.yml
+++ b/config/local/config_split.patch.language.entity.ja.yml
@@ -1,9 +1,0 @@
-adding:
-  dependencies:
-    module:
-      - disable_language
-  third_party_settings:
-    disable_language:
-      disable: true
-      redirect_language: en
-removing: {  }

--- a/config/production/config_split.patch.language.entity.ja.yml
+++ b/config/production/config_split.patch.language.entity.ja.yml
@@ -1,9 +1,0 @@
-adding:
-  dependencies:
-    module:
-      - disable_language
-  third_party_settings:
-    disable_language:
-      disable: true
-      redirect_language: en
-removing: {  }


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[VOTE-3015](https://cm-jira.usa.gov/browse/VOTE-3015)

## Description

Enable Japanese language on local and production environments.

### Post-deploy steps

1. Update the following setting in web/sites/settings.local.php file to include or reflect
`$config['config_split.config_split.production']['status'] = TRUE;`
2. Run `lando retune` or `lando drush cim` to import the production configurations.

### QA/Testing instructions

1. Login as an administrator
2. Goto /admin/config/regional/language and confirm that Japanese is not marked as disabled.
3. Goto the content admin page and identify any page that has been translated in Japanese.
4. View the translated page and confirm that the language selector button in the top right corner of the page includes Japanese as an option.
5. Logout and repeat Step 4.

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been included above.
- [ ] No merge conflicts exist with the target branch.
- [ ] Automated tests have passed on this PR.
- [ ] A reviewer has been designated.
- [ ] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
