### PR TITLE
VOTE-920 create a new block type for managing nvrf strings

### DIFF
--- a/config/sync/block_content.type.nvrf_display_content.yml
+++ b/config/sync/block_content.type.nvrf_display_content.yml
@@ -1,0 +1,8 @@
+uuid: ffd2a539-e65d-4dca-aa4e-1a97e3afd274
+langcode: en
+status: true
+dependencies: {  }
+id: nvrf_display_content
+label: 'NVRF display content'
+revision: false
+description: null

--- a/config/sync/core.entity_form_display.block_content.nvrf_display_content.default.yml
+++ b/config/sync/core.entity_form_display.block_content.nvrf_display_content.default.yml
@@ -4,19 +4,29 @@ status: true
 dependencies:
   config:
     - block_content.type.nvrf_display_content
+    - field.field.block_content.nvrf_display_content.field_confirm_group
     - field.field.block_content.nvrf_display_content.field_download_button_label
     - field.field.block_content.nvrf_display_content.field_edit_button_label
     - field.field.block_content.nvrf_display_content.field_mail_deadline_label
     - field.field.block_content.nvrf_display_content.field_not_required_label
+    - field.field.block_content.nvrf_display_content.field_nvrf_step
     - field.field.block_content.nvrf_display_content.field_print_button_label
+  module:
+    - vote_fields
 id: block_content.nvrf_display_content.default
 targetEntityType: block_content
 bundle: nvrf_display_content
 mode: default
 content:
+  field_confirm_group:
+    type: confirm_group
+    weight: 4
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_download_button_label:
     type: string_textfield
-    weight: 28
+    weight: 8
     region: content
     settings:
       size: 60
@@ -24,7 +34,7 @@ content:
     third_party_settings: {  }
   field_edit_button_label:
     type: string_textfield
-    weight: 26
+    weight: 5
     region: content
     settings:
       size: 60
@@ -32,7 +42,7 @@ content:
     third_party_settings: {  }
   field_mail_deadline_label:
     type: string_textfield
-    weight: 30
+    weight: 9
     region: content
     settings:
       size: 60
@@ -40,15 +50,21 @@ content:
     third_party_settings: {  }
   field_not_required_label:
     type: string_textfield
-    weight: 29
+    weight: 6
     region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  field_nvrf_step:
+    type: nvrf_step
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_print_button_label:
     type: string_textfield
-    weight: 27
+    weight: 7
     region: content
     settings:
       size: 60
@@ -56,7 +72,7 @@ content:
     third_party_settings: {  }
   info:
     type: string_textfield
-    weight: -5
+    weight: 0
     region: content
     settings:
       size: 60
@@ -64,13 +80,13 @@ content:
     third_party_settings: {  }
   langcode:
     type: language_select
-    weight: 2
+    weight: 1
     region: content
     settings:
       include_locked: true
     third_party_settings: {  }
   translation:
-    weight: 10
+    weight: 2
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.block_content.nvrf_display_content.default.yml
+++ b/config/sync/core.entity_form_display.block_content.nvrf_display_content.default.yml
@@ -1,0 +1,77 @@
+uuid: e4fdb2a2-9e80-4f80-903a-664fb311078e
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.nvrf_display_content
+    - field.field.block_content.nvrf_display_content.field_download_button_label
+    - field.field.block_content.nvrf_display_content.field_edit_button_label
+    - field.field.block_content.nvrf_display_content.field_mail_deadline_label
+    - field.field.block_content.nvrf_display_content.field_not_required_label
+    - field.field.block_content.nvrf_display_content.field_print_button_label
+id: block_content.nvrf_display_content.default
+targetEntityType: block_content
+bundle: nvrf_display_content
+mode: default
+content:
+  field_download_button_label:
+    type: string_textfield
+    weight: 28
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_edit_button_label:
+    type: string_textfield
+    weight: 26
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_mail_deadline_label:
+    type: string_textfield
+    weight: 30
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_not_required_label:
+    type: string_textfield
+    weight: 29
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_print_button_label:
+    type: string_textfield
+    weight: 27
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  info:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  translation:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden: {  }

