### PR TITLE
Vote-3185: Yupik Text Fix

### DIFF
--- a/web/themes/custom/votegov/src/sass/uswds-overrides/usa-card.scss
+++ b/web/themes/custom/votegov/src/sass/uswds-overrides/usa-card.scss
@@ -136,6 +136,7 @@
   }
 
   .vote-feature-card__content {
+    word-break: break-word;
     @include at-media-max('tablet-lg') {
       @include grid-col('auto');
     }


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[Vote-3185](https://cm-jira.usa.gov/browse/VOTE-3185)

## Description

Addressing bug with Yupik text running past the container 

<img width="1465" alt="Screenshot 2024-12-09 at 2 57 52 PM" src="https://github.com/user-attachments/assets/a3b219b3-4989-486f-ad38-03a999c8f941">


<img width="1504" alt="Screenshot 2024-12-09 at 2 57 40 PM" src="https://github.com/user-attachments/assets/d50c9433-ec18-4598-a673-b6fe63c842e8">


## Deployment and testing

### Post-deploy steps

1. cd into the `votegov` theme and run `npm run build`

### QA/Testing instructions

1. visit home page and change to Yupik translation and verify that test is no longer running past the card. 
2. spot check other translation to check for any regressions 

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
