### PR TITLE
VOTE-3536 Update revision retention to 25 for nodes and block_content…

### DIFF
--- a/config/sync/node.type.landing.yml
+++ b/config/sync/node.type.landing.yml
@@ -13,7 +13,7 @@ third_party_settings:
     amount:
       status: true
       settings:
-        amount: 50
+        amount: 25
     created:
       status: false
       settings:

--- a/config/sync/node.type.nvrf_page.yml
+++ b/config/sync/node.type.nvrf_page.yml
@@ -13,7 +13,7 @@ third_party_settings:
     amount:
       status: true
       settings:
-        amount: 50
+        amount: 25
     created:
       status: false
       settings:
@@ -22,6 +22,10 @@ third_party_settings:
       status: false
       settings:
         age: 1
+    only_drafts:
+      status: false
+      settings:
+        age: 0
 name: 'NVRF Page'
 type: nvrf_page
 description: 'NVRF app page content'

--- a/config/sync/node.type.page.yml
+++ b/config/sync/node.type.page.yml
@@ -13,7 +13,7 @@ third_party_settings:
     amount:
       status: true
       settings:
-        amount: 50
+        amount: 25
     created:
       status: false
       settings:

--- a/config/sync/node.type.state_territory.yml
+++ b/config/sync/node.type.state_territory.yml
@@ -13,7 +13,19 @@ third_party_settings:
     amount:
       status: true
       settings:
-        amount: 50
+        amount: 25
+    created:
+      status: false
+      settings:
+        age: 1
+    drafts:
+      status: false
+      settings:
+        age: 1
+    only_drafts:
+      status: false
+      settings:
+        age: 0
 name: 'State/Territory Page'
 type: state_territory
 description: null

--- a/config/sync/node.type.voter_guide.yml
+++ b/config/sync/node.type.voter_guide.yml
@@ -13,7 +13,7 @@ third_party_settings:
     amount:
       status: true
       settings:
-        amount: 50
+        amount: 25
     created:
       status: false
       settings:

--- a/web/modules/custom/vote_utility/inc/block_content_revisions.inc
+++ b/web/modules/custom/vote_utility/inc/block_content_revisions.inc
@@ -16,7 +16,7 @@ function vote_utility_block_content_update(EntityInterface $entity) {
     SELECT revision_id from block_content_revision
     WHERE id = :entity_id
 	ORDER BY revision_created DESC
-	LIMIT 50, 18446744073709551615', [
+	LIMIT 25, 18446744073709551615', [
    ':entity_id' => $entity->id(),
  ]);
   foreach ($query->fetchAllAssoc('revision_id') as $version) {


### PR DESCRIPTION
… entities

<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

https://cm-jira.usa.gov/browse/VOTE-3536

## Description

Update revision retention for nodes and block_content entities to 25.

## Deployment and testing

### Post-deploy steps

1. `lando retune`

### QA/Testing instructions

1. visit http://vote-gov.lndo.site/admin/structure/types/manage/page and confirm the node revision delete settings is marked as 25. You can do this for each content type.

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.
