### PR TITLE
Vote-3142: Remove when:always flag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,6 @@ jobs:
             cd testing
             npm install
             npm run cy:pipeline:axe
-          when: always
       - run:
           name: "Cypress - axe tests - rerun"
           command: |
@@ -280,7 +279,6 @@ jobs:
             cd testing
             npm install
             npm run cy:pipeline:proofer
-          when: always
       - run:
           name: "Cypress External Links - rerun"
           command: |


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[Vote-3142](https://cm-jira.usa.gov/browse/VOTE-3142)

## Description

Removing the `when:always` flag from the config.yml file.. according to [CircleCi Docs](https://circleci.com/docs/configuration-reference/#the-when-step) there is no need for an always flag since it will run no matter what unless you need to set a time. Such as on fail or something else. 

## Deployment and testing

### Post-deploy steps

n/a

### QA/Testing instructions

1. Review file and ensure there are no `when:always` flags present

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
