### PR TITLE
VOTE-2961 Add help text for state display content fields

### DIFF
--- a/config/sync/block_content.type.state_display_content.yml
+++ b/config/sync/block_content.type.state_display_content.yml
@@ -4,5 +4,5 @@ status: true
 dependencies: {  }
 id: state_display_content
 label: 'State Display Content'
-revision: false
+revision: true
 description: null

--- a/config/sync/core.entity_form_display.block_content.state_display_content.default.yml
+++ b/config/sync/core.entity_form_display.block_content.state_display_content.default.yml
@@ -8,13 +8,17 @@ dependencies:
     - field.field.block_content.state_display_content.field_display_title
     - field.field.block_content.state_display_content.field_election_date
     - field.field.block_content.state_display_content.field_election_text
+    - field.field.block_content.state_display_content.field_enable_digital_form_link
     - field.field.block_content.state_display_content.field_in_person_registration
+    - field.field.block_content.state_display_content.field_mail_reg_deadline_label
     - field.field.block_content.state_display_content.field_mail_registration
     - field.field.block_content.state_display_content.field_military_and_overseas_regi
     - field.field.block_content.state_display_content.field_no_mail_registration
     - field.field.block_content.state_display_content.field_no_online_registration
     - field.field.block_content.state_display_content.field_nvrf_details
+    - field.field.block_content.state_display_content.field_online_reg_deadline_label
     - field.field.block_content.state_display_content.field_online_registration
+    - field.field.block_content.state_display_content.field_person_reg_deadline_label
     - field.field.block_content.state_display_content.field_registration_not_needed
   module:
     - allowed_formats
@@ -28,13 +32,15 @@ mode: default
 content:
   field_check_registration:
     type: vote_fields_state_content
-    weight: 2
+    weight: 5
     region: content
     settings:
       form_subfield_display:
-        - heading
-        - text
-        - link_text
+        heading: heading
+        text: text
+        link_text: link_text
+      form_subfield_text_help_text: 'Use the placeholder <strong>@link</strong> to dynamically add a link using the link text below and the dynamic link url on the state page.'
+      form_subfield_link_text_help_text: 'This text will be inserted dynamically using the placeholder in the text above.'
     third_party_settings: {  }
   field_display_title:
     type: string_textfield
@@ -46,13 +52,13 @@ content:
     third_party_settings: {  }
   field_election_date:
     type: datetime_default
-    weight: 11
+    weight: 15
     region: content
     settings: {  }
     third_party_settings: {  }
   field_election_text:
     type: text_textarea
-    weight: 12
+    weight: 16
     region: content
     settings:
       rows: 3
@@ -61,7 +67,34 @@ content:
       allowed_formats:
         hide_help: '0'
         hide_guidelines: '0'
+  field_enable_digital_form_link:
+    type: boolean_checkbox
+    weight: 11
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
   field_in_person_registration:
+    type: vote_fields_state_content
+    weight: 12
+    region: content
+    settings:
+      form_subfield_display:
+        - heading
+        - text
+        - link_text
+      form_subfield_text_help_text: ''
+      form_subfield_link_text_help_text: ''
+    third_party_settings: {  }
+  field_mail_reg_deadline_label:
+    type: string_textfield
+    weight: 3
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_mail_registration:
     type: vote_fields_state_content
     weight: 8
     region: content
@@ -70,18 +103,22 @@ content:
         - heading
         - text
         - link_text
+      form_subfield_text_help_text: ''
+      form_subfield_link_text_help_text: ''
     third_party_settings: {  }
-  field_mail_registration:
+  field_military_and_overseas_regi:
     type: vote_fields_state_content
-    weight: 5
+    weight: 13
     region: content
     settings:
       form_subfield_display:
-        - heading
-        - text
-        - link_text
+        heading: heading
+        text: text
+        link_text: 0
+      form_subfield_text_help_text: ''
+      form_subfield_link_text_help_text: ''
     third_party_settings: {  }
-  field_military_and_overseas_regi:
+  field_no_mail_registration:
     type: vote_fields_state_content
     weight: 9
     region: content
@@ -90,8 +127,42 @@ content:
         heading: heading
         text: text
         link_text: 0
+      form_subfield_text_help_text: ''
+      form_subfield_link_text_help_text: ''
     third_party_settings: {  }
