### PR TITLE
VOTE-3508: adjust user-content-access to test dropdown list items correctly

### DIFF
--- a/testing/cypress/e2e/backEndTests/user-content-access.cy.js
+++ b/testing/cypress/e2e/backEndTests/user-content-access.cy.js
@@ -228,12 +228,9 @@ describe('Test User Role Access to Content Moderation', () => {
 
     // Can not delete content
     cy.visit('/admin/content')
-    pageObjects
-      .editDropDown().then(btn => {
-        cy.get(btn[0]).click()
-      })
-    pageObjects
-      .editOpt().should('not.contain', 'delete')
+    const listItems = []
+    cy.get('[class="dropbutton dropbutton--extrasmall dropbutton--multiple"] li').each(($li) => listItems.push($li.text()))
+    cy.wrap(listItems).should('not.contain', 'delete')
 
     // Can create media but not delete media
     cy.request('/media/add').then((response) => {


### PR DESCRIPTION

<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[VOTE-3508](https://cm-jira.usa.gov/browse/VOTE-3508)

## Description

Change user-content-access cypress test to properly evaluate dropdown items

## Deployment and testing

### QA/Testing instructions

1. Run cypress user-content-access tests locally
2. Ensure the Test Content Editor test for not deleting content is valid and passes

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been included above.
- [ ] No merge conflicts exist with the target branch.
- [ ] Automated tests have passed on this PR.
- [ ] A reviewer has been designated.
- [ ] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
