### PR TITLE
VOTE- 3094 Remove merge from override functions

### DIFF
--- a/web/themes/custom/votegov/templates/node/node--state-territory.html.twig
+++ b/web/themes/custom/votegov/templates/node/node--state-territory.html.twig
@@ -41,17 +41,17 @@
 {# State content with fallbacks. #}
 {# Get default state display content from the block type. #}
 {% set state_display_content = drupal_entity('block_content', 23) | children %}
-{% set registration_not_needed = state_display_content.field_registration_not_needed.0 | default([]) | merge(content.field_registration_not_needed.0 | default([])) %}
-{% set online_registration = state_display_content.field_online_registration.0 | default([]) | merge(content.field_online_registration.0 | default([])) %}
-{% set military_overseas_registration = state_display_content.field_military_and_overseas_regi.0 | default([]) | merge(content.field_military_and_overseas_regi.0 | default([])) %}
-{% set mail_registration = state_display_content.field_mail_registration.0 | default([]) | merge(content.field_mail_registration.0 | default([])) %}
-{% set no_mail_registration = state_display_content.field_no_mail_registration.0 | default([]) | merge(content.field_no_mail_registration.0 | default([])) %}
-{% set nvrf_details = state_display_content.field_nvrf_details.0 | default([]) | merge(content.field_nvrf_details.0 | default([])) %}
-{% set inperson_registration = state_display_content.field_in_person_registration.0 | default([]) | merge(content.field_in_person_registration.0 | default([])) %}
-{% set check_registration = state_display_content.field_check_registration.0 | default([]) | merge(content.field_check_registration.0 | default([])) %}
-{% set election_date = state_display_content.field_election_date.0 | default([]) | merge(content.field_election_date.0 | default([])) %}
-{% set election_text = state_display_content.field_election_text.0 | default([]) | merge(content.field_election_text.0 | default([])) %}
-{% set no_online_registration = state_display_content.field_no_online_registration.0 | default([]) | merge(content.field_no_online_registration.0 | default([])) %}
+{% set registration_not_needed = content.field_registration_not_needed.0 | default(state_display_content.field_registration_not_needed.0) %}
+{% set online_registration = content.field_online_registration.0 | default(state_display_content.field_online_registration.0) %}
+{% set military_overseas_registration = content.field_military_and_overseas_regi.0 | default(state_display_content.field_military_and_overseas_regi.0) %}
+{% set mail_registration = content.field_mail_registration.0 | default(state_display_content.field_mail_registration.0) %}
+{% set no_mail_registration = content.field_no_mail_registration.0 | default(state_display_content.field_no_mail_registration.0) %}
+{% set nvrf_details = content.field_nvrf_details.0 | default(state_display_content.field_nvrf_details.0) %}
+{% set inperson_registration = content.field_in_person_registration.0 | default(state_display_content.field_in_person_registration.0) %}
+{% set check_registration = content.field_check_registration.0 | default(state_display_content.field_check_registration.0) %}
+{% set election_date = content.field_election_date.0 | default(state_display_content.field_election_date.0) %}
+{% set election_text = content.field_election_text.0 | default(state_display_content.field_election_text.0) %}
+{% set no_online_registration = content.field_no_online_registration.0 | default(state_display_content.field_no_online_registration.0) %}
 
 {# Registration types #}
 {% set registration_types = content.field_registration_type | field_value | column('#markup') %}


### PR DESCRIPTION
This will ensure an empty override is treated as a value when other values are set.

<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

https://cm-jira.usa.gov/browse/VOTE-3094

## Description

Overrides should be handled by block, not per field. When one override field in a block is set, all fields use the override values, even it empty.
To accomplish this, I removed the merge function.

## Deployment and testing

### Post-deploy steps

1. lando retune

### QA/Testing instructions

1. Visit the Alabama page and confirm all the default state content displays.
2. Edit the Alabama page and set all the override fields. 
3. Confirm the override values display on the page.
4. Edit the Alabama page and delete one field value per registration type (a mix of headings, content, and link text)
5. Confirm that for each override field value deleted, no default content displays.

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been included above.
- [ ] No merge conflicts exist with the target branch.
- [ ] Automated tests have passed on this PR.
- [ ] A reviewer has been designated.
- [ ] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
