### PR TITLE
VOTE-3184 replace legacy % placeholders with @

### DIFF
--- a/web/themes/custom/votegov/templates/block/block-content--email-signup.html.twig
+++ b/web/themes/custom/votegov/templates/block/block-content--email-signup.html.twig
@@ -13,7 +13,7 @@
   {{ title_prefix }}
   {{ title_suffix }}
    <h2 class="usa-sign-up__heading">
-      {{ content.field_heading | field_value | render | replace({'%USAGov%': 'USAGov'}) | raw}}
+      {{ content.field_heading | field_value }}
   </h2>
   <form class="usa-form" target="_blank" action="{{ content.field_link | field_value }}" method="get">
     <label class="usa-label" for="email" id="emailsub">

--- a/web/themes/custom/votegov/templates/block/block-content--government-banner.html.twig
+++ b/web/themes/custom/votegov/templates/block/block-content--government-banner.html.twig
@@ -46,7 +46,7 @@
             <p>
               <strong>{{ content.field_gov_heading | field_value }}</strong>
               <br>
-              {{ content.field_gov_text | field_value | render | replace({'%.gov%': '<strong>.gov</strong>'}) | raw }}
+              {{ content.field_gov_text | field_value | render | replace({'@gov': '<strong>.gov</strong>'}) | raw }}
             </p>
           </div>
         </div>
@@ -63,8 +63,8 @@
                     </path>
                   </svg></span>)' %}
               {{ content.field_https_text | field_value | render | replace({
-                '%lock_icon%': lock_icon,
-                '%https%': '<strong>https://</strong>'
+                '@lock_icon': lock_icon,
+                '@https': '<strong>https://</strong>'
               }) | raw }}
             </p>
           </div>


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

https://cm-jira.usa.gov/browse/VOTE-3184

## Description

Update % placeholders to use @ for consistency. This will require updating the content in the CMS as a post-deploy step.

## Deployment and testing

### Post-deploy steps

1. `lando drush cr`

### QA/Testing instructions

1. visit http://vote-gov.lndo.site/ and expand the government banner and see the % placeholders
2. edit the block http://vote-gov.lndo.site/admin/content/block/1 and replace %.gov% with @gov, replace %lock_icon% with @lock_icon and %https% with @https then save the block.
3. revisit http://vote-gov.lndo.site/ and expand the government banner and confirm the placeholders are being replaced correctly.

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been included above.
- [ ] No merge conflicts exist with the target branch.
- [ ] Automated tests have passed on this PR.
- [ ] A reviewer has been designated.
- [ ] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