-  field_no_mail_registration:
+  field_no_online_registration:
+    type: vote_fields_state_content
+    weight: 7
+    region: content
+    settings:
+      form_subfield_display:
+        heading: heading
+        text: text
+        link_text: 0
+      form_subfield_text_help_text: ''
+      form_subfield_link_text_help_text: ''
+    third_party_settings: {  }
+  field_nvrf_details:
+    type: vote_fields_state_content
+    weight: 10
+    region: content
+    settings:
+      form_subfield_display:
+        text: text
+        link_text: link_text
+        heading: 0
+      form_subfield_text_help_text: ''
+      form_subfield_link_text_help_text: "This text will display as a button that launches Vote.gov's internal form filler tool."
+    third_party_settings: {  }
+  field_online_reg_deadline_label:
+    type: string_textfield
+    weight: 2
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_online_registration:
     type: vote_fields_state_content
     weight: 6
     region: content
@@ -100,46 +171,28 @@ content:
         - heading
         - text
         - link_text
+      form_subfield_text_help_text: ''
+      form_subfield_link_text_help_text: ''
     third_party_settings: {  }
-  field_no_online_registration:
-    type: vote_fields_state_content
+  field_person_reg_deadline_label:
+    type: string_textfield
     weight: 4
     region: content
     settings:
-      form_subfield_display:
-        - heading
-        - text
-        - link_text
-    third_party_settings: {  }
-  field_nvrf_details:
-    type: vote_fields_state_content
-    weight: 7
-    region: content
-    settings:
-      form_subfield_display:
-        - heading
-        - text
-        - link_text
-    third_party_settings: {  }
-  field_online_registration:
-    type: vote_fields_state_content
-    weight: 3
-    region: content
-    settings:
-      form_subfield_display:
-        - heading
-        - text
-        - link_text
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   field_registration_not_needed:
     type: vote_fields_state_content
-    weight: 10
+    weight: 14
     region: content
     settings:
       form_subfield_display:
-        - heading
-        - text
-        - link_text
+        heading: heading
+        text: text
+        link_text: link_text
+      form_subfield_text_help_text: 'Use the placeholder <strong>@link</strong> to dynamically add a link using the link text below and the dynamic link url on the state page.'
+      form_subfield_link_text_help_text: 'This text will be inserted dynamically using the placeholder in the text above.'
     third_party_settings: {  }
   info:
     type: string_textfield
@@ -151,13 +204,13 @@ content:
     third_party_settings: {  }
   langcode:
     type: language_select
-    weight: 14
+    weight: 18
     region: content
     settings:
       include_locked: true
     third_party_settings: {  }
   translation:
-    weight: 13
+    weight: 17
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.node.state_territory.default.yml
+++ b/config/sync/core.entity_form_display.node.state_territory.default.yml
@@ -225,7 +225,6 @@ third_party_settings:
     group_state_display_content:
       children:
         - field_check_registration
-        - field_registration_intro
         - field_online_registration
         - field_mail_registration
         - field_nvrf_details
@@ -243,7 +242,7 @@ third_party_settings:
         id: ''
         label_as_html: false
         formatter: closed
-        description: 'Entering content into these fields overrides the default state display content for this state/territory.'
+        description: "Entering content into these fields overrides the <strong>default state display content</strong> for this state/territory.\r\nIf you are looking to update the content that is shared across all states you can <a href=\"/admin/content/block/23\" target=\"_blank\">edit the default state display content</a>."
         required_fields: true
 id: node.state_territory.default
 targetEntityType: node
@@ -280,9 +279,11 @@ content:
     region: content
     settings:
       form_subfield_display:
-        - heading
-        - text
-        - link_text
+        heading: heading
+        text: text
+        link_text: link_text
+      form_subfield_text_help_text: 'Use the placeholder <strong>@link</strong> to dynamically add a link using the link text below and the dynamic link url on the state page.'
+      form_subfield_link_text_help_text: 'This text will be inserted dynamically using the placeholder in the text above.'
     third_party_settings: {  }
   field_confirm_registration_link:
     type: link_default
@@ -380,6 +381,8 @@ content:
         - heading
         - text
         - link_text
+      form_subfield_text_help_text: ''
+      form_subfield_link_text_help_text: ''
     third_party_settings: {  }
   field_in_state_name:
     type: string_textfield
@@ -417,6 +420,8 @@ content:
         - heading
         - text
         - link_text
+      form_subfield_text_help_text: ''
+      form_subfield_link_text_help_text: ''
     third_party_settings: {  }
   field_mail_registration_link:
     type: link_default
