### PR TITLE
VOTE-2926: Add aria-labelledby to featured card links

### DIFF
--- a/web/themes/custom/votegov/templates/component/feature-cards.html.twig
+++ b/web/themes/custom/votegov/templates/component/feature-cards.html.twig
@@ -37,14 +37,14 @@
 
     {# Temporary card for military FVAP.gov #}
     <article class="node--voter-guide node--view-mode-teaser usa-card">
-      <a extlinkjs-ignore class="vote-card__link" href={{ fvap_link_military }} target="_blank"
-         title={{ "Voting as a military service member" | t }}>
+      <a extlinkjs-ignore class="vote-card__link" href="{{ fvap_link_military }}" target="_blank"
+         aria-labelledby="vg-teaser-military">
         <div class="usa-card__container">
           <div class="vote-feature-card__icon">
             {{ source( directory ~ '/img/svg/Military.svg' ) }}
           </div>
           <div class="vote-feature-card__content">
-            <h3 class="usa-card__heading">
+            <h3 id="vg-teaser-military" class="usa-card__heading">
               <span>{{ "Voting as a military service member" | t }}</span>
             </h3>
             <div class="usa-card__body">
@@ -57,14 +57,14 @@
     </article>
     {# Temporary card for overseas FVAP.gov #}
     <article class="node--voter-guide node--view-mode-teaser usa-card">
-      <a extlinkjs-ignore class="vote-card__link" href={{ fvap_link_overseas }} target="_blank"
-         title={{ "Voting as a U.S. citizen from outside the U.S." | t }}>
+      <a extlinkjs-ignore class="vote-card__link" href="{{ fvap_link_overseas }}" target="_blank"
+         aria-labelledby="vg-teaser-overseas">
         <div class="usa-card__container">
           <div class="vote-feature-card__icon">
             {{ source( directory ~ '/img/svg/Overseas.svg' ) }}
           </div>
           <div class="vote-feature-card__content">
-            <h3 class="usa-card__heading">
+            <h3 id="vg-teaser-overseas" class="usa-card__heading">
               <span>{{ "Voting as a U.S. citizen from outside the U.S." | t }}</span>
             </h3>
             <div class="usa-card__body">

--- a/web/themes/custom/votegov/templates/node/node--voter-guide--teaser.html.twig
+++ b/web/themes/custom/votegov/templates/node/node--voter-guide--teaser.html.twig
@@ -11,13 +11,13 @@
 {% set attributes = attributes.addClass('usa-card') %}
 
 {% block content %}
-  <a class="vote-card__link" href="{{ url }}" title="{{ label | field_value }}">
+  <a class="vote-card__link" href="{{ url }}" aria-labelledby="vg-teaser-{{ node.id() }}">
     <div class="usa-card__container">
       <div class="vote-feature-card__icon">
         {{ content.field_icon | field_value }}
       </div>
       <div class="vote-feature-card__content">
-        <h3 class="usa-card__heading">{{ label }}</h3>
+        <h3 id="vg-teaser-{{ node.id() }}" class="usa-card__heading">{{ label }}</h3>
         <div class="usa-card__body">
           {{ content.body | render | striptags }}
         </div>


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

https://cm-jira.usa.gov/browse/VOTE-2926

## Description

Replace title attr with aria-labelledby on featured card links. This fixes the issue with the title being read twice by screen readers.

## Deployment and testing

### Post-deploy steps

1. `lando drush cr`

### QA/Testing instructions

1. visit http://vote-gov.lndo.site/ and use voiceover or screen reader tool to link to it read out each featured card link to make sure it only reads the title once.

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
