### PR TITLE
VOTE-2992: set COMPOSER_NO_DEV=1 to skip development package installs in all cloud envs

### DIFF
--- a/scripts/pipeline/exports.sh
+++ b/scripts/pipeline/exports.sh
@@ -36,7 +36,6 @@ elif [ "${cf_env}" == "test" ]; then
   export sso_assertion_key=${test_sso_assertion_key}
   export waf_name=${test_waf_name}
   export waf_external_endpoint=${test_waf_external_endpoint}
-  export composer_no_dev=0
 elif [ "${cf_env}" == "dev" ]; then
   export cf_space=${dev_cf_space}
   export cms_uri=${dev_cms_uri}
@@ -48,5 +47,4 @@ elif [ "${cf_env}" == "dev" ]; then
   export sso_assertion_key=${dev_sso_assertion_key}
   export waf_name=${dev_waf_name}
   export waf_external_endpoint=${dev_waf_external_endpoint}
-  export composer_no_dev=0
 fi


### PR DESCRIPTION


<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[VOTE-2992](https://cm-jira.usa.gov/browse/VOTE-2992)

## Description

Skip install of development packages by composer in every cloud env. Previously only enabled for test and dev.

## Deployment and testing

### QA/Testing instructions

1. Allow deployment pipeline to run.
2. Check installed modules to ensure no development packages were installed in dev and test.

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
