### PR TITLE
Vote-3101: Hiding non-translatable fields in block types

### DIFF
--- a/config/sync/language.content_settings.block_content.basic.yml
+++ b/config/sync/language.content_settings.block_content.basic.yml
@@ -10,7 +10,7 @@ third_party_settings:
   content_translation:
     enabled: true
     bundle_settings:
-      untranslatable_fields_hide: '0'
+      untranslatable_fields_hide: '1'
 id: block_content.basic
 target_entity_type_id: block_content
 target_bundle: basic

--- a/config/sync/language.content_settings.block_content.contact_identifier.yml
+++ b/config/sync/language.content_settings.block_content.contact_identifier.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '1'
 id: block_content.contact_identifier
 target_entity_type_id: block_content
 target_bundle: contact_identifier

--- a/config/sync/language.content_settings.block_content.email_signup.yml
+++ b/config/sync/language.content_settings.block_content.email_signup.yml
@@ -10,7 +10,7 @@ third_party_settings:
   content_translation:
     enabled: true
     bundle_settings:
-      untranslatable_fields_hide: '0'
+      untranslatable_fields_hide: '1'
 id: block_content.email_signup
 target_entity_type_id: block_content
 target_bundle: email_signup

--- a/config/sync/language.content_settings.block_content.government_banner.yml
+++ b/config/sync/language.content_settings.block_content.government_banner.yml
@@ -10,7 +10,7 @@ third_party_settings:
   content_translation:
     enabled: true
     bundle_settings:
-      untranslatable_fields_hide: '0'
+      untranslatable_fields_hide: '1'
 id: block_content.government_banner
 target_entity_type_id: block_content
 target_bundle: government_banner

--- a/config/sync/language.content_settings.block_content.inline_alert.yml
+++ b/config/sync/language.content_settings.block_content.inline_alert.yml
@@ -10,7 +10,7 @@ third_party_settings:
   content_translation:
     enabled: true
     bundle_settings:
-      untranslatable_fields_hide: '0'
+      untranslatable_fields_hide: '1'
 id: block_content.inline_alert
 target_entity_type_id: block_content
 target_bundle: inline_alert

--- a/config/sync/language.content_settings.block_content.nvrf_a_b_message.yml
+++ b/config/sync/language.content_settings.block_content.nvrf_a_b_message.yml
@@ -10,7 +10,7 @@ third_party_settings:
   content_translation:
     enabled: true
     bundle_settings:
-      untranslatable_fields_hide: '0'
+      untranslatable_fields_hide: '1'
 id: block_content.nvrf_a_b_message
 target_entity_type_id: block_content
 target_bundle: nvrf_a_b_message

--- a/config/sync/language.content_settings.block_content.nvrf_card.yml
+++ b/config/sync/language.content_settings.block_content.nvrf_card.yml
@@ -10,7 +10,7 @@ third_party_settings:
   content_translation:
     enabled: true
     bundle_settings:
-      untranslatable_fields_hide: '0'
+      untranslatable_fields_hide: '1'
 id: block_content.nvrf_card
 target_entity_type_id: block_content
 target_bundle: nvrf_card

--- a/config/sync/language.content_settings.block_content.partnership.yml
+++ b/config/sync/language.content_settings.block_content.partnership.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '1'
 id: block_content.partnership
 target_entity_type_id: block_content
 target_bundle: partnership

--- a/config/sync/language.content_settings.block_content.registration_form_selector.yml
+++ b/config/sync/language.content_settings.block_content.registration_form_selector.yml
@@ -10,7 +10,7 @@ third_party_settings:
   content_translation:
     enabled: true
     bundle_settings:
-      untranslatable_fields_hide: '0'
+      untranslatable_fields_hide: '1'
 id: block_content.registration_form_selector
 target_entity_type_id: block_content
 target_bundle: registration_form_selector

--- a/config/sync/language.content_settings.block_content.search.yml
+++ b/config/sync/language.content_settings.block_content.search.yml
@@ -10,7 +10,7 @@ third_party_settings:
   content_translation:
     enabled: true
     bundle_settings:
-      untranslatable_fields_hide: '0'
+      untranslatable_fields_hide: '1'
 id: block_content.search
 target_entity_type_id: block_content
 target_bundle: search

--- a/config/sync/language.content_settings.block_content.sitewide_alert.yml
+++ b/config/sync/language.content_settings.block_content.sitewide_alert.yml
@@ -10,7 +10,7 @@ third_party_settings:
   content_translation:
     enabled: true
     bundle_settings:
-      untranslatable_fields_hide: '0'
+      untranslatable_fields_hide: '1'
 id: block_content.sitewide_alert
 target_entity_type_id: block_content
 target_bundle: sitewide_alert

--- a/config/sync/language.content_settings.block_content.state_display_content.yml
+++ b/config/sync/language.content_settings.block_content.state_display_content.yml
@@ -10,7 +10,7 @@ third_party_settings:
   content_translation:
     enabled: true
     bundle_settings:
-      untranslatable_fields_hide: '0'
+      untranslatable_fields_hide: '1'
 id: block_content.state_display_content
 target_entity_type_id: block_content
 target_bundle: state_display_content


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[Vote-3101](https://cm-jira.usa.gov/browse/VOTE-3101)

## Description

Enabled `Hide non translatable fields` for block types. 


## Deployment and testing

### Post-deploy steps

1 run `lando retune`

### QA/Testing instructions

1. Create a test block type for the following blocks and verify that when translated those fields are not available to the edited


- Basic block - classes 
- ab message - message id and touch points id
- Partnership - each logo
- Form selector - form link 
- Site alert - alert type
- State display - date

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
