### PR TITLE
VOTE-3525 resolve issues with removal of nvrf_card and config split

### DIFF
--- a/config/local/config_split.patch.user.role.content_manager.yml
+++ b/config/local/config_split.patch.user.role.content_manager.yml
@@ -5,13 +5,4 @@ adding:
   permissions:
     - 'create content in disabled language'
     - 'view disabled languages'
-removing:
-  dependencies:
-    config:
-      - block_content.type.nvrf_card
-  permissions:
-    - 'access block library'
-    - 'delete any nvrf_card block content revisions'
-    - 'edit any nvrf_card block content'
-    - 'revert any nvrf_card block content revisions'
-    - 'view any nvrf_card block content history'
+removing: {  }

--- a/config/sync/user.role.content_manager.yml
+++ b/config/sync/user.role.content_manager.yml
@@ -9,7 +9,6 @@ dependencies:
     - block_content.type.government_banner
     - block_content.type.inline_alert
     - block_content.type.nvrf_a_b_message
-    - block_content.type.nvrf_card
     - block_content.type.nvrf_display_content
     - block_content.type.partnership
     - block_content.type.registration_form_selector
@@ -55,7 +54,6 @@ weight: -6
 is_admin: null
 permissions:
   - 'access administration pages'
-  - 'access block library'
   - 'access content overview'
   - 'access media overview'
   - 'access taxonomy overview'
@@ -94,7 +92,6 @@ permissions:
   - 'delete any inline_alert block content revisions'
   - 'delete any nvrf_a_b_message block content'
   - 'delete any nvrf_a_b_message block content revisions'
-  - 'delete any nvrf_card block content revisions'
   - 'delete any nvrf_display_content block content revisions'
   - 'delete any partnership block content revisions'
   - 'delete any registration_form_selector block content revisions'
@@ -122,7 +119,6 @@ permissions:
   - 'edit any inline_alert block content'
   - 'edit any landing content'
   - 'edit any nvrf_a_b_message block content'
-  - 'edit any nvrf_card block content'
   - 'edit any nvrf_display_content block content'
   - 'edit any nvrf_page content'
   - 'edit any page content'
@@ -156,7 +152,6 @@ permissions:
   - 'revert any government_banner block content revisions'
   - 'revert any inline_alert block content revisions'
   - 'revert any nvrf_a_b_message block content revisions'
-  - 'revert any nvrf_card block content revisions'
   - 'revert any nvrf_display_content block content revisions'
   - 'revert any partnership block content revisions'
   - 'revert any registration_form_selector block content revisions'
@@ -210,7 +205,6 @@ permissions:
   - 'view any image media revisions'
   - 'view any inline_alert block content history'
   - 'view any nvrf_a_b_message block content history'
-  - 'view any nvrf_card block content history'
   - 'view any nvrf_display_content block content history'
   - 'view any partnership block content history'
   - 'view any registration_form_selector block content history'


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

https://cm-jira.usa.gov/browse/VOTE-3525

## Description

Resolves issue with config split and the removal of the nvrf_card block type.

## Deployment and testing

### Post-deploy steps

1. temporarily modify your `/web/sites/settings.local.php` file:
find the line `$config['config_split.config_split.local']['status'] = TRUE;` and update to
`$config['config_split.config_split.non_production']['status'] = TRUE;`
2. run `lando retune`

### QA/Testing instructions

1. make sure the configuration imports without error

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been included above.
- [ ] No merge conflicts exist with the target branch.
- [ ] Automated tests have passed on this PR.
- [ ] A reviewer has been designated.
- [ ] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
