### PR TITLE
Vote-3138: Set up inpage nav to not show for non latin translations

### DIFF
--- a/web/themes/custom/votegov/templates/layout/page--node--voter-guide.html.twig
+++ b/web/themes/custom/votegov/templates/layout/page--node--voter-guide.html.twig
@@ -1,5 +1,6 @@
 {% extends "page.html.twig" %}
 {% set title = drupal_title() %}
+{% set excludedLanguages = ['ar', 'am', 'bn', 'zh-hans', 'zh', 'hi', 'ja', 'km', 'ru'] %}
 
 {% block main %}
   <main role="main" id="main-content">
@@ -9,7 +10,8 @@
       'media': drupal_field('field_media', 'node', node.id(), {type: 'media_thumbnail', settings: {image_style: 'scaled_lg' }}) | field_value,
       'variant': 'dark'
     } %}
-    <div class="vote-main-content-row vote-block-margin-y--narrow grid-container usa-in-page-nav-container">
+    <div class="vote-main-content-row vote-block-margin-y--narrow grid-container {% if language not in excludedLanguages %} usa-in-page-nav-container {% endif %}">
+{% if language not in excludedLanguages %}
       <aside
         class="usa-in-page-nav"
         data-main-content-selector=".usa-in-page-nav-container"
@@ -19,6 +21,7 @@
         data-root-margin="48px 0px -90% 0px"
         data-threshold="1"
       ></aside>
+      {% endif %}
       <div class="vote-page-content vote-page-content--alt">
         {{ page.content }}
       </div>


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[Vote-3138](https://cm-jira.usa.gov/browse/VOTE-3138)

## Description

This PR will hide the inpage nav for languages that use non latin characters to address the bug with no linking to headings 

## Deployment and testing

### Post-deploy steps

- `lando retune`

### QA/Testing instructions

1. visit a voter guide and switch between the various translation and ensure that the in page nav is hiding for the intended translations and is present and still working for the translations that use latin characters

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
