### PR TITLE
VOTE-3173: change download link for CF CLI to adjust for upstream change

### DIFF
--- a/scripts/pipeline/deb-cf-install.sh
+++ b/scripts/pipeline/deb-cf-install.sh
@@ -2,7 +2,7 @@
 
 echo "Installing CloudFoundry repository..."
 {
-  curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=v8&source=github" | tar -zx
+  curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=8.8.3&source=github-rel" | tar -zx
   if [ "$(whoami)" != "root" ]; then
     sudo mv cf cf8 /usr/local/bin
   else


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[VOTE-3173)](https://cm-jira.usa.gov/browse/VOTE-3173)

## Description

The CF CLI package URI changed and cannot be downloaded as previously done. Change the URI to one that can be downloaded.

## Deployment and testing

### QA/Testing instructions

1. Ensure the pipeline can install CF CLI.

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