@@ -455,9 +460,11 @@ content:
     region: content
     settings:
       form_subfield_display:
-        - heading
-        - text
-        - link_text
+        heading: heading
+        text: text
+        link_text: 0
+      form_subfield_text_help_text: ''
+      form_subfield_link_text_help_text: ''
     third_party_settings: {  }
   field_more_info_link:
     type: link_default
@@ -473,9 +480,11 @@ content:
     region: content
     settings:
       form_subfield_display:
-        - heading
-        - text
-        - link_text
+        text: text
+        link_text: link_text
+        heading: 0
+      form_subfield_text_help_text: ''
+      form_subfield_link_text_help_text: "This text will display as a button that launches Vote.gov's internal form filler tool."
     third_party_settings: {  }
   field_nvrf_fields:
     type: field_nvrf_fields
@@ -529,6 +538,8 @@ content:
         - heading
         - text
         - link_text
+      form_subfield_text_help_text: ''
+      form_subfield_link_text_help_text: ''
     third_party_settings: {  }
   field_override_confirm_reg_link:
     type: link_default
@@ -616,9 +627,11 @@ content:
     region: content
     settings:
       form_subfield_display:
-        - heading
-        - text
-        - link_text
+        heading: heading
+        text: text
+        link_text: link_text
+      form_subfield_text_help_text: 'Use the placeholder <strong>@link</strong> to dynamically add a link using the link text below and the dynamic link url on the state page.'
+      form_subfield_link_text_help_text: 'This text will be inserted dynamically using the placeholder in the text above.'
     third_party_settings: {  }
   field_registration_type:
     type: options_buttons

--- a/config/sync/core.entity_view_display.block_content.state_display_content.default.yml
+++ b/config/sync/core.entity_view_display.block_content.state_display_content.default.yml
@@ -8,13 +8,17 @@ dependencies:
     - field.field.block_content.state_display_content.field_display_title
     - field.field.block_content.state_display_content.field_election_date
     - field.field.block_content.state_display_content.field_election_text
+    - field.field.block_content.state_display_content.field_enable_digital_form_link
     - field.field.block_content.state_display_content.field_in_person_registration
+    - field.field.block_content.state_display_content.field_mail_reg_deadline_label
     - field.field.block_content.state_display_content.field_mail_registration
     - field.field.block_content.state_display_content.field_military_and_overseas_regi
     - field.field.block_content.state_display_content.field_no_mail_registration
     - field.field.block_content.state_display_content.field_no_online_registration
     - field.field.block_content.state_display_content.field_nvrf_details
+    - field.field.block_content.state_display_content.field_online_reg_deadline_label
     - field.field.block_content.state_display_content.field_online_registration
+    - field.field.block_content.state_display_content.field_person_reg_deadline_label
     - field.field.block_content.state_display_content.field_registration_not_needed
   module:
     - datetime
@@ -56,12 +60,30 @@ content:
     third_party_settings: {  }
     weight: 11
     region: content
+  field_enable_digital_form_link:
+    type: boolean
+    label: hidden
+    settings:
+      format: boolean
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 8
+    region: content
   field_in_person_registration:
     type: vote_fields_state_content_default
     label: above
     settings: {  }
     third_party_settings: {  }
     weight: 7
+    region: content
+  field_mail_reg_deadline_label:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 15
     region: content
   field_mail_registration:
     type: vote_fields_state_content_default
@@ -98,12 +120,28 @@ content:
     third_party_settings: {  }
     weight: 6
     region: content
+  field_online_reg_deadline_label:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 14
+    region: content
   field_online_registration:
     type: vote_fields_state_content_default
     label: above
     settings: {  }
     third_party_settings: {  }
     weight: 4
+    region: content
+  field_person_reg_deadline_label:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 16
     region: content
   field_registration_not_needed:
     type: vote_fields_state_content_default

--- a/config/sync/field.field.block_content.state_display_content.field_display_title.yml
+++ b/config/sync/field.field.block_content.state_display_content.field_display_title.yml
@@ -10,7 +10,7 @@ field_name: field_display_title
 entity_type: block_content
 bundle: state_display_content
 label: 'Page display title'
-description: ''
+description: 'Use the placeholder <strong>@state_name</strong> to dynamically add the state name on the state page.'
 required: true
 translatable: true
 default_value: {  }