--- a/config/sync/core.entity_view_display.block_content.nvrf_display_content.default.yml
+++ b/config/sync/core.entity_view_display.block_content.nvrf_display_content.default.yml
@@ -1,0 +1,58 @@
+uuid: a5c42abd-b298-4e65-b67b-f737f9fd03b9
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.nvrf_display_content
+    - field.field.block_content.nvrf_display_content.field_download_button_label
+    - field.field.block_content.nvrf_display_content.field_edit_button_label
+    - field.field.block_content.nvrf_display_content.field_mail_deadline_label
+    - field.field.block_content.nvrf_display_content.field_not_required_label
+    - field.field.block_content.nvrf_display_content.field_print_button_label
+id: block_content.nvrf_display_content.default
+targetEntityType: block_content
+bundle: nvrf_display_content
+mode: default
+content:
+  field_download_button_label:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_edit_button_label:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_mail_deadline_label:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 4
+    region: content
+  field_not_required_label:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  field_print_button_label:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  langcode: true

--- a/config/sync/core.entity_view_display.block_content.nvrf_display_content.default.yml
+++ b/config/sync/core.entity_view_display.block_content.nvrf_display_content.default.yml
@@ -4,16 +4,28 @@ status: true
 dependencies:
   config:
     - block_content.type.nvrf_display_content
+    - field.field.block_content.nvrf_display_content.field_confirm_group
     - field.field.block_content.nvrf_display_content.field_download_button_label
     - field.field.block_content.nvrf_display_content.field_edit_button_label
     - field.field.block_content.nvrf_display_content.field_mail_deadline_label
     - field.field.block_content.nvrf_display_content.field_not_required_label
+    - field.field.block_content.nvrf_display_content.field_nvrf_step
     - field.field.block_content.nvrf_display_content.field_print_button_label
+  module:
+    - vote_fields
 id: block_content.nvrf_display_content.default
 targetEntityType: block_content
 bundle: nvrf_display_content
 mode: default
 content:
+  field_confirm_group:
+    type: confirm_group_default
+    label: above
+    settings:
+      foo: bar
+    third_party_settings: {  }
+    weight: 6
+    region: content
   field_download_button_label:
     type: string
     label: above
@@ -45,6 +57,14 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     weight: 3
+    region: content
+  field_nvrf_step:
+    type: nvrf_step_default
+    label: above
+    settings:
+      foo: bar
+    third_party_settings: {  }
+    weight: 7
     region: content
   field_print_button_label:
     type: string

--- a/config/sync/field.field.block_content.nvrf_display_content.field_confirm_group.yml
+++ b/config/sync/field.field.block_content.nvrf_display_content.field_confirm_group.yml
@@ -1,0 +1,21 @@
+uuid: 6fbb0480-cbd1-42b3-abc6-1bf999366513
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.nvrf_display_content
+    - field.storage.block_content.field_confirm_group
+  module:
+    - vote_fields
+id: block_content.nvrf_display_content.field_confirm_group
+field_name: field_confirm_group
+entity_type: block_content
+bundle: nvrf_display_content
+label: 'Confirm Group'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: confirm_group

