### PR TITLE
VOTE-3337 Add new subfields to nvrf_step field type

### DIFF
--- a/web/modules/custom/vote_fields/config/schema/vote_fields.schema.yml
+++ b/web/modules/custom/vote_fields/config/schema/vote_fields.schema.yml
@@ -48,6 +48,12 @@ field.value.nvrf_step:
     next_button_label:
       type: string
       label: Next button label
+    step_aria_label:
+      type: string
+      label: Step indicator aria label
+    edit_aria_label:
+      type: string
+      label: Edit button aria label
 
 # Default value.
 field.value.confirm_group:

--- a/web/modules/custom/vote_fields/src/Plugin/Field/FieldFormatter/NvrfStepDefaultFormatter.php
+++ b/web/modules/custom/vote_fields/src/Plugin/Field/FieldFormatter/NvrfStepDefaultFormatter.php
@@ -45,6 +45,14 @@ final class NvrfStepDefaultFormatter extends FormatterBase {
         $data_array['next_button_label'] = $item->next_button_label;
       }
 
+      if ($item->step_aria_label) {
+        $data_array['step_aria_label'] = $item->step_aria_label;
+      }
+
+      if ($item->edit_aria_label) {
+        $data_array['edit_aria_label'] = $item->edit_aria_label;
+      }
+
       $element[$delta] = [
         '#type' => 'data',
         '#data' => SerializedData::create($data_array),

--- a/web/modules/custom/vote_fields/src/Plugin/Field/FieldType/NvrfStepItem.php
+++ b/web/modules/custom/vote_fields/src/Plugin/Field/FieldType/NvrfStepItem.php
@@ -27,7 +27,7 @@ final class NvrfStepItem extends FieldItemBase {
    * {@inheritdoc}
    */
   public function isEmpty(): bool {
-    return $this->step_id === NULL && $this->step_label === NULL && $this->back_button_label === NULL && $this->next_button_label === NULL;
+    return $this->step_id === NULL && $this->step_label === NULL && $this->back_button_label === NULL && $this->next_button_label === NULL && $this->step_aria_label === NULL && $this->edit_aria_label === NULL;
   }
 
   /**
@@ -43,6 +43,10 @@ final class NvrfStepItem extends FieldItemBase {
       ->setLabel(t('Back button label'));
     $properties['next_button_label'] = DataDefinition::create('string')
       ->setLabel(t('Next button label'));
+    $properties['step_aria_label'] = DataDefinition::create('string')
+      ->setLabel(t('Step indicator aria label'));
+    $properties['edit_aria_label'] = DataDefinition::create('string')
+      ->setLabel(t('Edit button aria label'));
 
     return $properties;
   }
@@ -83,6 +87,14 @@ final class NvrfStepItem extends FieldItemBase {
         'type' => 'varchar',
         'length' => 255,
       ],
+      'step_aria_label' => [
+        'type' => 'varchar',
+        'length' => 255,
+      ],
+      'edit_aria_label' => [
+        'type' => 'varchar',
+        'length' => 255,
+      ],
     ];
 
     $schema = [
@@ -107,6 +119,10 @@ final class NvrfStepItem extends FieldItemBase {
     $values['back_button_label'] = $random->word(mt_rand(1, 255));
 
     $values['next_button_label'] = $random->word(mt_rand(1, 255));
+
+    $values['step_aria_label'] = $random->word(mt_rand(1, 255));
+
+    $values['edit_aria_label'] = $random->word(mt_rand(1, 255));
 
     return $values;
   }

--- a/web/modules/custom/vote_fields/src/Plugin/Field/FieldWidget/NvrfStepWidget.php
+++ b/web/modules/custom/vote_fields/src/Plugin/Field/FieldWidget/NvrfStepWidget.php
@@ -54,6 +54,20 @@ final class NvrfStepWidget extends WidgetBase {
       '#size' => 60,
     ];
 
+    $element['step_aria_label'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Step indicator aria label'),
+      '#default_value' => $items[$delta]->step_aria_label ?? NULL,
+      '#size' => 60,
+    ];
+
+    $element['edit_aria_label'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Edit button aria label'),
+      '#default_value' => $items[$delta]->edit_aria_label ?? NULL,
+      '#size' => 60,
+    ];
+
     $element['#theme_wrappers'] = ['container', 'form_element'];
 
     return $element;
@@ -87,6 +101,12 @@ final class NvrfStepWidget extends WidgetBase {
       }
       if ($value['next_button_label'] === '') {
         $values[$delta]['next_button_label'] = NULL;
+      }
+      if ($value['step_aria_label'] === '') {
+        $values[$delta]['step_aria_label'] = NULL;
+      }
+      if ($value['edit_aria_label'] === '') {
+        $values[$delta]['edit_aria_label'] = NULL;
       }
     }
     return $values;

--- a/web/modules/custom/vote_fields/vote_fields.install
+++ b/web/modules/custom/vote_fields/vote_fields.install
@@ -1,0 +1,17 @@
+<?php
+
+use Drupal\Core\Database\Database;
+
+//function vote_fields_update_10001() {
+//  // Get the database connection
+//  $connection = Database::getConnection();
+//
+//  // Get the schema object
+//  $schema = $connection->schema();
+//
+//  // Define the new field
+//  $spec = [];
+//
+//  // Add the new field to the table
+//  $schema->addField('TABLE', 'FIELD', $spec);
+//}

--- a/web/modules/custom/vote_fields/vote_fields.install
+++ b/web/modules/custom/vote_fields/vote_fields.install
@@ -1,17 +1,81 @@
 <?php
 
-use Drupal\Core\Database\Database;
+/**
+ * Update tables for nvrf_step field instances with step_aria_label and
+ * edit_aria_label fields.
+ */
+function vote_fields_update_10001() {
+  $field_storage = \Drupal::entityTypeManager()->getStorage('field_storage_config');
+  // Get field instances for field type, nvrf_step.
+  $fields = $field_storage->loadByProperties([
+    'type' => 'nvrf_step',
+  ]);
 
-//function vote_fields_update_10001() {
-//  // Get the database connection
-//  $connection = Database::getConnection();
-//
-//  // Get the schema object
-//  $schema = $connection->schema();
-//
-//  // Define the new field
-//  $spec = [];
-//
-//  // Add the new field to the table
-//  $schema->addField('TABLE', 'FIELD', $spec);
-//}
+  //Loop through the field instances and update the tables that they are found in.
+  foreach ($fields as $field) {
+    $entity_type = $field->get('entity_type');
+    $field_name = $field->getName();
+
+    if ($table_name = get_field_table_name($entity_type, $field)) {
+      update_table_10001($table_name, $field_name);
+    }
+
+    if ($revision_table_name = get_field_table_name($entity_type, $field, TRUE)) {
+      update_table_10001($revision_table_name, $field_name);
+    }
+  }
+}
+
+/**
+ * Helper function to apply db table updates for update #10001.
+ */
+function update_table_10001($table_name, $field_name) {
+
+  $database = \Drupal::database();
+
+  // Check if the fields already exist before adding them.
+  $schema = $database->schema();
+  $field_name_prefix = $field_name . '_';
+
+  if ($schema->tableExists($table_name)) {
+    if (!$schema->fieldExists($table_name, $field_name_prefix . 'step_aria_label')) {
+      $schema->addField($table_name,
+        $field_name_prefix . 'step_aria_label',
+        ['type' => 'varchar',
+          'length' => 255,
+          'binary' => FALSE,
+          'not null' => FALSE,
+        ]);
+    }
+    if (!$schema->fieldExists($table_name, $field_name_prefix . 'edit_aria_label')) {
+      $schema->addField($table_name,
+      $field_name_prefix . 'edit_aria_label', [
+        'type' => 'varchar',
+        'length' => 255,
+        'binary' => FALSE,
+        'not null' => FALSE,
+      ]);
+    }
+  }
+}
+
+/**
+ * Utility function to retrieve the db field names for a given field.
+ */
+function get_field_table_name($entity_type_id, $field, $revision=FALSE) {
+  $entity_type_manager = \Drupal::entityTypeManager();
+  $storage = $entity_type_manager->getStorage($entity_type_id);
+
+  if ($storage) {
+    $table_mapping = $storage->getTableMapping();
+
+    if ($revision) {
+      return $table_mapping->getDedicatedRevisionTableName($field);
+    }
+    else {
+      return $table_mapping->getFieldTableName($field->getName());
+    }
+  }
+
+  return NULL;
+}

--- a/web/modules/custom/vote_fields/vote_fields.install
+++ b/web/modules/custom/vote_fields/vote_fields.install
@@ -6,8 +6,7 @@
  */
 
 /**
- * Update tables for nvrf_step field instances.
- * Add subfields step_aria_label and edit_aria_label.
+ * Update tables for nvrf_step field instances to add new subfields.
  */
 function vote_fields_update_10001() {
   $field_storage = \Drupal::entityTypeManager()

--- a/web/modules/custom/vote_fields/vote_fields.install
+++ b/web/modules/custom/vote_fields/vote_fields.install
@@ -1,17 +1,23 @@
 <?php
 
 /**
- * Update tables for nvrf_step field instances with step_aria_label and
- * edit_aria_label fields.
+ * @file
+ * Custom module update hooks.
+ */
+
+/**
+ * Update tables for nvrf_step field instances.
+ * Add subfields step_aria_label and edit_aria_label.
  */
 function vote_fields_update_10001() {
-  $field_storage = \Drupal::entityTypeManager()->getStorage('field_storage_config');
+  $field_storage = \Drupal::entityTypeManager()
+    ->getStorage('field_storage_config');
   // Get field instances for field type, nvrf_step.
   $fields = $field_storage->loadByProperties([
     'type' => 'nvrf_step',
   ]);
 
-  //Loop through the field instances and update the tables that they are found in.
+  // Loop through field instances and update the tables that they are found in.
   foreach ($fields as $field) {
     $entity_type = $field->get('entity_type');
     $field_name = $field->getName();
@@ -30,7 +36,6 @@ function vote_fields_update_10001() {
  * Helper function to apply db table updates for update #10001.
  */
 function update_table_10001($table_name, $field_name) {
-
   $database = \Drupal::database();
 
   // Check if the fields already exist before adding them.
@@ -41,7 +46,8 @@ function update_table_10001($table_name, $field_name) {
     if (!$schema->fieldExists($table_name, $field_name_prefix . 'step_aria_label')) {
       $schema->addField($table_name,
         $field_name_prefix . 'step_aria_label',
-        ['type' => 'varchar',
+        [
+          'type' => 'varchar',
           'length' => 255,
           'binary' => FALSE,
           'not null' => FALSE,
@@ -49,12 +55,12 @@ function update_table_10001($table_name, $field_name) {
     }
     if (!$schema->fieldExists($table_name, $field_name_prefix . 'edit_aria_label')) {
       $schema->addField($table_name,
-      $field_name_prefix . 'edit_aria_label', [
-        'type' => 'varchar',
-        'length' => 255,
-        'binary' => FALSE,
-        'not null' => FALSE,
-      ]);
+        $field_name_prefix . 'edit_aria_label', [
+          'type' => 'varchar',
+          'length' => 255,
+          'binary' => FALSE,
+          'not null' => FALSE,
+        ]);
     }
   }
 }
@@ -62,7 +68,7 @@ function update_table_10001($table_name, $field_name) {
 /**
  * Utility function to retrieve the db field names for a given field.
  */
-function get_field_table_name($entity_type_id, $field, $revision=FALSE) {
+function get_field_table_name($entity_type_id, $field, $revision = FALSE) {
   $entity_type_manager = \Drupal::entityTypeManager();
   $storage = $entity_type_manager->getStorage($entity_type_id);
 


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

https://cm-jira.usa.gov/browse/VOTE-3337

## Description

Add new subfields for NVRF API to to prepare for transfer of hardcoded data from the app to the CMS.

## Deployment and testing

### Post-deploy steps

1. `lando retune`

### QA/Testing instructions

1. Make sure the database updates complete in the console log without error
2. visit http://vote-gov.lndo.site/admin/content/block/27 and enter test content into the new fields: "Step indicator aria label", "Edit button aria label" and save the block
3. visit http://vote-gov.lndo.site/admin/reports/dblog to make sure there are no log errors
4. visit http://vote-gov.lndo.site/nvrf/assets/strings.json to make sure the test data is displayed on the endpoint
## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
