### PR TITLE
VOTE-3304: Disable Stage File Proxy on non production environments.

### DIFF
--- a/config/non_production/config_split.patch.core.extension.yml
+++ b/config/non_production/config_split.patch.core.extension.yml
@@ -5,7 +5,6 @@ adding:
     field_ui: 0
     s3fs: 0
     samlauth: 0
-    stage_file_proxy: 0
     usagov_login: 0
     views_ui: 0
     externalauth: 10

--- a/config/non_production/stage_file_proxy.settings.yml
+++ b/config/non_production/stage_file_proxy.settings.yml
@@ -1,9 +1,0 @@
-_core:
-  default_config_hash: LqXuXXQCTd1NWw7dGLef0PCi3_aEEWQuogAblo4hHaE
-hotlink: false
-origin: 'https://vote.gov'
-origin_dir: s3/files
-proxy_headers: ''
-use_imagecache_root: true
-verify: true
-excluded_extensions: ''


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[VOTE-3304](https://cm-jira.usa.gov/browse/VOTE-3304)

## Description

Disable Stage File Proxy module on non-production environments.

## Deployment and testing

### Post-deploy steps

1. Set your environment for config_split to "non_production" in your settings.local.php
`$config['config_split.config_split.non_production']['status'] = TRUE;`
2. Run `lando rebuild`

### QA/Testing instructions

1. Confirm that the Stage File Proxy module is disabled after you rebuild or import configs.

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
