### PR TITLE
VOTE-3441: Add cache exclusion during tome execution.

### DIFF
--- a/web/sites/default/nonlocal.services.yml
+++ b/web/sites/default/nonlocal.services.yml
@@ -1,0 +1,5 @@
+# For non-local environments. We want to be the cache.backend.null there too.
+#
+services:
+  cache.backend.null:
+    class: Drupal\Core\Cache\NullBackendFactory

--- a/web/sites/default/settings.cloudgov.php
+++ b/web/sites/default/settings.cloudgov.php
@@ -91,6 +91,14 @@ $settings['vote_tome_static_path_exclude_directories'] = [
   '/jsonapi',
 ];
 
+// Add cache.backend.null:
+$settings['container_yamls'][] = DRUPAL_ROOT . '/sites/default/nonlocal.services.yml';
+if (PHP_SAPI === 'cli' && str_starts_with($_SERVER["argv"][1], 'tome:static')) {
+  // Disable the page and menu cache on tome runs.
+  $settings['cache']['bins']['page'] = 'cache.backend.null';
+  $settings['cache']['bins']['menu'] = 'cache.backend.null';
+}
+
 $is_cloudgov = FALSE;
 
 if (!empty($cf_application_data['space_name']) &&


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[VOTE-3441](https://cm-jira.usa.gov/browse/VOTE-3441)

## Description

Disable select caches during the execution of Tome.

## Deployment and testing

### Post-deploy steps

1. To test locally, add the following code to you local settings.php file
`$settings['container_yamls'][] = DRUPAL_ROOT . '/sites/default/nonlocal.services.yml';
if (PHP_SAPI === 'cli' && str_starts_with($_SERVER["argv"][1], 'tome:static')) {
  // Disable the page and menu cache on tome runs.
  $settings['cache']['bins']['page'] = 'cache.backend.null';
  $settings['cache']['bins']['menu'] = 'cache.backend.null';
}`

### QA/Testing instructions

1. Generate tome and confirm that static site is built correctly without any missing elements.

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
