### PR TITLE
VOTE-3089: Add help text for cards field on feature cards pararaph type

### DIFF
--- a/config/sync/field.field.paragraph.feature_cards.field_cards.yml
+++ b/config/sync/field.field.paragraph.feature_cards.field_cards.yml
@@ -11,7 +11,7 @@ field_name: field_cards
 entity_type: paragraph
 bundle: feature_cards
 label: Cards
-description: ''
+description: "To add a new card, type the name of the content block into the empty text box to search for it. Select the block's name. Once you select a block's name, the block is added. Use the Change Order arrows to change the order the blocks are displayed."
 required: true
 translatable: false
 default_value: {  }


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

https://cm-jira.usa.gov/browse/VOTE-3089

## Description

Add help text for feature cards component
![Screenshot 2025-03-03 at 11 25 33 AM](https://github.com/user-attachments/assets/c084cf33-3619-49a2-8472-1af8384e5391)


## Deployment and testing

### Post-deploy steps

1. `lando retune`

### QA/Testing instructions

1. visit http://vote-gov.lndo.site/node/add/landing and create a new landing page with a new Feature card component. Confirm that the help text is displayed below the cards field.

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been included above.
- [ ] No merge conflicts exist with the target branch.
- [ ] Automated tests have passed on this PR.
- [ ] A reviewer has been designated.
- [ ] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
