### PR TITLE
VOTE-3525 resolve permissions to create new alerts in the system

### DIFF
--- a/config/sync/user.role.content_manager.yml
+++ b/config/sync/user.role.content_manager.yml
@@ -54,6 +54,7 @@ weight: -6
 is_admin: null
 permissions:
   - 'access administration pages'
+  - 'access block library'
   - 'access content overview'
   - 'access media overview'
   - 'access taxonomy overview'

--- a/web/modules/custom/vote_utility/inc/local_tasks_alter.inc
+++ b/web/modules/custom/vote_utility/inc/local_tasks_alter.inc
@@ -1,0 +1,22 @@
+<?php
+
+use \Drupal\Core\Cache\RefinableCacheableDependencyInterface;
+
+/**
+ * Implements hook_menu_local_tasks_alter().
+ */
+function vote_utility_menu_local_tasks_alter(&$data, $route_name, RefinableCacheableDependencyInterface &$cacheability) {
+  // Get current user roles.
+  $current_user = \Drupal::currentUser();
+  $roles = $current_user->getRoles();
+
+  if (in_array('content_manager', $roles) || in_array('content_editor', $roles)) {
+    // Restrict access to blocks admin listing page for content roles.
+    $data['tabs'][0]['entity.block_content.collection']['#access'] = FALSE;
+
+    // Set cache trigger via role change.
+    $cacheability->addCacheContexts([
+      'user.roles',
+    ]);
+  }
+}

--- a/web/modules/custom/vote_utility/vote_utility.module
+++ b/web/modules/custom/vote_utility/vote_utility.module
@@ -9,5 +9,6 @@ require_once dirname(__FILE__) . '/inc/block_content_revisions.inc';
 require_once dirname(__FILE__) . '/inc/token.inc';
 require_once dirname(__FILE__) . '/inc/form_alter.inc';
 require_once dirname(__FILE__) . '/inc/view_alter.inc';
+require_once dirname(__FILE__) . '/inc/local_tasks_alter.inc';
 require_once dirname(__FILE__) . '/inc/access.inc';
 require_once dirname(__FILE__) . '/inc/preprocess.inc';


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

https://cm-jira.usa.gov/browse/VOTE-3525

## Description

Resolve a bug with Content Managers not able to create a new site alerts.

## Deployment and testing

### Post-deploy steps

1. `lando retune`

### QA/Testing instructions

1. log into the site as a Content Manager and test that you do not see the "Blocks" tab on the `/admin/content` page then click on "Site Alerts" tab and click on the "Create a new site alert" button. Make sure you can access the form and save it without error.

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been included above.
- [ ] No merge conflicts exist with the target branch.
- [ ] Automated tests have passed on this PR.
- [ ] A reviewer has been designated.
- [ ] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.
