### PR TITLE
VOTE 3157 Add render filter to the state mail deadline

### DIFF
--- a/web/themes/custom/votegov/templates/node/node--state-territory.html.twig
+++ b/web/themes/custom/votegov/templates/node/node--state-territory.html.twig
@@ -25,14 +25,14 @@
 {% if content.field_mail_postmarked_deadline | render %}
   {% set postmarked_deadline = 'Must be postmarked by @date' | t({'@date': content.field_mail_postmarked_deadline.0 | render}) %}
 {% else %}
-  {% set postmarked_deadline = content.field_g_mail_postmarked_deadline | field_value %}
+  {% set postmarked_deadline = content.field_g_mail_postmarked_deadline | field_value | render %}
 {% endif %}
 
 {# Set received deadline with fallback #}
 {% if content.field_mail_received_deadline | render %}
   {% set received_deadline = 'Must be received by @date' | t({'@date': content.field_mail_received_deadline.0 | render}) %}
 {% else %}
-  {% set received_deadline = content.field_g_mail_received_deadline | field_value %}
+  {% set received_deadline = content.field_g_mail_received_deadline | field_value | render %}
 {% endif %}
 
 {# Set the deadline with fallback, prioritizing postmarked deadline. #}
@@ -176,7 +176,7 @@
 
   {% include '@votegov/component/info-card.html.twig' with {
     'heading': mail_registration.heading,
-    'body': mail_body | render | t({'@state_mail_deadline': bymail_deadline | render ,'@state_name': title_english}),
+    'body': mail_body | render | trim | t({'@state_mail_deadline': bymail_deadline,'@state_name': title_english}),
     'footer': mail_footer
   } %}
 {# No mail registration content #}

--- a/web/themes/custom/votegov/templates/node/node--state-territory.html.twig
+++ b/web/themes/custom/votegov/templates/node/node--state-territory.html.twig
@@ -114,7 +114,7 @@
       } %}
     {% endif %}
 
-     {# Election Date #}
+    {# Election Date #}
     {% if (election_date is not empty) and (election_text is not empty) %}
       {% set election_date_text = election_text['#text'] | t({'@date': election_date | render }) %}
       <div class="vote-date--election">{{ election_date_text }}</div>
@@ -176,7 +176,7 @@
 
   {% include '@votegov/component/info-card.html.twig' with {
     'heading': mail_registration.heading,
-    'body': mail_body | render | trim | t({'@state_mail_deadline': bymail_deadline ,'@state_name': title_english}),
+    'body': mail_body | render | t({'@state_mail_deadline': bymail_deadline | render ,'@state_name': title_english}),
     'footer': mail_footer
   } %}
 {# No mail registration content #}


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket
https://cm-jira.usa.gov/browse/VOTE-3157

## Description

A render error appeared after updating the latest db (11-21-2024). Last sprints the dates were reverted to be the general deadlines. 
I added a missing render filter to the general mail deadline variables.

## Deployment and testing

### Post-deploy steps

1. lando db-import drupal_2024-11-21.sql
2. lando retune

### QA/Testing instructions

1. Visit http://vote-gov.lndo.site/register/alabama and confirm the general mail deadline renders correctly for both English and Spanish.
2. Edit the Alabama data to use a specific date for the mail dealine.
3. Confirm the specific mail deadline renders correctly.
4. Visit http://vote-gov.lndo.site/register/american-samoa and confirm that the mail deadline does not display.

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
