### PR TITLE
HOTFIX: Remove copying of theme's fonts directory in upkeep script.

### DIFF
--- a/scripts/upkeep
+++ b/scripts/upkeep
@@ -91,7 +91,6 @@ echo "Adding Vote.gov custom theme assets..."
 echo "**************************************************"
 mkdir -p ${html_path}/themes/custom/votegov
 cp -rfp ${app_path}/web/themes/custom/votegov/dist ${html_path}/themes/custom/votegov/
-cp -rfp ${app_path}/web/themes/custom/votegov/fonts ${html_path}/themes/custom/votegov/
 cp -rfp ${app_path}/web/themes/custom/votegov/img ${html_path}/themes/custom/votegov/
 cp -rfp ${app_path}/web/themes/custom/votegov/json ${html_path}/themes/custom/votegov/
 echo "Adding Vote.gov custom theme assets...completed!"


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

n/a

## Description

Remove from the upkeep script the command to copy the votegov theme fonts directory which no longer exists

## Deployment and testing

### Post-deploy steps

n/a

### QA/Testing instructions

1. Should not see any errors in cloud.gov logs indicating that the fonts directory was not found.

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been included above.
- [ ] No merge conflicts exist with the target branch.
- [ ] Automated tests have passed on this PR.
- [ ] A reviewer has been designated.
- [ ] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