--- a/config/sync/field.field.block_content.nvrf_display_content.field_download_button_label.yml
+++ b/config/sync/field.field.block_content.nvrf_display_content.field_download_button_label.yml
@@ -1,0 +1,19 @@
+uuid: 7f1a8046-37dc-455d-9ddd-3bc96e64ebd8
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.nvrf_display_content
+    - field.storage.block_content.field_download_button_label
+id: block_content.nvrf_display_content.field_download_button_label
+field_name: field_download_button_label
+entity_type: block_content
+bundle: nvrf_display_content
+label: 'Download button label'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.block_content.nvrf_display_content.field_edit_button_label.yml
+++ b/config/sync/field.field.block_content.nvrf_display_content.field_edit_button_label.yml
@@ -1,0 +1,19 @@
+uuid: 98e5dc56-5de6-42a8-9926-b54b5a0f80bc
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.nvrf_display_content
+    - field.storage.block_content.field_edit_button_label
+id: block_content.nvrf_display_content.field_edit_button_label
+field_name: field_edit_button_label
+entity_type: block_content
+bundle: nvrf_display_content
+label: 'Edit button label'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.block_content.nvrf_display_content.field_mail_deadline_label.yml
+++ b/config/sync/field.field.block_content.nvrf_display_content.field_mail_deadline_label.yml
@@ -1,0 +1,19 @@
+uuid: 913a0670-6b4f-44df-91a4-346b2e7c2eb7
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.nvrf_display_content
+    - field.storage.block_content.field_mail_deadline_label
+id: block_content.nvrf_display_content.field_mail_deadline_label
+field_name: field_mail_deadline_label
+entity_type: block_content
+bundle: nvrf_display_content
+label: 'Mail deadline label'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.block_content.nvrf_display_content.field_not_required_label.yml
+++ b/config/sync/field.field.block_content.nvrf_display_content.field_not_required_label.yml
@@ -1,0 +1,19 @@
+uuid: 19a13a1f-4cc3-4321-b419-821824928d57
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.nvrf_display_content
+    - field.storage.block_content.field_not_required_label
+id: block_content.nvrf_display_content.field_not_required_label
+field_name: field_not_required_label
+entity_type: block_content
+bundle: nvrf_display_content
+label: 'Not required label'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.block_content.nvrf_display_content.field_nvrf_step.yml
+++ b/config/sync/field.field.block_content.nvrf_display_content.field_nvrf_step.yml
@@ -1,0 +1,21 @@
+uuid: 1eb9c66f-a6a3-479d-8b36-8dc558c506fa
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.nvrf_display_content
+    - field.storage.block_content.field_nvrf_step
+  module:
+    - vote_fields
+id: block_content.nvrf_display_content.field_nvrf_step
+field_name: field_nvrf_step
+entity_type: block_content
+bundle: nvrf_display_content
+label: 'NVRF step'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: nvrf_step

--- a/config/sync/field.field.block_content.nvrf_display_content.field_print_button_label.yml
+++ b/config/sync/field.field.block_content.nvrf_display_content.field_print_button_label.yml
@@ -1,0 +1,19 @@
+uuid: 173804cc-596d-48e5-b480-f57a4d32d9a0
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.nvrf_display_content
+    - field.storage.block_content.field_print_button_label
+id: block_content.nvrf_display_content.field_print_button_label
+field_name: field_print_button_label
+entity_type: block_content
+bundle: nvrf_display_content
+label: 'Print button label'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.storage.block_content.field_confirm_group.yml
+++ b/config/sync/field.storage.block_content.field_confirm_group.yml
@@ -1,0 +1,19 @@
+uuid: 6795f49c-b476-4780-8091-0369dd3de5ad
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - vote_fields
+id: block_content.field_confirm_group
+field_name: field_confirm_group
+entity_type: block_content
+type: confirm_group
+settings: {  }
+module: vote_fields
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.block_content.field_download_button_label.yml
+++ b/config/sync/field.storage.block_content.field_download_button_label.yml
@@ -1,0 +1,21 @@
+uuid: 97cc1197-0c35-4f78-8996-4c5bbc73af6b
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+id: block_content.field_download_button_label
+field_name: field_download_button_label
+entity_type: block_content
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.block_content.field_edit_button_label.yml
+++ b/config/sync/field.storage.block_content.field_edit_button_label.yml
@@ -1,0 +1,21 @@
+uuid: 678bc603-1155-470d-919c-c7a324d6312e
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+id: block_content.field_edit_button_label
+field_name: field_edit_button_label
+entity_type: block_content
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.block_content.field_mail_deadline_label.yml
+++ b/config/sync/field.storage.block_content.field_mail_deadline_label.yml
@@ -1,0 +1,21 @@
+uuid: 469e5f64-450f-4f9d-8e5d-5456f28f8dfa
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+id: block_content.field_mail_deadline_label
+field_name: field_mail_deadline_label
+entity_type: block_content
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.block_content.field_not_required_label.yml
+++ b/config/sync/field.storage.block_content.field_not_required_label.yml
@@ -1,0 +1,21 @@
+uuid: 8f00fd1d-3dde-424a-a1a4-924ed9b78519
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+id: block_content.field_not_required_label
+field_name: field_not_required_label
+entity_type: block_content
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.block_content.field_nvrf_step.yml
+++ b/config/sync/field.storage.block_content.field_nvrf_step.yml
@@ -1,0 +1,19 @@
+uuid: 1cb160d5-60f2-47b7-ad59-4fe54880ce96
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - vote_fields
+id: block_content.field_nvrf_step
+field_name: field_nvrf_step
+entity_type: block_content
+type: nvrf_step
+settings: {  }
+module: vote_fields
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.block_content.field_print_button_label.yml
+++ b/config/sync/field.storage.block_content.field_print_button_label.yml
@@ -1,0 +1,21 @@
+uuid: 2cc8ed0b-e04b-40b6-bc9f-583d16da3467
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+id: block_content.field_print_button_label
+field_name: field_print_button_label
+entity_type: block_content
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/language.content_settings.block_content.nvrf_display_content.yml
+++ b/config/sync/language.content_settings.block_content.nvrf_display_content.yml
@@ -1,0 +1,16 @@
+uuid: 60389bb7-6232-4d5b-8c32-70b5322d1b3b
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.nvrf_display_content
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: block_content.nvrf_display_content
+target_entity_type_id: block_content
+target_bundle: nvrf_display_content
+default_langcode: site_default
+language_alterable: false

