### PR TITLE
VOTE-2928: Move breadcrumbs out of main landmark for screen readers

### DIFF
--- a/web/themes/custom/votegov/src/sass/components/hero.scss
+++ b/web/themes/custom/votegov/src/sass/components/hero.scss
@@ -70,7 +70,7 @@
   }
 
   @include at-media('desktop') {
-    min-height: 28rem;
+    min-height: 25rem;
   }
 
   @include at-media-max('tablet-lg') {

--- a/web/themes/custom/votegov/src/sass/uswds-overrides/usa-breadcrumb.scss
+++ b/web/themes/custom/votegov/src/sass/uswds-overrides/usa-breadcrumb.scss
@@ -1,5 +1,6 @@
 @use "uswds-core" as *;
 @use "mixins" as *;
+@use "variables" as *;
 
 .usa-breadcrumb {
   background-color: transparent;
@@ -29,7 +30,15 @@
   @include vote-link-dark;
 }
 
-// targeting the div wrapping the breadcrumb block and add margin top to the following element
-.block.system-breadcrumb-block + * {
-  @include u-margin-top(5);
+.block.system-breadcrumb-block {
+  --vote-breadcrumb-bg: #{$base-dark};
+  --vote-breadcrumb-border: #{$ac-cool};
+  @include u-padding-y(1);
+  border-bottom: 1px solid var(--vote-breadcrumb-border);
+  background: var(--vote-breadcrumb-bg);
+
+  [data-theme="contrast"] & {
+    --vote-breadcrumb-bg: #{$bg-high-contrast};
+    --vote-breadcrumb-border: #{$base-white};
+  }
 }

--- a/web/themes/custom/votegov/templates/component/hero.html.twig
+++ b/web/themes/custom/votegov/templates/component/hero.html.twig
@@ -32,9 +32,6 @@
 <section{{ usa_attributes.addClass(usa_classes) }}>
   <div class="vote-hero__container">
     <div class="vote-hero__callout">
-      {% if variant == 'dark' %}
-        {{ drupal_entity('block', 'votegov_breadcrumbs') }}
-      {% endif %}
       <div class="vote-hero__content">
         <h1 class="vote-hero__heading">
           {{ heading }}

--- a/web/themes/custom/votegov/templates/layout/page.html.twig
+++ b/web/themes/custom/votegov/templates/layout/page.html.twig
@@ -93,6 +93,10 @@
 
 {{ page.admin }}
 
+{% if not is_front %}
+  {{ drupal_entity('block', 'votegov_breadcrumbs') }}
+{% endif %}
+
 {% block main %}
   {% if page.sidebar %}
     <section id="main-content" class="grid-container content-container">

--- a/web/themes/custom/votegov/templates/navigation/breadcrumb.html.twig
+++ b/web/themes/custom/votegov/templates/navigation/breadcrumb.html.twig
@@ -8,18 +8,20 @@
  */
 #}
 {% if breadcrumb %}
-  <nav role="navigation" aria-labelledby="system-breadcrumb" class="usa-breadcrumb">
-    <h2 id="system-breadcrumb" class="usa-sr-only visually-hidden">{{ 'Breadcrumb' | t }}</h2>
-    <ol class="usa-breadcrumb__list">
-      {% for item in breadcrumb %}
-        <li class="usa-breadcrumb__list-item">
-          {% if item.url %}
-            <a class="usa-breadcrumb__link" href="{{ item.url }}"><span>{{ item.text | t }}</span></a>
-          {% else %}
-            {{ item.text | t }}
-          {% endif %}
-        </li>
-      {% endfor %}
-    </ol>
-  </nav>
+  <div class="grid-container">
+    <nav role="navigation" aria-labelledby="system-breadcrumb" class="usa-breadcrumb">
+      <h2 id="system-breadcrumb" class="usa-sr-only visually-hidden">{{ 'Breadcrumb' | t }}</h2>
+      <ol class="usa-breadcrumb__list">
+        {% for item in breadcrumb %}
+          <li class="usa-breadcrumb__list-item">
+            {% if item.url %}
+              <a class="usa-breadcrumb__link" href="{{ item.url }}"><span>{{ item.text | t }}</span></a>
+            {% else %}
+              {{ item.text | t }}
+            {% endif %}
+          </li>
+        {% endfor %}
+      </ol>
+    </nav>
+  </div>
 {% endif %}

--- a/web/themes/custom/votegov/templates/paragraph/paragraph--registration-tool.html.twig
+++ b/web/themes/custom/votegov/templates/paragraph/paragraph--registration-tool.html.twig
@@ -16,7 +16,6 @@
   {{ title_suffix }}
   <div class="vote-registration-tool__container">
     <div class="vote-registration-tool__content">
-      {{ drupal_entity('block', 'votegov_breadcrumbs') }}
       <h1 class="vote-registration-tool__heading">
         {{ content.field_heading | field_value }}
       </h1>


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

https://cm-jira.usa.gov/browse/VOTE-2928

## Description

Move breadcrumbs out of the main landmark for improved screen reader experience.

## Deployment and testing

### Post-deploy steps

1. cd into the votegov theme directory and run `npm run build`
2. run `lando drush cr`

### QA/Testing instructions

1. visit https://vote-gov.lndo.site/guide-to-voting/college-student and confirm with screen reader by skipping to main content the breadcrumb is avoided.
2. Test styles on normal and high-contrast mode.
3. Test styles on desktop and mobile.
4. Test styles on Chrome, Firefox, Safari, Edge.

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
