### PR TITLE
VOTE-3125 add shared fields to state display content block type

### DIFF
--- a/config/sync/core.entity_form_display.block_content.state_display_content.default.yml
+++ b/config/sync/core.entity_form_display.block_content.state_display_content.default.yml
@@ -9,12 +9,15 @@ dependencies:
     - field.field.block_content.state_display_content.field_election_date
     - field.field.block_content.state_display_content.field_election_text
     - field.field.block_content.state_display_content.field_in_person_registration
+    - field.field.block_content.state_display_content.field_last_updated_label
     - field.field.block_content.state_display_content.field_mail_registration
     - field.field.block_content.state_display_content.field_military_and_overseas_regi
     - field.field.block_content.state_display_content.field_no_mail_registration
     - field.field.block_content.state_display_content.field_no_online_registration
     - field.field.block_content.state_display_content.field_nvrf_details
     - field.field.block_content.state_display_content.field_online_registration
+    - field.field.block_content.state_display_content.field_postmarked_mail_text
+    - field.field.block_content.state_display_content.field_received_mail_text
     - field.field.block_content.state_display_content.field_registration_not_needed
   module:
     - allowed_formats
@@ -70,6 +73,14 @@ content:
         - heading
         - text
         - link_text
+    third_party_settings: {  }
+  field_last_updated_label:
+    type: string_textfield
+    weight: 13
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   field_mail_registration:
     type: vote_fields_state_content
@@ -131,6 +142,22 @@ content:
         - text
         - link_text
     third_party_settings: {  }
+  field_postmarked_mail_text:
+    type: string_textfield
+    weight: 14
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_received_mail_text:
+    type: string_textfield
+    weight: 15
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   field_registration_not_needed:
     type: vote_fields_state_content
     weight: 10
@@ -151,13 +178,13 @@ content:
     third_party_settings: {  }
   langcode:
     type: language_select
-    weight: 14
+    weight: 17
     region: content
     settings:
       include_locked: true
     third_party_settings: {  }
   translation:
-    weight: 13
+    weight: 16
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_view_display.block_content.state_display_content.default.yml
+++ b/config/sync/core.entity_view_display.block_content.state_display_content.default.yml
@@ -9,12 +9,15 @@ dependencies:
     - field.field.block_content.state_display_content.field_election_date
     - field.field.block_content.state_display_content.field_election_text
     - field.field.block_content.state_display_content.field_in_person_registration
+    - field.field.block_content.state_display_content.field_last_updated_label
     - field.field.block_content.state_display_content.field_mail_registration
     - field.field.block_content.state_display_content.field_military_and_overseas_regi
     - field.field.block_content.state_display_content.field_no_mail_registration
     - field.field.block_content.state_display_content.field_no_online_registration
     - field.field.block_content.state_display_content.field_nvrf_details
     - field.field.block_content.state_display_content.field_online_registration
+    - field.field.block_content.state_display_content.field_postmarked_mail_text
+    - field.field.block_content.state_display_content.field_received_mail_text
     - field.field.block_content.state_display_content.field_registration_not_needed
   module:
     - datetime
@@ -63,6 +66,14 @@ content:
     third_party_settings: {  }
     weight: 7
     region: content
+  field_last_updated_label:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 14
+    region: content
   field_mail_registration:
     type: vote_fields_state_content_default
     label: above
@@ -104,6 +115,22 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 4
+    region: content
+  field_postmarked_mail_text:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 15
+    region: content
+  field_received_mail_text:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 16
     region: content
   field_registration_not_needed:
     type: vote_fields_state_content_default

--- a/config/sync/field.field.block_content.state_display_content.field_last_updated_label.yml
+++ b/config/sync/field.field.block_content.state_display_content.field_last_updated_label.yml
@@ -1,0 +1,19 @@
+uuid: 0b24ffb5-0c11-477e-a9ed-3f8b0f3b442c
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.state_display_content
+    - field.storage.block_content.field_last_updated_label
+id: block_content.state_display_content.field_last_updated_label
+field_name: field_last_updated_label
+entity_type: block_content
+bundle: state_display_content
+label: 'Last updated label'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.block_content.state_display_content.field_postmarked_mail_text.yml
+++ b/config/sync/field.field.block_content.state_display_content.field_postmarked_mail_text.yml
@@ -1,0 +1,19 @@
+uuid: 9a77ea9d-df6f-40dd-a798-91adf1dc7e54
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.state_display_content
+    - field.storage.block_content.field_postmarked_mail_text
+id: block_content.state_display_content.field_postmarked_mail_text
+field_name: field_postmarked_mail_text
+entity_type: block_content
+bundle: state_display_content
+label: 'Postmarked mail deadline text'
+description: 'Use the placeholder <strong>@date</strong> to insert the mail deadline date on the state page.'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.block_content.state_display_content.field_received_mail_text.yml
+++ b/config/sync/field.field.block_content.state_display_content.field_received_mail_text.yml
@@ -1,0 +1,19 @@
+uuid: 947b7637-8aa7-4b0d-8250-c44688868374
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.state_display_content
+    - field.storage.block_content.field_received_mail_text
+id: block_content.state_display_content.field_received_mail_text
+field_name: field_received_mail_text
+entity_type: block_content
+bundle: state_display_content
+label: 'Received mail deadline text'
+description: 'Use the placeholder <strong>@date</strong> to insert the mail deadline date on the state page.'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.storage.block_content.field_last_updated_label.yml
+++ b/config/sync/field.storage.block_content.field_last_updated_label.yml
@@ -1,0 +1,21 @@
+uuid: dfb91ee4-5cea-4a07-8096-5d3a05881fef
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+id: block_content.field_last_updated_label
+field_name: field_last_updated_label
+entity_type: block_content
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.block_content.field_postmarked_mail_text.yml
+++ b/config/sync/field.storage.block_content.field_postmarked_mail_text.yml
@@ -1,0 +1,21 @@
+uuid: be18e2bd-5a2f-40b4-8200-6700c6a4728a
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+id: block_content.field_postmarked_mail_text
+field_name: field_postmarked_mail_text
+entity_type: block_content
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.block_content.field_received_mail_text.yml
+++ b/config/sync/field.storage.block_content.field_received_mail_text.yml
@@ -1,0 +1,21 @@
+uuid: da92ce02-5efa-44dd-9c11-edff80d95c17
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+id: block_content.field_received_mail_text
+field_name: field_received_mail_text
+entity_type: block_content
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

https://cm-jira.usa.gov/browse/VOTE-3125

## Description

Add 3 new fields to the state display content block type:
- last updated label
- postmarked deadline text
- received deadline text

## Deployment and testing

### Post-deploy steps

1. `lando retune`

### QA/Testing instructions

1. visit http://vote-gov.lndo.site/admin/content/block/23 and see the new fields
<img width="783" alt="Screenshot 2024-11-13 at 8 40 43 AM" src="https://github.com/user-attachments/assets/30bd1f1a-fc0e-4db9-8eb7-723cfe872b29">
2. Confirm that they can be translated

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