--- a/config/sync/field.field.block_content.state_display_content.field_election_text.yml
+++ b/config/sync/field.field.block_content.state_display_content.field_election_text.yml
@@ -13,7 +13,7 @@ field_name: field_election_text
 entity_type: block_content
 bundle: state_display_content
 label: 'Election Text'
-description: ''
+description: 'Use the placeholder <strong>@date</strong> to dynamically add the election date on the state page.'
 required: false
 translatable: true
 default_value: {  }

--- a/config/sync/field.field.block_content.state_display_content.field_enable_digital_form_link.yml
+++ b/config/sync/field.field.block_content.state_display_content.field_enable_digital_form_link.yml
@@ -1,0 +1,21 @@
+uuid: 6129cbd8-9a60-4499-90f2-eaa5dadd5a24
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.state_display_content
+    - field.storage.block_content.field_enable_digital_form_link
+id: block_content.state_display_content.field_enable_digital_form_link
+field_name: field_enable_digital_form_link
+entity_type: block_content
+bundle: state_display_content
+label: 'Enable NVRF digital form link'
+description: 'Selecting this option launches the NVRF digital form to the public.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/field.field.block_content.state_display_content.field_mail_reg_deadline_label.yml
+++ b/config/sync/field.field.block_content.state_display_content.field_mail_reg_deadline_label.yml
@@ -1,0 +1,19 @@
+uuid: cb566395-2e50-40ea-bf0d-9b13cc6b964c
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.state_display_content
+    - field.storage.block_content.field_mail_reg_deadline_label
+id: block_content.state_display_content.field_mail_reg_deadline_label
+field_name: field_mail_reg_deadline_label
+entity_type: block_content
+bundle: state_display_content
+label: 'Mail registration deadline label'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.block_content.state_display_content.field_online_reg_deadline_label.yml
+++ b/config/sync/field.field.block_content.state_display_content.field_online_reg_deadline_label.yml
@@ -1,0 +1,19 @@
+uuid: e8b3b9a9-49d0-4985-9355-44a1d6ba1c3f
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.state_display_content
+    - field.storage.block_content.field_online_reg_deadline_label
+id: block_content.state_display_content.field_online_reg_deadline_label
+field_name: field_online_reg_deadline_label
+entity_type: block_content
+bundle: state_display_content
+label: 'Online registration deadline label'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.block_content.state_display_content.field_person_reg_deadline_label.yml
+++ b/config/sync/field.field.block_content.state_display_content.field_person_reg_deadline_label.yml
@@ -1,0 +1,19 @@
+uuid: 49e5680b-fdf2-4544-86ee-c3738af83881
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.state_display_content
+    - field.storage.block_content.field_person_reg_deadline_label
+id: block_content.state_display_content.field_person_reg_deadline_label
+field_name: field_person_reg_deadline_label
+entity_type: block_content
+bundle: state_display_content
+label: 'In-person registration deadline label'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.storage.block_content.field_mail_reg_deadline_label.yml
+++ b/config/sync/field.storage.block_content.field_mail_reg_deadline_label.yml
@@ -1,0 +1,21 @@
+uuid: 7ce748eb-d002-4143-b5db-f7c3ecbda2a5
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+id: block_content.field_mail_reg_deadline_label
+field_name: field_mail_reg_deadline_label
+entity_type: block_content
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.block_content.field_online_reg_deadline_label.yml
+++ b/config/sync/field.storage.block_content.field_online_reg_deadline_label.yml
@@ -1,0 +1,21 @@
+uuid: 7740d1f3-1200-4611-a67e-4cdca4e65cc9
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+id: block_content.field_online_reg_deadline_label
+field_name: field_online_reg_deadline_label
+entity_type: block_content
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.block_content.field_person_reg_deadline_label.yml
+++ b/config/sync/field.storage.block_content.field_person_reg_deadline_label.yml
@@ -1,0 +1,21 @@
+uuid: 36ac9f47-8d35-4cc0-9b70-38e59e404b0d
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+id: block_content.field_person_reg_deadline_label
+field_name: field_person_reg_deadline_label
+entity_type: block_content
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/vote_fields/config/schema/vote_fields.schema.yml
+++ b/web/modules/custom/vote_fields/config/schema/vote_fields.schema.yml
@@ -23,3 +23,9 @@ field.field_settings.vote_fields_state_content:
       label: Fields to display in the form
       sequence:
         type: string
+    form_subfield_text_help_text:
+      type: string
+      label: Text subfield help text
+    form_subfield_link_text_help_text:
+      type: string
+      label: Link text subfield help text