--- a/config/sync/views.view.nvrf_api_blocks.yml
+++ b/config/sync/views.view.nvrf_api_blocks.yml
@@ -5,19 +5,29 @@ dependencies:
   config:
     - block_content.type.nvrf_a_b_message
     - block_content.type.nvrf_card
+    - block_content.type.nvrf_display_content
     - field.storage.block_content.body
     - field.storage.block_content.field_button_label
+    - field.storage.block_content.field_confirm_group
+    - field.storage.block_content.field_download_button_label
+    - field.storage.block_content.field_edit_button_label
     - field.storage.block_content.field_heading
+    - field.storage.block_content.field_mail_deadline_label
     - field.storage.block_content.field_messager_identifier
+    - field.storage.block_content.field_not_required_label
+    - field.storage.block_content.field_nvrf_step
+    - field.storage.block_content.field_print_button_label
     - field.storage.block_content.field_touchpoints_id
     - user.role.anonymous
     - user.role.authenticated
   module:
     - block_content
     - rest
+    - rest_views
     - serialization
     - text
     - user
+    - vote_fields
 id: nvrf_api_blocks
 label: 'NVRF API Blocks'
 module: views
@@ -1461,3 +1471,743 @@ display:
         - 'config:field.storage.block_content.body'
         - 'config:field.storage.block_content.field_button_label'
         - 'config:field.storage.block_content.field_heading'
