### PR TITLE
Vote-3156: Update Heading Placeholder for Not-Needed

### DIFF
--- a/web/themes/custom/votegov/templates/node/node--state-territory--not-needed.html.twig
+++ b/web/themes/custom/votegov/templates/node/node--state-territory--not-needed.html.twig
@@ -20,9 +20,11 @@
 		{% endif %}
 		{# setting body text to have palceholder for both state name and link #}
 		{% set body = registration_not_needed.text['#markup']| t({'@state_name': title_english, '@link': {'#markup': link_markup } | render}) %}
+    {# setting heading text to have palceholder for state name #}
+    {% set heading = registration_not_needed.heading['#markup']| t({'@state_name': title_english | render}) %}
 
 		{% include '@votegov/component/info-card.html.twig' with {
-          'heading': registration_not_needed.heading,
+          'heading': heading,
           'body': body,
       } %}
 


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[Vote-3156](https://cm-jira.usa.gov/browse/VOTE-3156)

## Description

Address bug with heading for the not-needed template rendering `@state_name` and not the true state name

Screen shot of before and after 

<img width="1511" alt="Screenshot 2024-11-20 at 4 52 34 PM" src="https://github.com/user-attachments/assets/c3000056-2b30-4ff2-bb63-c2e385ff6a1e">


## Deployment and testing

### Post-deploy steps

1. run `lando retune` also cd into `votegov` theme and run npm run build

### QA/Testing instructions

1. visit `North Dakota` and verify that the info card is rendering `North Dakota` and not `@state_name`

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