--- a/web/modules/custom/vote_fields/src/Plugin/Field/FieldWidget/StateContentWidget.php
+++ b/web/modules/custom/vote_fields/src/Plugin/Field/FieldWidget/StateContentWidget.php
@@ -29,6 +29,8 @@ final class StateContentWidget extends WidgetBase {
       'text',
       'link_text',
     ];
+    $settings['form_subfield_text_help_text'] = '';
+    $settings['form_subfield_link_text_help_text'] = '';
 
     return $settings + parent::defaultSettings();
   }
@@ -41,7 +43,7 @@ final class StateContentWidget extends WidgetBase {
 
     $element['form_subfield_display'] = [
       '#type' => 'checkboxes',
-      '#title' => t('Fields to display in the form'),
+      '#title' => $this->t('Fields to display in the form'),
       '#options' => [
         'heading' => 'Heading',
         'text' => 'Text',
@@ -49,7 +51,19 @@ final class StateContentWidget extends WidgetBase {
       ],
       '#required' => TRUE,
       '#default_value' => $settings['form_subfield_display'],
-      '#description' => t('Select all subfields that you want to display in the form.'),
+      '#description' => $this->t('Select all subfields that you want to display in the form.'),
+    ];
+
+    $element['form_subfield_text_help_text'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Text subfield help text'),
+      '#default_value' => $settings['form_subfield_text_help_text'],
+    ];
+
+    $element['form_subfield_link_text_help_text'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Link text subfield help text'),
+      '#default_value' => $settings['form_subfield_link_text_help_text'],
     ];
 
     return $element;
@@ -75,6 +89,7 @@ final class StateContentWidget extends WidgetBase {
       '#format' => 'simple_html',
       '#allowed_formats' => ['simple_html'],
       '#access' => in_array('text', $settings['form_subfield_display']),
+      '#description' => $settings['form_subfield_text_help_text'],
     ];
 
     $element['link_text'] = [
@@ -82,9 +97,17 @@ final class StateContentWidget extends WidgetBase {
       '#title' => $this->t('Link text'),
       '#default_value' => $items[$delta]->link_text ?? NULL,
       '#access' => in_array('link_text', $settings['form_subfield_display']),
+      '#description' => $settings['form_subfield_link_text_help_text'],
     ];
 
-    $element['#theme_wrappers'] = ['fieldset'];
+    $element['#theme_wrappers'] = [
+      'details' => [
+        '#description' => [
+          '#markup' => 'Use the placeholder <strong>@state_name</strong> to dynamically add the state name on the state page.'
+        ],
+        '#summary_attributes' =>  []
+      ]
+    ];
     $element['#attributes']['class'][] = 'vote-fields-state-content-elements';
     $element['#attached']['library'][] = 'vote_fields/vote_fields_state_content';
 

--- a/web/modules/custom/vote_fields/src/Plugin/Field/FieldWidget/StateContentWidget.php
+++ b/web/modules/custom/vote_fields/src/Plugin/Field/FieldWidget/StateContentWidget.php
@@ -103,10 +103,10 @@ final class StateContentWidget extends WidgetBase {
     $element['#theme_wrappers'] = [
       'details' => [
         '#description' => [
-          '#markup' => 'Use the placeholder <strong>@state_name</strong> to dynamically add the state name on the state page.'
+          '#markup' => 'Use the placeholder <strong>@state_name</strong> to dynamically add the state name on the state page.',
         ],
-        '#summary_attributes' =>  []
-      ]
+        '#summary_attributes' => [],
+      ],
     ];
     $element['#attributes']['class'][] = 'vote-fields-state-content-elements';
     $element['#attached']['library'][] = 'vote_fields/vote_fields_state_content';


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

https://cm-jira.usa.gov/browse/VOTE-2961

## Description

Add helptext features to state page enhancement fields and data types. Add missing fields for:
- deadline labels
- toggle display digital form filler tool

## Deployment and testing

### Post-deploy steps

1. `lando retune`

### QA/Testing instructions

1. Visit http://vote-gov.lndo.site/admin/content/block/23 and see the new fields
2. Confirm the content is in collapsible groups now (requested by Susan)
3. Confirm the help text is applied to various fields in the form
4. Translate the block and make sure the new fields are translatable
5. Visit http://vote-gov.lndo.site/node/26/edit
6. Confirm the content in the State Display Content tab is collapsible
7. Confirm the help text is applied to various fields in the form
8. Translate the state and make sure experience is the same

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