+  api_strings:
+    id: api_strings
+    display_title: 'NVRF display strings'
+    display_plugin: rest_export
+    position: 1
+    display_options:
+      fields:
+        uuid:
+          id: uuid
+          table: block_content
+          field: uuid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: block_content
+          entity_field: uuid
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        langcode:
+          id: langcode
+          table: block_content_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: block_content
+          entity_field: langcode
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: true
+            text: '{{ langcode__value }}'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: language
+          settings:
+            link_to_entity: false
+            native_language: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_nvrf_step_export:
+          id: field_nvrf_step_export
+          table: block_content__field_nvrf_step
+          field: field_nvrf_step_export
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field_export
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: step_id
+          type: nvrf_step_default
+          settings: {  }
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          field_api_classes: false
+        field_confirm_group_export:
+          id: field_confirm_group_export
+          table: block_content__field_confirm_group
+          field: field_confirm_group_export
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field_export
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: confirm_group_id
+          type: confirm_group_default
+          settings: {  }
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          field_api_classes: false
+        field_edit_button_label:
+          id: field_edit_button_label
+          table: block_content__field_edit_button_label
+          field: field_edit_button_label
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_mail_deadline_label:
+          id: field_mail_deadline_label
+          table: block_content__field_mail_deadline_label
+          field: field_mail_deadline_label
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_not_required_label:
+          id: field_not_required_label
+          table: block_content__field_not_required_label
+          field: field_not_required_label
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_print_button_label:
+          id: field_print_button_label
+          table: block_content__field_print_button_label
+          field: field_print_button_label
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_download_button_label:
+          id: field_download_button_label
+          table: block_content__field_download_button_label
+          field: field_download_button_label
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 1
+      arguments: {  }
+      filters:
+        status:
+          id: status
+          table: block_content_field_data
+          field: status
+          entity_type: block_content
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+        type:
+          id: type
+          table: block_content_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: block_content
+          entity_field: type
+          plugin_id: bundle
+          operator: in
+          value:
+            nvrf_display_content: nvrf_display_content
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        langcode:
+          id: langcode
+          table: block_content_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: block_content
+          entity_field: langcode
+          plugin_id: language
+          operator: in
+          value:
+            '***LANGUAGE_language_interface***': '***LANGUAGE_language_interface***'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: serializer
+        options:
+          formats:
+            json: json
+      row:
+        type: data_field
+        options:
+          field_options:
+            uuid:
+              alias: ''
+              raw_output: false
+            langcode:
+              alias: lang
+              raw_output: false
+            field_nvrf_step_export:
+              alias: step
+              raw_output: false
+            field_confirm_group_export:
+              alias: confirm_group
+              raw_output: false
+            field_edit_button_label:
+              alias: edit_button_label
+              raw_output: false
+            field_mail_deadline_label:
+              alias: mail_deadline_label
+              raw_output: false
+            field_not_required_label:
+              alias: not_required_label
+              raw_output: false
+            field_print_button_label:
+              alias: print_button_label
+              raw_output: false
+            field_download_button_label:
+              alias: download_button_label
+              raw_output: false
+      defaults:
+        relationships: false
+        fields: false
+        arguments: false
+        filters: false
+        filter_groups: false
+      relationships: {  }
+      display_description: ''
+      rendering_language: '***LANGUAGE_language_interface***'
+      display_extenders: {  }
+      path: nvrf/assets/strings.json
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - request_format
+        - user.roles
+      tags:
+        - 'config:field.storage.block_content.field_confirm_group'
+        - 'config:field.storage.block_content.field_download_button_label'
+        - 'config:field.storage.block_content.field_edit_button_label'
+        - 'config:field.storage.block_content.field_mail_deadline_label'
+        - 'config:field.storage.block_content.field_not_required_label'
+        - 'config:field.storage.block_content.field_nvrf_step'
+        - 'config:field.storage.block_content.field_print_button_label'

--- a/web/modules/custom/vote_fields/config/schema/vote_fields.schema.yml
+++ b/web/modules/custom/vote_fields/config/schema/vote_fields.schema.yml
@@ -29,3 +29,37 @@ field.field_settings.vote_fields_state_content:
     form_subfield_link_text_help_text:
       type: string
       label: Link text subfield help text
+
+
+# Default value.
+field.value.nvrf_step:
+  type: mapping
+  label: Nvrf step
+  mapping:
+    step_id:
+      type: string
+      label: Step Id
+    step_label:
+      type: string
+      label: Step label
+    back_button_label:
+      type: string
+      label: Back button label
+    next_button_label:
+      type: string
+      label: Next button label
+
+# Default value.
+field.value.confirm_group:
+  type: mapping
+  label: Confirm group
+  mapping:
+    confirm_group_id:
+      type: string
+      label: Confirm group Id
+    confirm_group_label:
+      type: string
+      label: Confirm group label
+    confirm_group_message:
+      type: string
+      label: Confirm group message

--- a/web/modules/custom/vote_fields/src/Plugin/Field/FieldFormatter/ConfirmGroupDefaultFormatter.php
+++ b/web/modules/custom/vote_fields/src/Plugin/Field/FieldFormatter/ConfirmGroupDefaultFormatter.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\vote_fields\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\FormatterBase;
+use Drupal\rest_views\SerializedData;
+
+/**
+ * Plugin implementation of the 'confirm_group_default' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "confirm_group_default",
+ *   label = @Translation("Default"),
+ *   field_types = {"confirm_group"},
+ * )
+ */
+final class ConfirmGroupDefaultFormatter extends FormatterBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode): array {
+    $element = [];
+
+    foreach ($items as $delta => $item) {
+
+      $data_array = [];
+
+      if ($item->confirm_group_id) {
+        $data_array['confirm_group_id'] = $item->confirm_group_id;
+      }
+
+      if ($item->confirm_group_label) {
+        $data_array['confirm_group_label'] = $item->confirm_group_label;
+      }
+
+      if ($item->confirm_group_message) {
+        $data_array['confirm_group_message'] = $item->confirm_group_message;
+      }
+
+      $element[$delta] = [
+        '#type' => 'data',
+        '#data' => SerializedData::create($data_array),
+      ];
+
+    }
+
+    return $element;
+  }
+
+}

