### PR TITLE
VOTE-3138 add external class to state pdf link

### DIFF
--- a/web/themes/custom/votegov/templates/node/node--state-territory.html.twig
+++ b/web/themes/custom/votegov/templates/node/node--state-territory.html.twig
@@ -203,7 +203,9 @@
     {{ mail_registration.text }}
 
     {% if state_mail_pdf_link and mail_registration.link_text %}
-      <p>{{ link(mail_registration.link_text, state_mail_pdf_link, create_attribute().setAttribute('data-state-ext', 'state-mail-registration')) }}</p>
+      <p>{{ link(mail_registration.link_text, state_mail_pdf_link, create_attribute()
+            .setAttribute('data-state-ext', 'state-mail-registration')
+            .addClass('usa-link--external')) }}</p>
     {% endif %}
   {% endset %}
 


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

https://cm-jira.usa.gov/browse/VOTE-3183

## Description

Force state PDFs to open in a new tab. Added the usa--external-link class to the link in TWIG since the script doesn't target the dynamic links.

## Deployment and testing

### Post-deploy steps

1. lando retune

### QA/Testing instructions

1. Visit http://vote-gov.lndo.site/register/montana and confirm the PDF download opens in a new tab. (NOTE: depending on browser settings, you may see an allow pop-up first)

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been included above.
- [ ] No merge conflicts exist with the target branch.
- [ ] Automated tests have passed on this PR.
- [ ] A reviewer has been designated.
- [ ] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