--- a/web/modules/custom/vote_fields/src/Plugin/Field/FieldFormatter/NvrfStepDefaultFormatter.php
+++ b/web/modules/custom/vote_fields/src/Plugin/Field/FieldFormatter/NvrfStepDefaultFormatter.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\vote_fields\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\FormatterBase;
+use Drupal\rest_views\SerializedData;
+
+/**
+ * Plugin implementation of the 'nvrf_step_default' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "nvrf_step_default",
+ *   label = @Translation("Default"),
+ *   field_types = {"nvrf_step"},
+ * )
+ */
+final class NvrfStepDefaultFormatter extends FormatterBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode): array {
+    $element = [];
+
+    foreach ($items as $delta => $item) {
+
+      $data_array = [];
+
+      if ($item->step_id) {
+        $data_array['step_id'] = $item->step_id;
+      }
+
+      if ($item->step_label) {
+        $data_array['step_label'] = $item->step_label;
+      }
+
+      if ($item->back_button_label) {
+        $data_array['back_button_label'] = $item->back_button_label;
+      }
+
+      if ($item->next_button_label) {
+        $data_array['next_button_label'] = $item->next_button_label;
+      }
+
+      $element[$delta] = [
+        '#type' => 'data',
+        '#data' => SerializedData::create($data_array),
+      ];
+
+    }
+
+    return $element;
+  }
+
+}

--- a/web/modules/custom/vote_fields/src/Plugin/Field/FieldType/ConfirmGroupItem.php
+++ b/web/modules/custom/vote_fields/src/Plugin/Field/FieldType/ConfirmGroupItem.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\vote_fields\Plugin\Field\FieldType;
+
+use Drupal\Component\Utility\Random;
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Field\FieldItemBase;
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Core\TypedData\DataDefinition;
+
+/**
+ * Defines the 'confirm_group' field type.
+ *
+ * @FieldType(
+ *   id = "confirm_group",
+ *   label = @Translation("Confirm group"),
+ *   description = @Translation("Some description."),
+ *   default_widget = "confirm_group",
+ *   default_formatter = "confirm_group_default",
+ * )
+ */
+final class ConfirmGroupItem extends FieldItemBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isEmpty(): bool {
+    return $this->confirm_group_id === NULL && $this->confirm_group_label === NULL && $this->confirm_group_message === NULL;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function propertyDefinitions(FieldStorageDefinitionInterface $field_definition): array {
+
+    $properties['confirm_group_id'] = DataDefinition::create('string')
+      ->setLabel(t('Confirm group id'));
+    $properties['confirm_group_label'] = DataDefinition::create('string')
+      ->setLabel(t('Confirm group label'));
+    $properties['confirm_group_message'] = DataDefinition::create('string')
+      ->setLabel(t('Confirm group message'));
+
+    return $properties;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getConstraints(): array {
+    $constraints = parent::getConstraints();
+
+    $options['confirm_group_id']['NotBlank'] = [];
+
+    $options['confirm_group_label']['NotBlank'] = [];
+
+    $constraint_manager = \Drupal::typedDataManager()->getValidationConstraintManager();
+    $constraints[] = $constraint_manager->create('ComplexData', $options);
+    // @todo Add more constraints here.
+    return $constraints;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function schema(FieldStorageDefinitionInterface $field_definition): array {
+
+    $columns = [
+      'confirm_group_id' => [
+        'type' => 'varchar',
+        'length' => 255,
+      ],
+      'confirm_group_label' => [
+        'type' => 'varchar',
+        'length' => 255,
+      ],
+      'confirm_group_message' => [
+        'type' => 'varchar',
+        'length' => 255,
+      ],
+    ];
+
+    $schema = [
+      'columns' => $columns,
+      // @DCG Add indexes here if necessary.
+    ];
+
+    return $schema;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function generateSampleValue(FieldDefinitionInterface $field_definition): array {
+
+    $random = new Random();
+
+    $values['confirm_group_id'] = $random->word(mt_rand(1, 255));
+
+    $values['confirm_group_label'] = $random->word(mt_rand(1, 255));
+
+    $values['confirm_group_message'] = $random->word(mt_rand(1, 255));
+
+    return $values;
+  }
+
+}

--- a/web/modules/custom/vote_fields/src/Plugin/Field/FieldType/NvrfStepItem.php
+++ b/web/modules/custom/vote_fields/src/Plugin/Field/FieldType/NvrfStepItem.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\vote_fields\Plugin\Field\FieldType;
+
+use Drupal\Component\Utility\Random;
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Field\FieldItemBase;
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Core\TypedData\DataDefinition;
+
+/**
+ * Defines the 'nvrf_step' field type.
+ *
+ * @FieldType(
+ *   id = "nvrf_step",
+ *   label = @Translation("NVRF step"),
+ *   description = @Translation("Some description."),
+ *   default_widget = "nvrf_step",
+ *   default_formatter = "nvrf_step_default",
+ * )
+ */
+final class NvrfStepItem extends FieldItemBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isEmpty(): bool {
+    return $this->step_id === NULL && $this->step_label === NULL && $this->back_button_label === NULL && $this->next_button_label === NULL;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function propertyDefinitions(FieldStorageDefinitionInterface $field_definition): array {
+
+    $properties['step_id'] = DataDefinition::create('string')
+      ->setLabel(t('Step Id'));
+    $properties['step_label'] = DataDefinition::create('string')
+      ->setLabel(t('Step label'));
+    $properties['back_button_label'] = DataDefinition::create('string')
+      ->setLabel(t('Back button label'));
+    $properties['next_button_label'] = DataDefinition::create('string')
+      ->setLabel(t('Next button label'));
+
+    return $properties;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getConstraints(): array {
+    $constraints = parent::getConstraints();
+
+    $options['step_id']['NotBlank'] = [];
+
+    $constraint_manager = \Drupal::typedDataManager()->getValidationConstraintManager();
+    $constraints[] = $constraint_manager->create('ComplexData', $options);
+    // @todo Add more constraints here.
+    return $constraints;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function schema(FieldStorageDefinitionInterface $field_definition): array {
+
+    $columns = [
+      'step_id' => [
+        'type' => 'varchar',
+        'length' => 255,
+      ],
+      'step_label' => [
+        'type' => 'varchar',
+        'length' => 255,
+      ],
+      'back_button_label' => [
+        'type' => 'varchar',
+        'length' => 255,
+      ],
+      'next_button_label' => [
+        'type' => 'varchar',
+        'length' => 255,
+      ],
+    ];
+
+    $schema = [
+      'columns' => $columns,
+      // @DCG Add indexes here if necessary.
+    ];
+
+    return $schema;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function generateSampleValue(FieldDefinitionInterface $field_definition): array {
+
+    $random = new Random();
+
+    $values['step_id'] = $random->word(mt_rand(1, 255));
+
+    $values['step_label'] = $random->word(mt_rand(1, 255));
+
+    $values['back_button_label'] = $random->word(mt_rand(1, 255));
+
+    $values['next_button_label'] = $random->word(mt_rand(1, 255));
+
+    return $values;
+  }
+
+}

--- a/web/modules/custom/vote_fields/src/Plugin/Field/FieldWidget/ConfirmGroupWidget.php
+++ b/web/modules/custom/vote_fields/src/Plugin/Field/FieldWidget/ConfirmGroupWidget.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\vote_fields\Plugin\Field\FieldWidget;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\WidgetBase;
+use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\Validator\ConstraintViolationInterface;
+
+/**
+ * Defines the 'confirm_group' field widget.
+ *
+ * @FieldWidget(
+ *   id = "confirm_group",
+ *   label = @Translation("Confirm Group"),
+ *   field_types = {"confirm_group"},
+ * )
+ */
+final class ConfirmGroupWidget extends WidgetBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state): array {
+
+    $element['confirm_group_id'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Confirm group id'),
+      '#default_value' => $items[$delta]->confirm_group_id ?? NULL,
+      '#size' => 60,
+      '#description' => $this->t('This field value must be the same for all languages.'),
+    ];
+
+    $element['confirm_group_label'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Confirm group label'),
+      '#default_value' => $items[$delta]->confirm_group_label ?? NULL,
+      '#size' => 60,
+    ];
+
+    $element['confirm_group_message'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Confirm group message'),
+      '#default_value' => $items[$delta]->confirm_group_message ?? NULL,
+      '#size' => 60,
+    ];
+
+    $element['#theme_wrappers'] = ['container', 'form_element'];
+
+    return $element;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function errorElement(array $element, ConstraintViolationInterface $error, array $form, FormStateInterface $form_state): array|bool {
+    $element = parent::errorElement($element, $error, $form, $form_state);
+    if ($element === FALSE) {
+      return FALSE;
+    }
+    $error_property = explode('.', $error->getPropertyPath())[1];
+    return $element[$error_property];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function massageFormValues(array $values, array $form, FormStateInterface $form_state): array {
+    foreach ($values as $delta => $value) {
+      if ($value['confirm_group_id'] === '') {
+        $values[$delta]['confirm_group_id'] = NULL;
+      }
+      if ($value['confirm_group_label'] === '') {
+        $values[$delta]['confirm_group_label'] = NULL;
+      }
+      if ($value['confirm_group_message'] === '') {
+        $values[$delta]['confirm_group_message'] = NULL;
+      }
+    }
+    return $values;
+  }
+
+}

--- a/web/modules/custom/vote_fields/src/Plugin/Field/FieldWidget/NvrfStepWidget.php
+++ b/web/modules/custom/vote_fields/src/Plugin/Field/FieldWidget/NvrfStepWidget.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\vote_fields\Plugin\Field\FieldWidget;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\WidgetBase;
+use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\Validator\ConstraintViolationInterface;
+
+/**
+ * Defines the 'nvrf_step' field widget.
+ *
+ * @FieldWidget(
+ *   id = "nvrf_step",
+ *   label = @Translation("NVRF step"),
+ *   field_types = {"nvrf_step"},
+ * )
+ */
+final class NvrfStepWidget extends WidgetBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state): array {
+
+    $element['step_id'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Step Id'),
+      '#default_value' => $items[$delta]->step_id ?? NULL,
+      '#size' => 60,
+      '#description' => $this->t('This field value must be the same for all languages.'),
+    ];
+
+    $element['step_label'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Step label'),
+      '#default_value' => $items[$delta]->step_label ?? NULL,
+      '#size' => 60,
+    ];
+
+    $element['back_button_label'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Back button label'),
+      '#default_value' => $items[$delta]->back_button_label ?? NULL,
+      '#size' => 60,
+    ];
+
+    $element['next_button_label'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Next button label'),
+      '#default_value' => $items[$delta]->next_button_label ?? NULL,
+      '#size' => 60,
+    ];
+
+    $element['#theme_wrappers'] = ['container', 'form_element'];
+
+    return $element;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function errorElement(array $element, ConstraintViolationInterface $error, array $form, FormStateInterface $form_state): array|bool {
+    $element = parent::errorElement($element, $error, $form, $form_state);
+    if ($element === FALSE) {
+      return FALSE;
+    }
+    $error_property = explode('.', $error->getPropertyPath())[1];
+    return $element[$error_property];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function massageFormValues(array $values, array $form, FormStateInterface $form_state): array {
+    foreach ($values as $delta => $value) {
+      if ($value['step_id'] === '') {
+        $values[$delta]['step_id'] = NULL;
+      }
+      if ($value['step_label'] === '') {
+        $values[$delta]['step_label'] = NULL;
+      }
+      if ($value['back_button_label'] === '') {
+        $values[$delta]['back_button_label'] = NULL;
+      }
+      if ($value['next_button_label'] === '') {
+        $values[$delta]['next_button_label'] = NULL;
+      }
+    }
+    return $values;
+  }
+
+}


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

https://cm-jira.usa.gov/browse/VOTE-920

## Description

Create a new block type for managing nvrf strings

## Deployment and testing

### Post-deploy steps

1. `lando retune`

### QA/Testing instructions

1. visit http://vote-gov.lndo.site/block/add/nvrf_display_content and add new block type content instance
2. translate the new block into Spanish and change some values but NOT the id fields
3. visit http://vote-gov.lndo.site/nvrf/assets/strings.json and confirm the english content is exposed
4. visit http://vote-gov.lndo.site/es/nvrf/assets/strings.json and confirm the spanish content is exposed

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
